### PR TITLE
Scale contrastive loss by world size

### DIFF
--- a/pylate/losses/cached_contrastive.py
+++ b/pylate/losses/cached_contrastive.py
@@ -257,11 +257,7 @@ class CachedContrastive(nn.Module):
                 masks[0],
                 *[torch.cat(all_gather(mask)) for mask in masks[1:]],
             ]
-            rank = (
-                torch.distributed.get_rank()
-                if torch.distributed.is_initialized()
-                else 0
-            )
+            rank = get_rank()
             # Adjust the labels to match the gathered embeddings positions
             labels = labels + rank * batch_size
         losses: list[torch.Tensor] = []

--- a/pylate/losses/cached_contrastive.py
+++ b/pylate/losses/cached_contrastive.py
@@ -13,7 +13,7 @@ from torch.utils.checkpoint import get_device_states, set_device_states
 
 from ..models import ColBERT
 from ..scores import colbert_scores
-from ..utils import all_gather, all_gather_with_gradients
+from ..utils import all_gather, all_gather_with_gradients, get_rank, get_world_size
 from .contrastive import extract_skiplist_mask
 
 
@@ -300,10 +300,13 @@ class CachedContrastive(nn.Module):
                 dim=1,
             )
             # We don't want to average the loss across the mini-batch as mini-batch sizes can vary, which would create an issue similar to this one: https://huggingface.co/blog/gradient_accumulation#where-does-it-stem-from
-            loss_mbatch = F.cross_entropy(
-                input=scores,
-                target=labels[begin:end],
-                reduction="sum",
+            loss_mbatch = (
+                F.cross_entropy(
+                    input=scores,
+                    target=labels[begin:end],
+                    reduction="sum",
+                )
+                * get_world_size()
             )
 
             if with_backward:

--- a/pylate/losses/contrastive.py
+++ b/pylate/losses/contrastive.py
@@ -8,7 +8,7 @@ from torch import Tensor, nn
 
 from ..models import ColBERT
 from ..scores import colbert_scores
-from ..utils import all_gather, all_gather_with_gradients
+from ..utils import all_gather, all_gather_with_gradients, get_rank
 
 
 def extract_skiplist_mask(
@@ -175,11 +175,7 @@ class Contrastive(nn.Module):
                 masks[0],
                 *[torch.cat(all_gather(mask)) for mask in masks[1:]],
             ]
-            rank = (
-                torch.distributed.get_rank()
-                if torch.distributed.is_initialized()
-                else 0
-            )
+            rank = get_rank()
             # Adjust the labels to match the gathered embeddings positions
             labels = labels + rank * batch_size
         # Note: the queries mask is not used, if added, take care that the expansion tokens are not masked from scoring (because they might be masked during encoding).

--- a/pylate/losses/contrastive.py
+++ b/pylate/losses/contrastive.py
@@ -8,7 +8,7 @@ from torch import Tensor, nn
 
 from ..models import ColBERT
 from ..scores import colbert_scores
-from ..utils import all_gather, all_gather_with_gradients, get_rank
+from ..utils import all_gather, all_gather_with_gradients, get_rank, get_world_size
 
 
 def extract_skiplist_mask(
@@ -190,8 +190,11 @@ class Contrastive(nn.Module):
 
         # compute constrastive loss using cross-entropy over the scores
 
-        return F.cross_entropy(
-            input=scores,
-            target=labels,
-            reduction="mean" if self.size_average else "sum",
+        return (
+            F.cross_entropy(
+                input=scores,
+                target=labels,
+                reduction="mean" if self.size_average else "sum",
+            )
+            * get_world_size()
         )

--- a/pylate/utils/__init__.py
+++ b/pylate/utils/__init__.py
@@ -17,4 +17,5 @@ __all__ = [
     "_start_multi_process_pool",
     "all_gather",
     "all_gather_with_gradients",
+    "get_rank",
 ]

--- a/pylate/utils/__init__.py
+++ b/pylate/utils/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from .collator import ColBERTCollator
-from .distributed import all_gather, all_gather_with_gradients
+from .distributed import all_gather, all_gather_with_gradients, get_rank, get_world_size
 from .huggingface_models import HUGGINGFACE_MODELS
 from .iter_batch import iter_batch
 from .multi_process import _start_multi_process_pool
@@ -18,4 +18,5 @@ __all__ = [
     "all_gather",
     "all_gather_with_gradients",
     "get_rank",
+    "get_world_size",
 ]

--- a/pylate/utils/distributed.py
+++ b/pylate/utils/distributed.py
@@ -111,3 +111,12 @@ def get_rank() -> int:
         return dist.get_rank()
     else:
         return 0
+
+
+def get_world_size() -> int:
+    """Returns the world size in a distributed training."""
+    # Check if torch.distributed is properly available and initialized.
+    if dist.is_available() and dist.is_initialized():
+        return dist.get_world_size()
+    else:
+        return 1

--- a/pylate/utils/distributed.py
+++ b/pylate/utils/distributed.py
@@ -102,3 +102,12 @@ def all_gather_with_gradients(tensor: torch.Tensor) -> Sequence[torch.Tensor]:
         _has_warned_dist_not_initialized = True
 
     return [tensor]
+
+
+def get_rank() -> int:
+    """Returns the current rank in a distributed training."""
+    # Check if torch.distributed is properly available and initialized.
+    if dist.is_available() and dist.is_initialized():
+        return torch.distributed.get_rank()
+    else:
+        return 0

--- a/pylate/utils/distributed.py
+++ b/pylate/utils/distributed.py
@@ -88,7 +88,7 @@ def all_gather_with_gradients(tensor: torch.Tensor) -> Sequence[torch.Tensor]:
 
     # Check if torch.distributed is properly available and initialized.
     if dist.is_available() and dist.is_initialized():
-        tensor = torch.distributed.nn.all_gather(tensor)
+        tensor = dist.nn.all_gather(tensor)
         return tensor
 
     # Warn once about uninitialized or single-GPU usage.
@@ -108,6 +108,6 @@ def get_rank() -> int:
     """Returns the current rank in a distributed training."""
     # Check if torch.distributed is properly available and initialized.
     if dist.is_available() and dist.is_initialized():
-        return torch.distributed.get_rank()
+        return dist.get_rank()
     else:
         return 0

--- a/pylate/utils/distributed.py
+++ b/pylate/utils/distributed.py
@@ -109,8 +109,7 @@ def get_rank() -> int:
     # Check if torch.distributed is properly available and initialized.
     if dist.is_available() and dist.is_initialized():
         return dist.get_rank()
-    else:
-        return 0
+    return 0
 
 
 def get_world_size() -> int:
@@ -118,5 +117,4 @@ def get_world_size() -> int:
     # Check if torch.distributed is properly available and initialized.
     if dist.is_available() and dist.is_initialized():
         return dist.get_world_size()
-    else:
-        return 1
+    return 1


### PR DESCRIPTION
With the recent addition of gathering from other gpus in a multi-gpu setting, there's a scaling by the world size missing to the loss (because PyTorch does an average over the number of GPUs by default, so we need to scale by the same number to have a similar loss no matter the number of GPUs).
Also took the opportunity to create a dedicated function for getting the rank instead of duplicating code.

I wonder if we should set the world size/rank as a parameter to only read it once instead of at each step... Maybe it's too much optimization idk