### PR TITLE
Use load_sbert for ST models

### DIFF
--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -1167,6 +1167,21 @@ class ColBERT(SentenceTransformer):
             Whether the model has modules.json. Defaults to False.
 
         """
+        # Due to a change in ST, load_sbert is now only call by default for PyLate models directly (because the class name match the config name). However, ST models needs to be called with load_sbert to load the modules, so if the model has modules, we load it with load_sbert even if the class name is not ColBERT (it is a ST model)
+        if has_modules:
+            model, module_kwargs = self._load_sbert_model(
+                model_name_or_path=model_name_or_path,
+                token=token,
+                cache_folder=cache_folder,
+                revision=revision,
+                trust_remote_code=trust_remote_code,
+                local_files_only=local_files_only,
+                model_kwargs=model_kwargs,
+                tokenizer_kwargs=tokenizer_kwargs,
+                config_kwargs=config_kwargs,
+            )
+            return model
+
         logger.warning(
             f"No sentence-transformers model found with name {model_name_or_path}."
         )


### PR DESCRIPTION
ST did a change on how they choose between load_auto and load_sbert.
Back then, if the model has modules, it was using load_sbert and so it was used for both PyLate models and ST models.
A check was added to make sure the class name was the same as the config name (because they have a case where they want to use load_auto even if the model has modules).
I fixed the loading of PyLate model in #151 by setting the config name returned, however the ST models are still loaded with load_auto, which effectively does not load the modules.
This PR adds a check when we enter load_auto to check whether there has modules or not and if so, call load_sbert instead.
This thus is now equivalent to the previous behavior
PyLate models have modules and have the correct config name -> load_sbert
ST models do not have the correct config name -> load_auto but has modules -> load_sbert
Base model do not have the correct config name -> load_auto without modules


See also this [issue](https://github.com/UKPLab/sentence-transformers/issues/3536)

cc @tomaarsen 

It should be noted that the use of Gemma models will be broken again (#161), because right now it worked because we were not loading the dense layers, only adding a PyLate dense layer to the base model. I need to update the code because it only supports loading one dense layer, this only one of the two is casted to a Pylate dense layer, which create a mismatch between both layers
