### PR TITLE
Stanford loading using bin file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open(file="README.md", mode="r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 base_packages = [
-    "sentence-transformers == 3.2.0",
+    "sentence-transformers == 3.3.0",
     "datasets >= 2.20.0",
     "accelerate >= 0.31.0",
     "voyager >= 2.0.9",

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ base_packages = [
     "voyager >= 2.0.9",
     "sqlitedict >= 2.1.0",
     "pandas >= 2.2.1",
+    "transformers == 4.46.2",
 ]
 
 


### PR DESCRIPTION
#68 fixed the local loading of Stanford models, but the issue is that the safe tensor is only created when uploaded to HF through the dedicated bot.
This PR changes the loading logic to rely on the `pytorch_model.bin` file that is always there both locally and remotely.
cc @jessiejuachon
