### PR TITLE
[Draft] Setting normalize_scores default to False

### DIFF
--- a/docs/documentation/training.md
+++ b/docs/documentation/training.md
@@ -176,6 +176,12 @@ trainer.train()
 
     Refer to this [documentation](https://sbert.net/docs/sentence_transformer/training/distributed.html) for more information.
 
+Note that the Distillation also support min-max normalizing the output scores, which have been shown to improve results if the teacher scores are also normalized in [JaColBERTv2.5](https://arxiv.org/pdf/2407.20750) but the gains are not guaranteed as shown in [Jina-ColBERT-v2](https://arxiv.org/abs/2408.16672).
+To normalize the output scores, simply use the ```normalize_scores``` parameter when creating the loss object (you still have to normalize the scores in your dataset):
+```python
+train_loss = losses.Distillation(model=model, normalize_scores=True)
+```
+
 ## ColBERT parameters
 All the parameters of the ColBERT modeling can be found [here](https://lightonai.github.io/pylate/api/models/ColBERT/#parameters). Important parameters to consider are:
 

--- a/pylate/losses/distillation.py
+++ b/pylate/losses/distillation.py
@@ -54,7 +54,7 @@ class Distillation(torch.nn.Module):
         model: ColBERT,
         score_metric: Callable = colbert_kd_scores,
         size_average: bool = True,
-        normalize_scores: bool = True,
+        normalize_scores: bool = False,
     ) -> None:
         super(Distillation, self).__init__()
         self.score_metric = score_metric


### PR DESCRIPTION
This PR change the default of normalize_scores to False and add documentation about the parameters.
The rationale behind this change is two-fold:
1. The setup is not really common for the large audience and [the user can be surprised by the loss magnitude](https://github.com/lightonai/pylate/discussions/58). Also, if the user use his own dataset without normalizing the teacher scores, it could be hurting the performance.
2. [JinaColBERT-v2 had mitigated results using normalization](https://arxiv.org/pdf/2408.16672), so I am not sure it is worth it to make it the default.


Before merging, there is two things that needs to be discussed:
1. The datasets we have released have normalized scores, which could make the boilerplate a bit off.
2. When building the functionality, I decoupled the normalization of the output scores and the teachers' to offload part of the computation pre-training as it would be re-usable. But now that I think about it again, it might be more painful for the user and we could add the normalization of the teacher scores during the training aswell.

Related issue: https://github.com/lightonai/pylate/issues/59