### PR TITLE
Fix: Handle index loading correctly to prevent stream read error

### DIFF
--- a/pylate/indexes/voyager.py
+++ b/pylate/indexes/voyager.py
@@ -162,7 +162,8 @@ class Voyager(Base):
 
         """
         if os.path.exists(path=index_path) and not override:
-            return Index.load(index_path)
+            with open(index_path, "rb") as f:
+                return Index.load(f)
 
         if os.path.exists(path=index_path):
             os.remove(index_path)


### PR DESCRIPTION
This fixes a bug where loading an existing index file caused a RuntimeError due to incorrect use of Index.load. The code was passing a file path instead of a file object. The fix opens the file in binary mode and passes the file handle to Index.load, resolving the issue.