### PR TITLE
Use file-like loading for the Voyager index to fix Windows loading (and add loading tests for indexes)

### DIFF
--- a/pylate/indexes/plaid.py
+++ b/pylate/indexes/plaid.py
@@ -126,13 +126,15 @@ class PLAID(Base):
         self.index_folder = index_folder
         self.indexer = Indexer(config=self.config)
         self.documents_ids_to_plaid_ids_path = os.path.join(
-            index_folder, f"{index_name}_documents_ids_to_plaid_ids.sqlite"
+            index_folder, index_name, "documents_ids_to_plaid_ids.sqlite"
         )
         self.plaid_ids_to_documents_ids_path = os.path.join(
-            index_folder, f"{index_name}_plaid_ids_to_documents_ids.sqlite"
+            index_folder, index_name, "plaid_ids_to_documents_ids.sqlite"
         )
         if not os.path.exists(index_folder):
             os.makedirs(index_folder)
+        if not os.path.exists(f"{index_folder}/{index_name}"):
+            os.makedirs(f"{index_folder}/{index_name}")
         if override:
             if os.path.exists(self.documents_ids_to_plaid_ids_path):
                 os.remove(self.documents_ids_to_plaid_ids_path)

--- a/pylate/indexes/plaid.py
+++ b/pylate/indexes/plaid.py
@@ -124,7 +124,7 @@ class PLAID(Base):
         )
         self.index_name = index_name
         self.index_folder = index_folder
-        self.indexer = Indexer(checkpoint="colbert-ir/colbertv2.0", config=self.config)
+        self.indexer = Indexer(config=self.config)
         self.documents_ids_to_plaid_ids_path = os.path.join(
             index_folder, f"{index_name}_documents_ids_to_plaid_ids.sqlite"
         )

--- a/pylate/indexes/stanford_nlp/indexer.py
+++ b/pylate/indexes/stanford_nlp/indexer.py
@@ -8,7 +8,7 @@ from pylate.indexes.stanford_nlp.utils.utils import create_directory, print_mess
 
 
 class Indexer:
-    def __init__(self, checkpoint, config=None, verbose: int = 3):
+    def __init__(self, config=None, verbose: int = 3):
         """
         Use Run().context() to choose the run's configuration. They are NOT extracted from `config`.
         """

--- a/pylate/indexes/voyager.py
+++ b/pylate/indexes/voyager.py
@@ -95,6 +95,32 @@ class Voyager(Base):
     >>> assert isinstance(matchs, dict)
     >>> assert "documents_ids" in matchs
     >>> assert "distances" in matchs
+    >>> index = indexes.Voyager(
+    ...     index_folder="test_indexes",
+    ...     index_name="colbert",
+    ...     override=False,
+    ... )
+    >>> matchs = index(queries_embeddings, k=30)
+    >>> assert isinstance(matchs, dict)
+    >>> assert "documents_ids" in matchs
+    >>> assert "distances" in matchs
+    >>> index = index.remove_documents(
+    ...     documents_ids=["1"],
+    ... )
+    >>> matchs = index(queries_embeddings, k=30)
+    >>> assert isinstance(matchs, dict)
+    >>> assert "documents_ids" in matchs
+    >>> assert "distances" in matchs
+    >>> index = index.add_documents(
+    ...     documents_ids=["1"],
+    ...     documents_embeddings=documents_embeddings[0],
+    ... )
+    >>> matchs = index(queries_embeddings, k=30)
+    >>> assert isinstance(matchs, dict)
+    >>> assert "documents_ids" in matchs
+    >>> assert "distances" in matchs
+
+
 
     """
 

--- a/pylate/indexes/voyager.py
+++ b/pylate/indexes/voyager.py
@@ -138,13 +138,15 @@ class Voyager(Base):
 
         if not os.path.exists(path=index_folder):
             os.makedirs(name=index_folder)
+        if not os.path.exists(path=os.path.join(index_folder, index_name)):
+            os.makedirs(name=os.path.join(index_folder, index_name))
 
-        self.index_path = os.path.join(index_folder, f"{index_name}.voyager")
+        self.index_path = os.path.join(index_folder, index_name, "index.voyager")
         self.documents_ids_to_embeddings_path = os.path.join(
-            index_folder, f"{index_name}_document_ids_to_embeddings.sqlite"
+            index_folder, index_name, "document_ids_to_embeddings.sqlite"
         )
         self.embeddings_to_documents_ids_path = os.path.join(
-            index_folder, f"{index_name}_embeddings_to_documents_ids.sqlite"
+            index_folder, index_name, "embeddings_to_documents_ids.sqlite"
         )
 
         self.index = self._create_collection(

--- a/pylate/indexes/voyager.py
+++ b/pylate/indexes/voyager.py
@@ -162,7 +162,8 @@ class Voyager(Base):
 
         """
         if os.path.exists(path=index_path) and not override:
