### PR TITLE
Add safetensor OR bin loading logic + add loading tests

### DIFF
--- a/pylate/models/Dense.py
+++ b/pylate/models/Dense.py
@@ -123,6 +123,7 @@ class Dense(DenseSentenceTransformer):
                     use_auth_token=use_auth_token,
                 )
             except EnvironmentError:
+                print("No safetensor model found, falling back to bin.")
                 model_name_or_path = cached_file(
                     model_name_or_path,
                     filename="pytorch_model.bin",
@@ -140,6 +141,7 @@ class Dense(DenseSentenceTransformer):
                     model_name_or_path, "model.safetensors"
                 )
             else:
+                print("No safetensor model found, falling back to bin.")
                 model_name_or_path = os.path.join(
                     model_name_or_path, "pytorch_model.bin"
                 )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,91 @@
+import math
+
+import torch
+
+from pylate import models, rank
+
+
+def test_model_creation(**kwargs) -> None:
+    """Test the creation of different models."""
+    query = ["fruits are healthy."]
+    documents = [["fruits are healthy.", "fruits are good for health."]]
+    torch.manual_seed(42)
+    # Creation from a base encoder
+    model = models.ColBERT(model_name_or_path="bert-base-uncased")
+    queries_embeddings = model.encode(sentences=query, is_query=True)
+    documents_embeddings = model.encode(sentences=documents, is_query=False)
+    reranked_documents = rank.rerank(
+        documents_ids=[["1", "2"]],
+        queries_embeddings=queries_embeddings,
+        documents_embeddings=documents_embeddings,
+    )
+    assert math.isclose(
+        reranked_documents[0][0]["score"], 25.92, rel_tol=0.01, abs_tol=0.01
+    )
+    assert math.isclose(
+        reranked_documents[0][1]["score"], 23.7, rel_tol=0.01, abs_tol=0.01
+    )
+
+    # Creation from a base sentence-transformer
+    model = models.ColBERT(model_name_or_path="sentence-transformers/all-MiniLM-L6-v2")
+    queries_embeddings = model.encode(sentences=query, is_query=True)
+    documents_embeddings = model.encode(sentences=documents, is_query=False)
+    reranked_documents = rank.rerank(
+        documents_ids=[["1", "2"]],
+        queries_embeddings=queries_embeddings,
+        documents_embeddings=documents_embeddings,
+    )
+    assert math.isclose(
+        reranked_documents[0][0]["score"], 18.77, rel_tol=0.01, abs_tol=0.01
+    )
+    assert math.isclose(
+        reranked_documents[0][1]["score"], 18.63, rel_tol=0.01, abs_tol=0.01
+    )
+
+    # Creation from stanford-nlp (safetensor)
+    model = models.ColBERT(model_name_or_path="answerdotai/answerai-colbert-small-v1")
+    queries_embeddings = model.encode(sentences=query, is_query=True)
+    documents_embeddings = model.encode(sentences=documents, is_query=False)
+    reranked_documents = rank.rerank(
+        documents_ids=[["1", "2"]],
+        queries_embeddings=queries_embeddings,
+        documents_embeddings=documents_embeddings,
+    )
+    assert math.isclose(
+        reranked_documents[0][0]["score"], 31.71, rel_tol=0.01, abs_tol=0.01
+    )
+    assert math.isclose(
+        reranked_documents[0][1]["score"], 31.64, rel_tol=0.01, abs_tol=0.01
+    )
+
+    # Creation from stanford-nlp (bin)
+    model = models.ColBERT(model_name_or_path="Crystalcareai/Colbertv2")
+    queries_embeddings = model.encode(sentences=query, is_query=True)
+    documents_embeddings = model.encode(sentences=documents, is_query=False)
+    reranked_documents = rank.rerank(
+        documents_ids=[["1", "2"]],
+        queries_embeddings=queries_embeddings,
+        documents_embeddings=documents_embeddings,
+    )
+    assert math.isclose(
+        reranked_documents[0][0]["score"], 31.15, rel_tol=0.01, abs_tol=0.01
+    )
+    assert math.isclose(
+        reranked_documents[0][1]["score"], 30.61, rel_tol=0.01, abs_tol=0.01
+    )
+
+    # Creation from PyLate
+    model = models.ColBERT(model_name_or_path="lightonai/colbertv2.0")
+    queries_embeddings = model.encode(sentences=query, is_query=True)
+    documents_embeddings = model.encode(sentences=documents, is_query=False)
+    reranked_documents = rank.rerank(
+        documents_ids=[["1", "2"]],
+        queries_embeddings=queries_embeddings,
+        documents_embeddings=documents_embeddings,
+    )
+    assert math.isclose(
+        reranked_documents[0][0]["score"], 30.01, rel_tol=0.01, abs_tol=0.01
+    )
+    assert math.isclose(
+        reranked_documents[0][1]["score"], 26.98, rel_tol=0.01, abs_tol=0.01
+    )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -12,9 +12,34 @@ def test_model_creation(**kwargs) -> None:
     torch.manual_seed(42)
     # Creation from a base encoder
     model = models.ColBERT(model_name_or_path="bert-base-uncased")
