### PR TITLE
Jina loading

### DIFF
--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -261,6 +261,9 @@ class ColBERT(SentenceTransformer):
                         use_auth_token,
                     )
                 )
+                # Setting the prefixes from stanford-nlp models
+                self.query_prefix = "[unused0]"
+                self.document_prefix = "[unused1]"
                 logger.warning("Loaded the ColBERT model from Stanford NLP.")
             else:
                 # Add a linear projection layer to the model in order to project the embeddings to the desired size

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -272,6 +272,7 @@ class ColBERT(SentenceTransformer):
                 logger.warning(
                     f"The checkpoint does not contain a linear projection layer. Adding one with output dimensions ({hidden_size}, {embedding_size})."
                 )
+                logger.warning("Created a PyLate model from base encoder.")
                 self.append(
                     Dense(
                         in_features=hidden_size, out_features=embedding_size, bias=bias
@@ -1079,7 +1080,7 @@ class ColBERT(SentenceTransformer):
 
         """
         logger.warning(
-            f"No sentence-transformers model found with name {model_name_or_path}. Creating a ColBERT model from base encoder."
+            f"No sentence-transformers model found with name {model_name_or_path}."
         )
 
         shared_kwargs = {

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -294,8 +294,12 @@ class ColBERT(SentenceTransformer):
         else:
             logger.warning("Pylate model loaded successfully.")
 
-        if model_kwargs is not None and "torch_dtype" in model_kwargs:
-            self[1].to(model_kwargs["torch_dtype"])
+        # Ensure all tensors in the model are of the same dtype as the first tensor
+        try:
+            dtype = next(self.parameters()).dtype
+            self.to(dtype)
+        except StopIteration:
+            pass
 
         self.to(device)
         self.is_hpu_graph_enabled = False


### PR DESCRIPTION
This PR enable the support of models that does not implement vocabulary resizing (as jina-colbert-v2).
This part of the code is messy but I did not find a better way of not adding tokens if the resizing crash than just doing a sanity check before adding the tokens.

It also add a more general type casting for the dense layer in case the model is loaded because the weights are in bf16 (even without dtype set) as jina-colbert-v2.

Finally, it sets the prefixes of stanford-nlp models to the ones of the lib and correct the logging messages to be more accurate.