### PR TITLE
Fix local loading of Stanford model

### DIFF
--- a/pylate/models/Dense.py
+++ b/pylate/models/Dense.py
@@ -121,6 +121,9 @@ class Dense(DenseSentenceTransformer):
                 token=token,
                 use_auth_token=use_auth_token,
             )
+        # If the model a local folder, load the safetensor
+        else:
+            model_name_or_path = os.path.join(model_name_or_path, "model.safetensors")
         with safe_open(model_name_or_path, framework="pt", device="cpu") as f:
             state_dict = {"linear.weight": f.get_tensor("linear.weight")}
 


### PR DESCRIPTION
When making the test for the new loading logic for Stanford models, I only tested with remote (HF repo) models.
Turns out, the code does not work if the model is a local folder.
The fix was simple: correctly set the path of the safetensor if the model is local.