+    # We don't test the embeddings of newly initied models for now as we need to make it deterministic
+    # queries_embeddings = model.encode(sentences=query, is_query=True)
+    # documents_embeddings = model.encode(sentences=documents, is_query=False)
+    # reranked_documents = rank.rerank(
+    #     documents_ids=[["1", "2"]],
+    #     queries_embeddings=queries_embeddings,
+    #     documents_embeddings=documents_embeddings,
+    # )
+    # assert math.isclose(
+    #     reranked_documents[0][0]["score"], 25.92, rel_tol=0.01, abs_tol=0.01
+    # )
+    # assert math.isclose(reranked_documents[0][1]["score"], 23.7, rel_tol=0.01, abs_tol=0.01)
 
     # Creation from a base sentence-transformer
     model = models.ColBERT(model_name_or_path="sentence-transformers/all-MiniLM-L6-v2")
+    # We don't test the embeddings of newly initied models for now as we need to make it deterministic
+    # queries_embeddings = model.encode(sentences=query, is_query=True)
+    # documents_embeddings = model.encode(sentences=documents, is_query=False)
+    # reranked_documents = rank.rerank(
+    #     documents_ids=[["1", "2"]],
+    #     queries_embeddings=queries_embeddings,
+    #     documents_embeddings=documents_embeddings,
+    # )
+    # assert math.isclose(
+    #     reranked_documents[0][0]["score"], 18.77, rel_tol=0.01, abs_tol=0.01
+    # )
+    # assert math.isclose(
+    #     reranked_documents[0][1]["score"], 18.63, rel_tol=0.01, abs_tol=0.01
 
     # Creation from stanford-nlp (safetensor)
     model = models.ColBERT(model_name_or_path="answerdotai/answerai-colbert-small-v1")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -12,35 +12,9 @@ def test_model_creation(**kwargs) -> None:
     torch.manual_seed(42)
     # Creation from a base encoder
     model = models.ColBERT(model_name_or_path="bert-base-uncased")
-    queries_embeddings = model.encode(sentences=query, is_query=True)
-    documents_embeddings = model.encode(sentences=documents, is_query=False)
-    reranked_documents = rank.rerank(
-        documents_ids=[["1", "2"]],
-        queries_embeddings=queries_embeddings,
-        documents_embeddings=documents_embeddings,
-    )
-    assert math.isclose(
-        reranked_documents[0][0]["score"], 25.92, rel_tol=0.01, abs_tol=0.01
-    )
-    assert math.isclose(
-        reranked_documents[0][1]["score"], 23.7, rel_tol=0.01, abs_tol=0.01
-    )
 
     # Creation from a base sentence-transformer
     model = models.ColBERT(model_name_or_path="sentence-transformers/all-MiniLM-L6-v2")
-    queries_embeddings = model.encode(sentences=query, is_query=True)
-    documents_embeddings = model.encode(sentences=documents, is_query=False)
-    reranked_documents = rank.rerank(
-        documents_ids=[["1", "2"]],
-        queries_embeddings=queries_embeddings,
-        documents_embeddings=documents_embeddings,
-    )
-    assert math.isclose(
-        reranked_documents[0][0]["score"], 18.77, rel_tol=0.01, abs_tol=0.01
-    )
-    assert math.isclose(
-        reranked_documents[0][1]["score"], 18.63, rel_tol=0.01, abs_tol=0.01
-    )
 
     # Creation from stanford-nlp (safetensor)
     model = models.ColBERT(model_name_or_path="answerdotai/answerai-colbert-small-v1")


### PR DESCRIPTION
#69 actually broke the loading of recent stanford-nlp models (small/jina), as they do not have bin.
That is on me, I checked the colbertv2 repository that had both safe tensor AND bin and rushed to the conclusion that all of them had both.

This PR merge old safe tensor loading and the new bin loading to be able to load both type of repository.
We first try to load safe tensors and fall back to bin if not existing.

Also added some tests for loading different types of models (base, ST base, stanford-nlp bin/safetensor and PyLate), as well as a small check that should make sure that the model is not only loaded but correctly loaded.