### PR TITLE
Allow higher transformers version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "voyager >= 2.0.9",
     "sqlitedict >= 2.1.0",
     "pandas >= 2.2.1",
-    "transformers == 4.48.2",
+    "transformers>=4.48.2,<5.0.0",
     "ujson == 5.10.0",
     "ninja == 1.11.1.4",
     "fastkmeans == 0.5.0",


### PR DESCRIPTION
Newer models can't be used because of the strict transformers version.

Related to #133.

- Matched the transformers version specifier to that of sentence transformers.
- Ran tests locally and all are passing without issue