### PR TITLE
fix: use model card from pylate for  upload to hub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,7 @@ livedoc:
 
 deploydoc:
 	mkdocs gh-deploy --force
+
+
+install:
+	pip install -e ."[dev]"

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -1213,12 +1213,6 @@ class ColBERT(SentenceTransformer):
         # we don't generate a new model card, but reuse the old one instead.
         if self._model_card_text and "generated_from_trainer" not in self.model_card_data.tags:
             model_card = self._model_card_text
-            if self.model_card_data.model_id:
-                # If the original model card was saved without a model_id, we replace the model_id with the new model_id
-                model_card = model_card.replace(
-                    'model = SentenceTransformer("sentence_transformers_model_id"',
-                    f'model = SentenceTransformer("{self.model_card_data.model_id}"',
-                )
         else:
             try:
                 model_card = generate_model_card(self)

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -6,6 +6,8 @@ import logging
 import math
 import os
 import string
+import traceback
+from pathlib import Path
 from typing import Iterable, Literal, Optional
 
 import numpy as np
@@ -20,7 +22,7 @@ from sentence_transformers.util import batch_to_device, load_file_path
 from torch import nn
 from tqdm.autonotebook import trange
 
-from ..hf_hub.model_card import PylateModelCardData
+from ..hf_hub.model_card import PylateModelCardData, generate_model_card
 from ..scores import SimilarityFunction
 from ..utils import _start_multi_process_pool
 from .Dense import Dense
@@ -1186,3 +1188,47 @@ class ColBERT(SentenceTransformer):
             if isinstance(module, Transformer)
             or isinstance(module, DenseSentenceTransformer)
         ], module_kwargs
+    
+    def _create_model_card(
+        self, path: str, model_name: str | None = None, train_datasets: list[str] | None = "deprecated"
+    ) -> None:
+        """
+        Create an automatic model and stores it in the specified path. If no training was done and the loaded model
+        was a Sentence Transformer model already, then its model card is reused.
+
+        Args:
+            path (str): The path where the model card will be stored.
+            model_name (Optional[str], optional): The name of the model. Defaults to None.
+            train_datasets (Optional[List[str]], optional): Deprecated argument. Defaults to "deprecated".
+
+        Returns:
+            None
+        """
+        if model_name:
+            model_path = Path(model_name)
+            if not model_path.exists() and not self.model_card_data.model_id:
+                self.model_card_data.model_id = model_name
+
+        # If we loaded a Sentence Transformer model from the Hub, and no training was done, then
+        # we don't generate a new model card, but reuse the old one instead.
+        if self._model_card_text and "generated_from_trainer" not in self.model_card_data.tags:
+            model_card = self._model_card_text
+            if self.model_card_data.model_id:
+                # If the original model card was saved without a model_id, we replace the model_id with the new model_id
+                model_card = model_card.replace(
+                    'model = SentenceTransformer("sentence_transformers_model_id"',
+                    f'model = SentenceTransformer("{self.model_card_data.model_id}"',
+                )
+        else:
+            try:
+                model_card = generate_model_card(self)
+            except Exception:
+                logger.error(
+                    f"Error while generating model card:\n{traceback.format_exc()}"
+                    "Consider opening an issue on https://github.com/UKPLab/sentence-transformers/issues with this traceback.\n"
+                    "Skipping model card creation."
+                )
+                return
+
+        with open(os.path.join(path, "README.md"), "w", encoding="utf8") as fOut:
+            fOut.write(model_card)


### PR DESCRIPTION
This PR allows the use of push_to_hub with the PyLate template. 

ST lib is importing its own create ModelCard function that is not getting overwritten by PyLate. 

```

from pylate import models
from pylate.models.colbert import PylateModelCardData

model = models.ColBERT(
    model_name_or_path="colbert-ir/colbertv2.0",
    model_card_data=PylateModelCardData(model_name="GerColBERT2"),
)

model.push_to_hub(".....", private=True,  exist_ok=True)



```