### PR TITLE
Bump version 1.1.5

### DIFF
--- a/pylate/__version__.py
+++ b/pylate/__version__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-VERSION = (1, 1, 4)
+VERSION = (1, 1, 5)
 
 __version__ = ".".join(map(str, VERSION))


### PR DESCRIPTION
- Addition of NanoBEIREvaluator, allowing to give quick signal about the learning during training
Support of Python 3.9

- Bump of transformers/ST versions, allowing to use ModernBERT in PyLate and also fixing an issue for loading models after training them with trust_remote_code=True

- Reading of Stanford-NLP models configurations (markers, attending to expansion tokens, ...), allowing to load models such as Jina-ColBERT without having to specify all these parameters
Some fixes
