### PR TITLE
add `__future__` annotations

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -7,16 +7,21 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+          python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
       run: |

--- a/pylate/__init__.py
+++ b/pylate/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __all__ = [
     "evaluation",
     "indexes",

--- a/pylate/__version__.py
+++ b/pylate/__version__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 VERSION = (1, 1, 4)
 
 __version__ = ".".join(map(str, VERSION))

--- a/pylate/evaluation/__init__.py
+++ b/pylate/evaluation/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .beir import evaluate, get_beir_triples, load_beir
 from .colbert_distillation import ColBERTDistillationEvaluator
 from .colbert_triplet import ColBERTTripletEvaluator

--- a/pylate/evaluation/beir.py
+++ b/pylate/evaluation/beir.py
@@ -1,4 +1,5 @@
 """Neural Cherche evaluation module for BEIR datasets."""
+from __future__ import annotations
 
 import random
 from collections import defaultdict

--- a/pylate/evaluation/colbert_distillation.py
+++ b/pylate/evaluation/colbert_distillation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 import logging
 import os

--- a/pylate/evaluation/colbert_triplet.py
+++ b/pylate/evaluation/colbert_triplet.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import csv
 import logging
 import os

--- a/pylate/evaluation/custom_dataset.py
+++ b/pylate/evaluation/custom_dataset.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def load_custom_dataset(path: str, split: str = "test") -> tuple[list, list, dict]:
     """Load a custom dataset.
 

--- a/pylate/hf_hub/__init__.py
+++ b/pylate/hf_hub/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .model_card import PylateModelCardData
 
 __all__ = ["PylateModelCardData"]

--- a/pylate/indexes/__init__.py
+++ b/pylate/indexes/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .voyager import Voyager
 
 __all__ = ["Voyager"]

--- a/pylate/indexes/base.py
+++ b/pylate/indexes/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 
 

--- a/pylate/indexes/voyager.py
+++ b/pylate/indexes/voyager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 import os
 

--- a/pylate/losses/__init__.py
+++ b/pylate/losses/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .contrastive import Contrastive
 from .distillation import Distillation
 

--- a/pylate/losses/contrastive.py
+++ b/pylate/losses/contrastive.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Iterable
 
 import torch

--- a/pylate/losses/distillation.py
+++ b/pylate/losses/distillation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable, Iterable
 
 import torch

--- a/pylate/models/Dense.py
+++ b/pylate/models/Dense.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 

--- a/pylate/models/__init__.py
+++ b/pylate/models/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .colbert import ColBERT
 from .Dense import Dense
 

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import json
 import logging

--- a/pylate/rank/__init__.py
+++ b/pylate/rank/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .rank import rerank
 
 __all__ = ["rerank"]

--- a/pylate/rank/rank.py
+++ b/pylate/rank/rank.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import torch
 

--- a/pylate/retrieve/__init__.py
+++ b/pylate/retrieve/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .colbert import ColBERT
 
 __all__ = ["ColBERT"]

--- a/pylate/retrieve/colbert.py
+++ b/pylate/retrieve/colbert.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 import numpy as np

--- a/pylate/scores/__init__.py
+++ b/pylate/scores/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .scores import colbert_kd_scores, colbert_scores, colbert_scores_pairwise
 from .similarity_functions import SimilarityFunction
 

--- a/pylate/scores/scores.py
+++ b/pylate/scores/scores.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import torch
 

--- a/pylate/server/server.py
+++ b/pylate/server/server.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 from typing import List
 

--- a/pylate/utils/__init__.py
+++ b/pylate/utils/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .collator import ColBERTCollator
 from .huggingface_models import HUGGINGFACE_MODELS
 from .iter_batch import iter_batch

--- a/pylate/utils/collator.py
+++ b/pylate/utils/collator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 from typing import Callable
 

--- a/pylate/utils/huggingface_models.py
+++ b/pylate/utils/huggingface_models.py
@@ -1,6 +1,8 @@
 """Relevant constants for the project."""
 
 # List of models that do not have a family in the Hugging Face model hub.
+from __future__ import annotations
+
 HUGGINGFACE_MODELS = [
     "albert-base-v1",
     "albert-base-v2",

--- a/pylate/utils/iter_batch.py
+++ b/pylate/utils/iter_batch.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import tqdm
 
 

--- a/pylate/utils/multi_process.py
+++ b/pylate/utils/multi_process.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import queue
 

--- a/pylate/utils/processing.py
+++ b/pylate/utils/processing.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 import logging
 

--- a/pylate/utils/tensor.py
+++ b/pylate/utils/tensor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import torch
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -37,7 +37,7 @@ target-version = "py310"
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = ["E4", "E7", "E9", "F"]
+select = ["E4", "E7", "E9", "F", "I"]
 ignore = []
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
@@ -46,6 +46,9 @@ unfixable = []
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[lint.isort]
+required-imports = ["from __future__ import annotations"]
 
 [format]
 quote-style = "double"


### PR DESCRIPTION
I've added `from __future__ import annotations` to all files by updating `ruff.toml`. Tests are now running on Python 3.9 to 3.12.