-            return Index.load(index_path)
+            with open(index_path, "rb") as f:
+                return Index.load(f)
 
         if os.path.exists(path=index_path):
             os.remove(index_path)

--- a/tests/test_plaid.py
+++ b/tests/test_plaid.py
@@ -8,8 +8,8 @@ def test_plaid():
     random_hash = uuid.uuid4().hex
 
     index = indexes.PLAID(
-        index_folder=random_hash,
-        index_name=random_hash,
+        index_folder=f"test_indexes_{uuid.uuid4().hex}",
+        index_name=f"colbert_{uuid.uuid4().hex}",
         override=True,
     )
 
@@ -39,6 +39,7 @@ def test_plaid():
 
     assert isinstance(matchs, list)
     assert len(matchs) == 2
+    assert len(matchs[0]) == 2
     assert matchs[0][0].keys() == {"id", "score"}
 
     queries_embeddings = model.encode(
@@ -50,6 +51,43 @@ def test_plaid():
 
     assert isinstance(matchs, list)
     assert len(matchs) == 1
+    assert len(matchs[0]) == 2
+    assert matchs[0][0].keys() == {"id", "score"}
+
+    # Test loading
+    index = indexes.PLAID(
+        index_folder=f"test_indexes_{random_hash}",
+        index_name=f"colbert_{random_hash}",
+        override=False,
+    )
+
+    matchs = index(queries_embeddings, k=30)
+    assert isinstance(matchs, list)
+    assert len(matchs) == 1
+    assert len(matchs[0]) == 2
+    assert matchs[0][0].keys() == {"id", "score"}
+
+    # Test removing documents
+    index.remove_documents(
+        documents_ids=["1"],
+    )
+
+    matchs = index(queries_embeddings, k=30)
+    assert isinstance(matchs, list)
+    assert len(matchs) == 1
+    assert len(matchs[0]) == 1
+    assert matchs[0][0].keys() == {"id", "score"}
+
+    # Test second insertion after init of the index
+    index.add_documents(
+        documents_ids=["1"],
+        documents_embeddings=documents_embeddings[0],
+    )
+
+    matchs = index(queries_embeddings, k=30)
+    assert isinstance(matchs, list)
+    assert len(matchs) == 1
+    assert len(matchs[0]) == 2
     assert matchs[0][0].keys() == {"id", "score"}
 
     shutil.rmtree(random_hash)

--- a/tests/test_plaid.py
+++ b/tests/test_plaid.py
@@ -8,8 +8,8 @@ def test_plaid():
     random_hash = uuid.uuid4().hex
 
     index = indexes.PLAID(
-        index_folder=f"test_indexes_{uuid.uuid4().hex}",
-        index_name=f"colbert_{uuid.uuid4().hex}",
+        index_folder=f"test_indexes_{random_hash}",
+        index_name=f"colbert_{random_hash}",
         override=True,
     )
 

--- a/tests/test_plaid.py
+++ b/tests/test_plaid.py
@@ -90,4 +90,4 @@ def test_plaid():
     assert len(matchs[0]) == 2
     assert matchs[0][0].keys() == {"id", "score"}
 
-    shutil.rmtree(random_hash)
+    shutil.rmtree(f"test_indexes_{random_hash}")


### PR DESCRIPTION
This is #121 locally to extend the branch and add some tests.
Essentially, Voyager do not handle index loading from path on Windows (I suppose they do not added the case), but file-like loading is working and it seems to also work on Linux.