### PR TITLE
Check if architectures is in the config before reading it

### DIFF
--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -250,7 +250,10 @@ class ColBERT(SentenceTransformer):
         # Add a linear projection layer to the model in order to project the embeddings to the desired size.
         if len(self) < 2:
             # If the model is a stanford-nlp ColBERT, load the weights of the dense layer
-            if self[0].auto_model.config.architectures[0] == "HF_ColBERT":
+            if (
+                self[0].auto_model.config.architectures is not None
+                and self[0].auto_model.config.architectures[0] == "HF_ColBERT"
+            ):
                 self.append(
                     Dense.from_stanford_weights(
                         model_name_or_path,


### PR DESCRIPTION
When experimenting around, I realized that some models do not have "architectures" in their config (e.g, [debertav3](https://huggingface.co/microsoft/deberta-v3-base).

This PR just check if there is one before checking if it is a HF_ColBERT (and thus that the model is a stanford-nlp model). 