### PR TITLE
fix:  Loading Model - Stanford Models

### DIFF
--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -279,18 +279,27 @@ class ColBERT(SentenceTransformer):
                     with open(metadata, "r") as f:
                         metadata = json.load(f)
                         # If the user do not override the values, read from config file
-                        if self.query_prefix is None:
-                            self.query_prefix = metadata["query_token_id"]
-                        if self.document_prefix is None:
-                            self.document_prefix = metadata["doc_token_id"]
-                        if self.query_length is None:
-                            self.query_length = metadata["query_maxlen"]
-                        if self.document_length is None:
-                            self.document_length = metadata["doc_maxlen"]
-                        if self.attend_to_expansion_tokens is None:
-                            self.attend_to_expansion_tokens = metadata[
-                                "attend_to_mask_tokens"
-                            ]
+                        meta_query_token_id =  metadata.get("query_token_id", None)
+                        if self.query_prefix is None and meta_query_token_id is not None:
+                            self.query_prefix = meta_query_token_id
+
+                        meta_doc_token_id = metadata.get("doc_token_id", None)
+                        if self.document_prefix is None and meta_doc_token_id is not None:
+                            self.document_prefix = meta_doc_token_id
+
+                        meta_query_maxlen = metadata.get("query_maxlen", None)    
+                        if self.query_length is None and meta_query_maxlen is not None:
+                            self.query_length = meta_query_maxlen
+                
+
+                        meta_doc_maxlen = metadata.get("doc_maxlen", None)
+                        if self.document_length is None and meta_doc_maxlen is not None:
+                            self.document_length = meta_doc_maxlen
+
+                        meta_attend_to_mask_tokens = metadata.get("attend_to_mask_tokens", None)
+                        if self.attend_to_expansion_tokens is None and meta_attend_to_mask_tokens is not None:
+                            self.attend_to_expansion_tokens = meta_attend_to_mask_tokens
+                            
                     logger.info("Loaded the configuration from Stanford NLP model.")
                 except EnvironmentError:
                     if self.query_prefix is None:

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -280,24 +280,24 @@ class ColBERT(SentenceTransformer):
                         metadata = json.load(f)
                         # If the user do not override the values, read from config file
                         meta_query_token_id =  metadata.get("query_token_id", None)
-                        if self.query_prefix is None and meta_query_token_id is not None:
+                        if self.query_prefix is None and meta_query_token_id:
                             self.query_prefix = meta_query_token_id
 
                         meta_doc_token_id = metadata.get("doc_token_id", None)
-                        if self.document_prefix is None and meta_doc_token_id is not None:
+                        if self.document_prefix is None and meta_doc_token_id:
                             self.document_prefix = meta_doc_token_id
 
                         meta_query_maxlen = metadata.get("query_maxlen", None)    
-                        if self.query_length is None and meta_query_maxlen is not None:
+                        if self.query_length is None and meta_query_maxlen:
                             self.query_length = meta_query_maxlen
                 
 
                         meta_doc_maxlen = metadata.get("doc_maxlen", None)
-                        if self.document_length is None and meta_doc_maxlen is not None:
+                        if self.document_length is None and meta_doc_maxlen:
                             self.document_length = meta_doc_maxlen
 
                         meta_attend_to_mask_tokens = metadata.get("attend_to_mask_tokens", None)
-                        if self.attend_to_expansion_tokens is None and meta_attend_to_mask_tokens is not None:
+                        if self.attend_to_expansion_tokens is None and meta_attend_to_mask_tokens:
                             self.attend_to_expansion_tokens = meta_attend_to_mask_tokens
                             
                     logger.info("Loaded the configuration from Stanford NLP model.")


### PR DESCRIPTION
@raphaelsty @NohTow 

I believe this is an urgent fix that also requires a new release.  
```python
from pylate import models


model = models.ColBERT(
    model_name_or_path="colbert-ir/colbertv2.0",
)
```

```
No sentence-transformers model found with name colbert-ir/colbertv2.0.
Traceback (most recent call last):
  File "/Users/A200009373/Documents/Coding/pylate/test.py", line 7, in <module>
    model = models.ColBERT(
            ^^^^^^^^^^^^^^^
  File "/Users/A200009373/Documents/Coding/pylate/pylate/models/colbert.py", line 283, in __init__
    self.query_prefix = metadata["query_token_id"]
                        ~~~~~~~~^^^^^^^^^^^^^^^^^^
KeyError: 'query_token_id'
```