### PR TITLE
Cast indexing numpy int to Python int

### DIFF
--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -595,7 +595,7 @@ class ColBERT(SentenceTransformer):
 
         all_embeddings = []
         length_sorted_idx = np.argsort([-self._text_length(sen) for sen in sentences])
-        sentences_sorted = [sentences[idx] for idx in length_sorted_idx]
+        sentences_sorted = [sentences[int(idx)] for idx in length_sorted_idx]
 
         for start_index in trange(
             0,


### PR DESCRIPTION
Hello,

As mentioned in #139, an update of `datasets` broke the encoding function (which is the reason why tests are failing although the same code was passing before).
As in [ST](https://github.com/UKPLab/sentence-transformers/pull/3455), the simple fix is just to cast the numpy int to a python integer.