### PR TITLE
Read stanford configs

### DIFF
--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -390,7 +390,11 @@ class ColBERT(SentenceTransformer):
         self.skiplist = [
             self.tokenizer.convert_tokens_to_ids(word) for word in self.skiplist_words
         ]
-        self.attend_to_expansion_tokens = attend_to_expansion_tokens or False
+        self.attend_to_expansion_tokens = (
+            attend_to_expansion_tokens
+            if attend_to_expansion_tokens is not None
+            else self.attend_to_expansion_tokens or False
+        )
 
     @staticmethod
     def load(input_path) -> "ColBERT":

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -343,11 +343,15 @@ class ColBERT(SentenceTransformer):
 
         self.to(device)
         self.is_hpu_graph_enabled = False
-
-        if self.query_prefix is None:
-            self.query_prefix = "[Q] "
-        if self.document_prefix is None:
-            self.document_prefix = "[D] "
+        # Override the configuration values with the provided arguments, if any.
+        self.query_prefix = (
+            query_prefix if query_prefix is not None else self.query_prefix or "[Q] "
+        )
+        self.document_prefix = (
+            document_prefix
+            if document_prefix is not None
+            else self.document_prefix or "[D] "
+        )
 
         # Try adding the prefixes to the tokenizer. We call resize_token_embeddings twice to ensure the tokens are added only if resize_token_embeddings works. There should be a better way to do this.
         try:
@@ -369,7 +373,6 @@ class ColBERT(SentenceTransformer):
         # Set the padding token ID to be the same as the mask token ID for queries.
         self.tokenizer.pad_token_id = self.tokenizer.mask_token_id
 
-        # Override the configuration values with the provided arguments, if any.
         self.document_length = (
             document_length
             if document_length is not None

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -265,7 +265,7 @@ class ColBERT(SentenceTransformer):
                         use_auth_token,
                     )
                 )
-                logger.warning("Loaded the weights from Stanford NLP model.")
+                logger.info("Loaded the weights from Stanford NLP model.")
                 try:
                     metadata = cached_file(
                         model_name_or_path,
@@ -291,7 +291,7 @@ class ColBERT(SentenceTransformer):
                             self.attend_to_expansion_tokens = metadata[
                                 "attend_to_mask_tokens"
                             ]
-                    logger.warning("Loaded the configuration from Stanford NLP model.")
+                    logger.info("Loaded the configuration from Stanford NLP model.")
                 except EnvironmentError:
                     if self.query_prefix is None:
                         self.query_prefix = "[unused0]"
@@ -305,10 +305,10 @@ class ColBERT(SentenceTransformer):
                 # Add a linear projection layer to the model in order to project the embeddings to the desired size
                 embedding_size = embedding_size or 128
 
-                logger.warning(
+                logger.info(
                     f"The checkpoint does not contain a linear projection layer. Adding one with output dimensions ({hidden_size}, {embedding_size})."
                 )
-                logger.warning("Created a PyLate model from base encoder.")
+                logger.info("Created a PyLate model from base encoder.")
                 self.append(
                     Dense(
                         in_features=hidden_size, out_features=embedding_size, bias=bias
@@ -332,7 +332,7 @@ class ColBERT(SentenceTransformer):
             )
             self[1] = Dense.from_sentence_transformers(dense=self[1])
         else:
-            logger.warning("PyLate model loaded successfully.")
+            logger.info("PyLate model loaded successfully.")
 
         # Ensure all tensors in the model are of the same dtype as the first tensor
         try:

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -343,7 +343,7 @@ class ColBERT(SentenceTransformer):
 
         self.to(device)
         self.is_hpu_graph_enabled = False
-        # Override the configuration values with the provided arguments, if any.
+        # Override the configuration values with the provided arguments, if any. If not set and values have not been read from configs, set to default values.
         self.query_prefix = (
             query_prefix if query_prefix is not None else self.query_prefix or "[Q] "
         )


### PR DESCRIPTION
Right now, we are using default values for doc/query length, markers and attending to expansion tokens when reading stanford models.
This causes some issues as highlighted in #85 and also requires the user to specify a lot of information when using a model that is not using default values, as can be seen with the [loading of Jina-ColBERT.](https://lightonai.github.io/pylate/models/models/#available-models)

This PR simply add the reading process of the `artifact.metadata` file of Stanford NLP models and read markers, lengths and attend to expansion tokens values.

As usual, we override those if the user feed values to the init of the model. Also changed the `attend_to_expansion_tokens` parameter to match the other (None by default and override at the end).