### PR TITLE
Loading logic rework

### DIFF
--- a/pylate/models/Dense.py
+++ b/pylate/models/Dense.py
@@ -2,10 +2,12 @@ import json
 import os
 
 import torch
+from safetensors import safe_open
 from safetensors.torch import load_model as load_safetensors_model
 from sentence_transformers.models import Dense as DenseSentenceTransformer
 from sentence_transformers.util import import_from_string
 from torch import nn
+from transformers.utils import cached_file
 
 __all__ = ["Dense"]
 
@@ -75,6 +77,40 @@ class Dense(DenseSentenceTransformer):
         config["activation_function"] = nn.Identity()
         model = Dense(**config)
         model.load_state_dict(dense.state_dict())
+        return model
+
+    @staticmethod
+    def from_stanford_weights(
+        model_name_or_path,
+        cache_folder,
+        revision,
+        local_files_only,
+        token,
+        use_auth_token,
+    ) -> "Dense":
+        # Check if the model is locally available
+        if not (os.path.exists(os.path.join(model_name_or_path))):
+            # Else download the model/use the cached version
+            model_name_or_path = cached_file(
+                model_name_or_path,
+                filename="model.safetensors",
+                cache_dir=cache_folder,
+                revision=revision,
+                local_files_only=local_files_only,
+                token=token,
+                use_auth_token=use_auth_token,
+            )
+        with safe_open(model_name_or_path, framework="pt", device="cpu") as f:
+            state_dict = {"linear.weight": f.get_tensor("linear.weight")}
+
+        # Determine input and output dimensions
+        in_features = state_dict["linear.weight"].shape[1]
+        out_features = state_dict["linear.weight"].shape[0]
+
+        # Create Dense layer instance
+        model = Dense(in_features=in_features, out_features=out_features, bias=False)
+
+        model.load_state_dict(state_dict)
         return model
 
     @staticmethod

--- a/pylate/models/Dense.py
+++ b/pylate/models/Dense.py
@@ -81,13 +81,34 @@ class Dense(DenseSentenceTransformer):
 
     @staticmethod
     def from_stanford_weights(
-        model_name_or_path,
-        cache_folder,
-        revision,
-        local_files_only,
-        token,
-        use_auth_token,
+        model_name_or_path: str | os.PathLike,
+        cache_folder: str | os.PathLike | None = None,
+        revision: str | None = None,
+        local_files_only: bool | None = None,
+        token: str | bool | None = None,
+        use_auth_token: str | bool | None = None,
     ) -> "Dense":
+        """Load the weight of the Dense layer using weights from a stanford-nlp checkpoint.
+
+        Parameters
+        ----------
+        model_name_or_path (`str` or `os.PathLike`):
+            This can be either:
+            - a string, the *model id* of a model repo on huggingface.co.
+            - a path to a *directory* potentially containing the file.
+        cache_folder (`str` or `os.PathLike`, *optional*):
+            Path to a directory in which a downloaded pretrained model configuration should be cached if the standard
+            cache should not be used.
+        token (`str` or *bool*, *optional*):
+            The token to use as HTTP bearer authorization for remote files. If `True`, will use the token generated
+            when running `huggingface-cli login` (stored in `~/.huggingface`).
+        revision (`str`, *optional*, defaults to `"main"`):
+            The specific model version to use. It can be a branch name, a tag name, or a commit id, since we use a
+            git-based system for storing models and other artifacts on huggingface.co, so `revision` can be any
+            identifier allowed by git.
+        local_files_only (`bool`, *optional*, defaults to `False`):
+            If `True`, will only try to load the tokenizer configuration from local files.
+        """
         # Check if the model is locally available
         if not (os.path.exists(os.path.join(model_name_or_path))):
             # Else download the model/use the cached version

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open(file="README.md", mode="r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 base_packages = [
-    "sentence-transformers >= 3.0.1",
+    "sentence-transformers == 3.0.1",
     "datasets >= 2.20.0",
     "accelerate >= 0.31.0",
     "voyager >= 2.0.9",


### PR DESCRIPTION
This PR solves some of the issues related to model loading.

First, it removes the model_kwargs `add_pooling_layer` that prevented the instantiation of a pooler within BERT models but is not common across all encoders (see #51).
I considered removing the pooler after initialization, but then the saved PyLate model does not have weights for it and it yields a warning saying that those weights are not properly loaded from checkpoint. Although it does not matter as we are not using it anyways, this message can be misleading. Thus, I choose to let it be, as we are using the sequence_embeddings and not the pooled output, it's a small additional useless computation but I did not find a better solution.

Second, it adds a function to support loading a model created using the stanford-nlp library. This has two benefits:

1. Every ColBERT model (with a base model loadable using ST) is now **natively compatible with PyLate**, without having to convert it manually. This should greatly enhance the number of compatible models (#50).
2. Besides not having to convert it, it also means that we do not have to add the PyLate files to an existing stanford-nlp repository, as we did for Colbert-small. Besides not duplicating the weights, it solves this issue where the Transformer (from ST) folder was not at the root but in a subfolder, which resulted in the model configuration not being properly loaded and thus not properly loading the model to a specified dtype (#49).

Also took the opportunity to add dtype casting to the Dense layer to match the Transformer.