### PR TITLE
Fixing issue with ST 3.1 and bumping version

### DIFF
--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -301,7 +301,7 @@ class ColBERT(SentenceTransformer):
             )
             self[1] = Dense.from_sentence_transformers(dense=self[1])
         else:
-            logger.warning("Pylate model loaded successfully.")
+            logger.warning("PyLate model loaded successfully.")
 
         # Ensure all tensors in the model are of the same dtype as the first tensor
         try:
@@ -1150,7 +1150,7 @@ class ColBERT(SentenceTransformer):
         config_kwargs: dict | None = None,
     ) -> list[nn.Module]:
         """Create a Sentence Transformer model from a model name or path."""
-        modules = super()._load_sbert_model(
+        modules, module_kwargs = super()._load_sbert_model(
             model_name_or_path=model_name_or_path,
             token=token,
             cache_folder=cache_folder,
@@ -1196,4 +1196,4 @@ class ColBERT(SentenceTransformer):
             for module in modules.values()
             if isinstance(module, Transformer)
             or isinstance(module, DenseSentenceTransformer)
-        ]
+        ], module_kwargs

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open(file="README.md", mode="r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 base_packages = [
-    "sentence-transformers == 3.0.1",
+    "sentence-transformers == 3.2.0",
     "datasets >= 2.20.0",
     "accelerate >= 0.31.0",
     "voyager >= 2.0.9",


### PR DESCRIPTION
This PR fixes a compatibility issue introduced in ST 3.1 in [this commit](https://github.com/UKPLab/sentence-transformers/commit/6257cb00ef87ddc8f445f0e436377ea4c48879b2).

Basically, this added the possibility add module_kwargs in the config so that the model can leverage them for a specific processing, such as the dataset_embeddings of [cde](https://huggingface.co/jxm/cde-small-v1).

This fix allows to bump the version of ST to newer ones and also to handle such custom processing aswell (as we are extending the ST model).

Edit for more information: the [load_sbert_model function set the self.modules_kwargs](https://github.com/UKPLab/sentence-transformers/blob/a4be00f3fcb635f536566044d40c41513a495818/sentence_transformers/SentenceTransformer.py#L306) that are then used in the [forward pass of the Transformer model](https://github.com/UKPLab/sentence-transformers/blob/1802076d4eae42ff0a5629e1b04e75785d4e193b/sentence_transformers/SentenceTransformer.py#L686) if some are [set in the config.json](https://huggingface.co/jxm/cde-small-v1/blob/main/modules.json#L7)

Related issue: https://github.com/lightonai/pylate/issues/64