### PR TITLE
fix: Remove default padding of queries to 32

### DIFF
--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -979,7 +979,7 @@ class ColBERT(SentenceTransformer):
         )  # Subtract 1 for the prefix token
 
         # Pad queries (query expansion) and handle padding for documents if specified
-        tokenize_args = {"padding": "max_length"} if pad_document or is_query else {}
+        tokenize_args = {"padding": "max_length"} if pad_document else {}
 
         # Tokenize the texts
         tokenized_outputs = self._first_module().tokenize(texts, **tokenize_args)


### PR DESCRIPTION
Previously, the default behavior was to pad every query to a length of 32, resulting in unnecessary computational overhead during comparisons.

I hope I haven’t overlooked any details. Please feel free to let me know if anything needs further review.

