### PR TITLE
fixed bug in model card template

### DIFF
--- a/pylate/hf_hub/model_card_template.md
+++ b/pylate/hf_hub/model_card_template.md
@@ -85,7 +85,7 @@ from pylate import indexes, models, retrieve
 
 # Step 1: Load the ColBERT model
 model = models.ColBERT(
-    model_name_or_path={{ model_id | default('pylate_model_id', true) }},
+    model_name_or_path="{{ model_id | default('pylate_model_id', true) }}",
 )
 
 # Step 2: Initialize the Voyager index
@@ -169,7 +169,7 @@ documents_ids = [
 ]
 
 model = models.ColBERT(
-    model_name_or_path={{ model_id | default('pylate_model_id', true) }},
+    model_name_or_path="{{ model_id | default('pylate_model_id', true) }}",
 )
 
 queries_embeddings = model.encode(


### PR DESCRIPTION
In the current version, when a model card is generated, the `model id` of the new pylate model in the sample python code sections is not surrounded by quotation marks.

This causes an error whenever someone copies and tries to run the sample code

Example:

```python
model = models.ColBERT(
    model_name_or_path=rasyosef/colbert-roberta-amharic-base,
)
```

### Fix:

Added double quotes around the model id in `model_card_template.md`

```
model = models.ColBERT(
    model_name_or_path="{{ model_id | default('pylate_model_id', true) }}",
)
```