### PR TITLE
Change the gathering versions to local losses with gradients

### DIFF
--- a/pylate/utils/__init__.py
+++ b/pylate/utils/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from .collator import ColBERTCollator
-from .distributed import all_gather
+from .distributed import all_gather, all_gather_with_gradients
 from .huggingface_models import HUGGINGFACE_MODELS
 from .iter_batch import iter_batch
 from .multi_process import _start_multi_process_pool
@@ -16,4 +16,5 @@ __all__ = [
     "KDProcessing",
     "_start_multi_process_pool",
     "all_gather",
+    "all_gather_with_gradients",
 ]


### PR DESCRIPTION
Hello,

To compute contrastive loss with gathered elements from other GPUs, you have two solutions:

- Gather everything (queries + documents) _without the gradients in remote elements_. In this case, you need to compute the loss for all the elements on all the GPUs so every elements receive their full update on their local GPUs.
- Gather only the documents _with the gradients_. In this setup, the queries receive the full update because we gathered all the documents, but the documents receive the update w.r.t each query directly from the GPU holding those queries.
Please see [this](https://github.com/mlfoundations/open_clip/issues/616) for more information.

The former requires less communication (IIUC, a reduce_scatter operation during the backprop) while the latter is less memory intensive because we do not have to compute the full `(bs * n_gpu, bs*n_gpu)` scores on all the GPUs but only `(bs, bs*n_gpu)`. 
In the case of late interaction models, the score computation (MaxSim) is actually _really_ expensive (way more than standard dense contrastive dot products), which led to the [chunking of the scores computation](https://github.com/lightonai/pylate/blob/2d094a724866d6e15701781528368438081c0157/pylate/losses/cached_contrastive.py#L259)in the GradCache implementation, because the BS gets so big it explodes memory usage.

However, it appears that, for very big batch sizes (16k), this chunked score computation becomes a speed bottleneck.
Using the second setup allows to reduce the number of scores chunk to compute drastically and thus improves the speed of training. 

In my tests, it seems that the additional communication has only a marginal cost on a single node but multi-GPUs setup, which is way more than counterbalanced by a faster score computation.
Maybe it would be a bit different in a multi-node setup, but this PR should speed-up training on the most usual training setups (and I think with infiniband even multinode should be ok).

I tested and both methods yields very similar results. I am not sure why it is not 100% the same (as it should), but it seems very minor.

cc @tomaarsen 