### PR TITLE
Add temperature parameter to contrastive losses

### DIFF
--- a/pylate/losses/cached_contrastive.py
+++ b/pylate/losses/cached_contrastive.py
@@ -132,6 +132,7 @@ class CachedContrastive(nn.Module):
         size_average: bool = True,
         gather_across_devices: bool = False,
         show_progress_bar: bool = False,
+        temperature: float = 1.0,
     ) -> None:
         super(CachedContrastive, self).__init__()
         self.model = model
@@ -140,6 +141,7 @@ class CachedContrastive(nn.Module):
         self.size_average = size_average
         self.gather_across_devices = gather_across_devices
         self.show_progress_bar = show_progress_bar
+        self.temperature = temperature
 
         # Will hold partial derivatives for each embedding chunk
         self.cache: list[list[Tensor]] | None = None
@@ -302,7 +304,7 @@ class CachedContrastive(nn.Module):
             # We don't want to average the loss across the mini-batch as mini-batch sizes can vary, which would create an issue similar to this one: https://huggingface.co/blog/gradient_accumulation#where-does-it-stem-from
             loss_mbatch = (
                 F.cross_entropy(
-                    input=scores,
+                    input=scores / self.temperature,
                     target=labels[begin:end],
                     reduction="sum",
                 )

--- a/pylate/losses/contrastive.py
+++ b/pylate/losses/contrastive.py
@@ -119,12 +119,14 @@ class Contrastive(nn.Module):
         score_metric=colbert_scores,
         size_average: bool = True,
         gather_across_devices: bool = False,
+        temperature: float = 1.0,
     ) -> None:
         super(Contrastive, self).__init__()
         self.score_metric = score_metric
         self.model = model
         self.size_average = size_average
         self.gather_across_devices = gather_across_devices
+        self.temperature = temperature
 
     def forward(
         self,
@@ -192,7 +194,7 @@ class Contrastive(nn.Module):
 
         return (
             F.cross_entropy(
-                input=scores,
+                input=scores / self.temperature,
                 target=labels,
                 reduction="mean" if self.size_average else "sum",
             )


### PR DESCRIPTION
Hey,
This PR adds a temperature parameter to the contrastive losses.
I initially removed it when copying the losses from ST because it is named "scale" and was actually a multiplicative scalar instead of being called temperature and dividing the similarities.
It turns out, for contrastive training, we require a very low temperature if we want to get the best performance possible.
I set the default to 1.0 to be equivalent to previous trainings, but maybe using 0.02 is better as it is the most commonly used value.
WDYT @raphaelsty?