### PR TITLE
Only scale by world size when gathering

### DIFF
--- a/pylate/losses/cached_contrastive.py
+++ b/pylate/losses/cached_contrastive.py
@@ -312,14 +312,14 @@ class CachedContrastive(nn.Module):
                 dim=1,
             )
             # We don't want to average the loss across the mini-batch as mini-batch sizes can vary, which would create an issue similar to this one: https://huggingface.co/blog/gradient_accumulation#where-does-it-stem-from
-            loss_mbatch = (
-                F.cross_entropy(
-                    input=scores / self.temperature,
-                    target=labels[begin:end],
-                    reduction="sum",
-                )
-                * get_world_size()
+            loss_mbatch = F.cross_entropy(
+                input=scores / self.temperature,
+                target=labels[begin:end],
+                reduction="sum",
             )
+            # Scale by world size when gathering across device
+            if self.gather_across_devices:
+                loss_mbatch *= get_world_size()
 
             if with_backward:
                 loss_mbatch.backward()

--- a/pylate/losses/contrastive.py
+++ b/pylate/losses/contrastive.py
@@ -201,12 +201,13 @@ class Contrastive(nn.Module):
         )
 
         # compute constrastive loss using cross-entropy over the scores
-
-        return (
-            F.cross_entropy(
-                input=scores / self.temperature,
-                target=labels,
-                reduction="mean" if self.size_average else "sum",
-            )
-            * get_world_size()
+        loss = F.cross_entropy(
+            input=scores / self.temperature,
+            target=labels,
+            reduction="mean" if self.size_average else "sum",
         )
+
+        # Scale by world size when gathering across device
+        if self.gather_across_devices:
+            loss *= get_world_size()
+        return loss


### PR DESCRIPTION
This PR fixes a small issue, in a multi-gpu setting, we were scaling the contrastive losses even when not gathering the samples from other GPUs