### PR TITLE
Add gathering to (cached) contrastive loss

### DIFF
--- a/pylate/losses/cached_contrastive.py
+++ b/pylate/losses/cached_contrastive.py
@@ -13,8 +13,8 @@ from torch.utils.checkpoint import get_device_states, set_device_states
 
 from ..models import ColBERT
 from ..scores import colbert_scores
-from .contrastive import extract_skiplist_mask
 from ..utils import all_gather
+from .contrastive import extract_skiplist_mask
 
 
 class RandContext:
@@ -141,7 +141,6 @@ class CachedContrastive(nn.Module):
         # Will hold random states for each chunk, so we can re-run the embedding pass with grads
         self.random_states: list[list[RandContext]] | None = None
 
-
     def embed_minibatch(
         self,
         sentence_feature: dict[str, Tensor],
@@ -239,10 +238,11 @@ class CachedContrastive(nn.Module):
         # Possibly gather the embeddings across devices to have more in-batch negatives. For GradCache, we only need to gather them to compute the scores matrix and nowhere else.
         if self.gather_across_devices:
             embeddings_anchor = torch.cat(all_gather(embeddings_anchor))
-            embeddings_other = [torch.cat(all_gather(embeddings)) for embeddings in embeddings_other]
+            embeddings_other = [
+                torch.cat(all_gather(embeddings)) for embeddings in embeddings_other
+            ]
             masks = [torch.cat(all_gather(mask)) for mask in masks]
-   
-            
+
         batch_size = len(embeddings_anchor)
         labels = torch.tensor(
             range(batch_size), dtype=torch.long, device=reps[0][0].device
@@ -370,6 +370,3 @@ class CachedContrastive(nn.Module):
     primaryClass={cs.LG}
 }
 """
-
-
-

--- a/pylate/losses/cached_contrastive.py
+++ b/pylate/losses/cached_contrastive.py
@@ -62,8 +62,8 @@ def _backward_hook(
                 ),
                 grad,
             ):
-                # Dot the embedding chunk with the cached gradient chunk,
-                # scaled by grad_output from the top-level backward pass
+                # Plug back the cached gradients into the backward pass by dotting them with the corresponding representations
+                # Scale by grad_output from the top-level backward pass to account for gradient of downstream operations (not useful in this setup)
                 surrogate = (
                     torch.dot(reps_mb.flatten(), grad_mb.flatten()) * grad_output
                 )

--- a/pylate/losses/cached_contrastive.py
+++ b/pylate/losses/cached_contrastive.py
@@ -240,6 +240,7 @@ class CachedContrastive(nn.Module):
         if self.gather_across_devices:
             embeddings_anchor = torch.cat(all_gather(embeddings_anchor))
             embeddings_other = [torch.cat(all_gather(embeddings)) for embeddings in embeddings_other]
+            masks = [torch.cat(all_gather(mask)) for mask in masks]
    
             
         batch_size = len(embeddings_anchor)

--- a/pylate/losses/cached_contrastive.py
+++ b/pylate/losses/cached_contrastive.py
@@ -307,7 +307,17 @@ class CachedContrastive(nn.Module):
     def forward(
         self,
         sentence_features: Iterable[dict[str, Tensor]],
+        labels: Optional[Tensor] = None,
     ) -> Tensor:
+        """Compute the CachedConstrastive loss.
+
+        Parameters
+        ----------
+        sentence_features
+            List of tokenized sentences. The first sentence is the anchor and the rest are the positive and negative examples.
+        labels
+            The labels for the contrastive loss. Not used in this implementation, but kept for compatibility with Trainer.
+        """
         # Step (1): A quick embedding step without gradients/computation graphs to get all the embeddings
         reps = []
         self.random_states = []  # Copy random states to guarantee exact reproduction of the embeddings during the second forward pass, i.e. step (3)

--- a/pylate/losses/contrastive.py
+++ b/pylate/losses/contrastive.py
@@ -124,7 +124,6 @@ class Contrastive(nn.Module):
     def forward(
         self,
         sentence_features: Iterable[dict[str, Tensor]],
-        labels: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Compute the Constrastive loss.
 

--- a/pylate/losses/contrastive.py
+++ b/pylate/losses/contrastive.py
@@ -158,8 +158,8 @@ class Contrastive(nn.Module):
         )
         # Possibly gather the embeddings across devices to have more in-batch negatives.
         if self.gather_across_devices:
-            embeddings = [all_gather(embedding) for embedding in embeddings]
-            masks = [all_gather(mask) for mask in masks]
+            embeddings = [torch.cat(all_gather(embedding)) for embedding in embeddings]
+            masks = [torch.cat(all_gather(mask)) for mask in masks]
         # Note: the queries mask is not used, if added, take care that the expansion tokens are not masked from scoring (because they might be masked during encoding).
         # We might not need to compute the mask for queries but I let the logic there for now
         scores = torch.cat(

--- a/pylate/losses/contrastive.py
+++ b/pylate/losses/contrastive.py
@@ -129,6 +129,7 @@ class Contrastive(nn.Module):
     def forward(
         self,
         sentence_features: Iterable[dict[str, Tensor]],
+        labels: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Compute the Constrastive loss.
 
@@ -136,6 +137,8 @@ class Contrastive(nn.Module):
         ----------
         sentence_features
             List of tokenized sentences. The first sentence is the anchor and the rest are the positive and negative examples.
+        labels
+            The labels for the contrastive loss. Not used in this implementation, but kept for compatibility with Trainer.
 
         """
         embeddings = [

--- a/pylate/utils/__init__.py
+++ b/pylate/utils/__init__.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from .collator import ColBERTCollator
+from .distributed import all_gather
 from .huggingface_models import HUGGINGFACE_MODELS
 from .iter_batch import iter_batch
 from .multi_process import _start_multi_process_pool
 from .processing import KDProcessing
 from .tensor import convert_to_tensor
-from .distributed import all_gather
 
 __all__ = [
     "HUGGINGFACE_MODELS",

--- a/pylate/utils/__init__.py
+++ b/pylate/utils/__init__.py
@@ -6,6 +6,7 @@ from .iter_batch import iter_batch
 from .multi_process import _start_multi_process_pool
 from .processing import KDProcessing
 from .tensor import convert_to_tensor
+from .distributed import all_gather
 
 __all__ = [
     "HUGGINGFACE_MODELS",
@@ -14,4 +15,5 @@ __all__ = [
     "ColBERTCollator",
     "KDProcessing",
     "_start_multi_process_pool",
+    "all_gather",
 ]

--- a/pylate/utils/distributed.py
+++ b/pylate/utils/distributed.py
@@ -1,0 +1,14 @@
+import torch.distributed as dist
+from typing import Sequence
+import torch
+def all_gather(tensor: torch.Tensor) -> Sequence[torch.Tensor]:
+    """Collects a Tensor from each rank, and returns a list of gathered Tensors indexed by rank. The tensor for the local rank is the original one, with the gradients while the others have no gradients.
+    """
+    if dist.is_available() and dist.is_initialized():
+        obj_gather_list = [torch.zeros_like(tensor) for _ in range(dist.get_world_size())]
+        dist.all_gather(obj_gather_list, tensor)
+        obj_gather_list[dist.get_rank()] = tensor
+        return obj_gather_list
+    world_size = dist.get_world_size()
+    if world_size == 1:
+        return [tensor]

--- a/pylate/utils/distributed.py
+++ b/pylate/utils/distributed.py
@@ -1,14 +1,25 @@
 import torch.distributed as dist
 from typing import Sequence
 import torch
+import logging
+
+not_init_warning = True
+logger = logging.getLogger(__name__)
 def all_gather(tensor: torch.Tensor) -> Sequence[torch.Tensor]:
     """Collects a Tensor from each rank, and returns a list of gathered Tensors indexed by rank. The tensor for the local rank is the original one, with the gradients while the others have no gradients.
     """
+    global not_init_warning
     if dist.is_available() and dist.is_initialized():
         obj_gather_list = [torch.zeros_like(tensor) for _ in range(dist.get_world_size())]
         dist.all_gather(obj_gather_list, tensor)
         obj_gather_list[dist.get_rank()] = tensor
         return obj_gather_list
-    world_size = dist.get_world_size()
-    if world_size == 1:
+    try:
+        world_size = dist.get_world_size()
+        if world_size == 1:
+            return [tensor]
+    except ValueError:
+        if not_init_warning:
+            logger.warning("Trying to gather while torch.distributed is not available or has not been initialized, returning the original (local) tensor. This is expected if you are only using one GPU; consider not using gathering to remove this warning.")
+            not_init_warning = False
         return [tensor]

--- a/pylate/utils/distributed.py
+++ b/pylate/utils/distributed.py
@@ -9,25 +9,55 @@ import torch.distributed as dist
 not_init_warning = True
 logger = logging.getLogger(__name__)
 
+_has_warned_dist_not_initialized = False
+
 
 def all_gather(tensor: torch.Tensor) -> Sequence[torch.Tensor]:
-    """Collects a Tensor from each rank, and returns a list of gathered Tensors indexed by rank. The tensor for the local rank is the original one, with the gradients while the others have no gradients."""
-    global not_init_warning
+    """Gathers a tensor from each distributed rank into a list. The tensor for the local rank is the original one, with the gradients while the others have no gradients.
+
+    - If torch.distributed is available and initialized:
+      1. Creates a list of tensors (each sized like the input `tensor`).
+      2. Gathers tensors from each rank into that list.
+      3. Replaces the local tensor in the list with the original tensor that retains gradients.
+
+    - If torch.distributed is either unavailable, uninitialized, or
+      `world_size == 1`, it returns a list containing only the
+      original tensor and throws a warning to notify the user (helpful when using a single GPU setup).
+
+    Parameters
+    ----------
+    tensor:
+        The input tensor to be gathered from each rank.
+
+    Returns
+    -------
+    Sequence:
+        A list of tensors collected from each rank. On a single GPU or when distributed is uninitialized, the list will contain only the original tensor.
+
+    """
+    global _has_warned_dist_not_initialized
+
+    # Check if torch.distributed is properly available and initialized.
     if dist.is_available() and dist.is_initialized():
-        obj_gather_list = [
-            torch.zeros_like(tensor) for _ in range(dist.get_world_size())
-        ]
-        dist.all_gather(obj_gather_list, tensor)
-        obj_gather_list[dist.get_rank()] = tensor
-        return obj_gather_list
-    try:
         world_size = dist.get_world_size()
-        if world_size == 1:
-            return [tensor]
-    except ValueError:
-        if not_init_warning:
-            logger.warning(
-                "Trying to gather while torch.distributed is not available or has not been initialized, returning the original (local) tensor. This is expected if you are only using one GPU; consider not using gathering to remove this warning."
-            )
-            not_init_warning = False
-        return [tensor]
+        gathered_tensors = [torch.zeros_like(tensor) for _ in range(world_size)]
+
+        # Perform all_gather.
+        dist.all_gather(gathered_tensors, tensor)
+
+        # Replace local rank's tensor with the original (retaining gradients).
+        local_rank = dist.get_rank()
+        gathered_tensors[local_rank] = tensor
+        return gathered_tensors
+
+    # Warn once about uninitialized or single-GPU usage.
+    if not _has_warned_dist_not_initialized:
+        warning = """
+            Trying to gather while torch.distributed is not available or has not been initialized, 
+             returning the original (local) tensor. This is expected if you are 
+             only using one GPU; consider not using gathering to remove this warning.
+       """
+        logger.warning(warning)
+        _has_warned_dist_not_initialized = True
+
+    return [tensor]

--- a/pylate/utils/distributed.py
+++ b/pylate/utils/distributed.py
@@ -1,16 +1,22 @@
-import torch.distributed as dist
-from typing import Sequence
-import torch
+from __future__ import annotations
+
 import logging
+from typing import Sequence
+
+import torch
+import torch.distributed as dist
 
 not_init_warning = True
 logger = logging.getLogger(__name__)
+
+
 def all_gather(tensor: torch.Tensor) -> Sequence[torch.Tensor]:
-    """Collects a Tensor from each rank, and returns a list of gathered Tensors indexed by rank. The tensor for the local rank is the original one, with the gradients while the others have no gradients.
-    """
+    """Collects a Tensor from each rank, and returns a list of gathered Tensors indexed by rank. The tensor for the local rank is the original one, with the gradients while the others have no gradients."""
     global not_init_warning
     if dist.is_available() and dist.is_initialized():
-        obj_gather_list = [torch.zeros_like(tensor) for _ in range(dist.get_world_size())]
+        obj_gather_list = [
+            torch.zeros_like(tensor) for _ in range(dist.get_world_size())
+        ]
         dist.all_gather(obj_gather_list, tensor)
         obj_gather_list[dist.get_rank()] = tensor
         return obj_gather_list
@@ -20,6 +26,8 @@ def all_gather(tensor: torch.Tensor) -> Sequence[torch.Tensor]:
             return [tensor]
     except ValueError:
         if not_init_warning:
-            logger.warning("Trying to gather while torch.distributed is not available or has not been initialized, returning the original (local) tensor. This is expected if you are only using one GPU; consider not using gathering to remove this warning.")
+            logger.warning(
+                "Trying to gather while torch.distributed is not available or has not been initialized, returning the original (local) tensor. This is expected if you are only using one GPU; consider not using gathering to remove this warning."
+            )
             not_init_warning = False
         return [tensor]


### PR DESCRIPTION
This PR adds the option to gather documents from the other GPUs in both contrastive and cached contrastive loss.
The default is still not to gather even though in my opinion it should be the default for back-compatibility purpose.
Also, this is most likely bringing the most improvement when all the GPUs have batches from the same dataset in the multi dataset setting. 
I am having discussion with @tomaarsen to define what is the best way to include this option into ST, but for now I have found a workaround and will add a boilerplate later.

The sanity check I ran on a ms marco dataset:
- GradCache is almost equivalent to standard contrastive for the same bs (Not == because I cannot seed everything into ST)
- Increasing the global batch size with grad cache while using the old batch size as mini batch size gets better perf without using more VRAM
- Gathering brings a lot of improvements and is compatible works with both grad cache and contrastive loss
- Increasing the global batch size with grad cache and gathering yield the best results without increasing VRAM usage

Also enhanced a bit the documentation.
