### PR TITLE
Add residual behavior to dense layers

### DIFF
--- a/pylate/models/Dense.py
+++ b/pylate/models/Dense.py
@@ -70,7 +70,7 @@ class Dense(DenseSentenceTransformer):
         )
         self.use_residual = use_residual
         if use_residual and self.in_features != self.out_features:
-            self.residual = nn.Linear(in_features, self.out_features, bias=False)
+            self.residual = nn.Linear(self.in_features, self.out_features, bias=False)
 
     def forward(self, features: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """Performs linear projection on the token embeddings."""


### PR DESCRIPTION
Hello,
This PR adds the possibility to use a residual connexion for dense layers in PyLate
It was a feature requested by @bclavie which is a co-author of this PR

If the layer is downcasting/upcasting the features, we use a linear layer to project the input to the output dimension for the residual layer (ResNet style)

Example of usage:
```python

import torch
from sentence_transformers.models import Transformer
from pylate import models

base_model = Transformer("jhu-clsp/ettin-encoder-32m")

dense_1 = models.Dense(
    in_features=384,
    out_features=768,
    bias=False,
    activation_function=torch.nn.GELU(),
    use_residual=False,
)
dense_2 = models.Dense(
    in_features=768,
    out_features=768,
    bias=False,
    activation_function=torch.nn.GELU(),
    use_residual=True,
)
dense_3 = models.Dense(
    in_features=768,
    out_features=128,
    bias=False,
    activation_function=torch.nn.Identity(),
    use_residual=False,
)

model = models.ColBERT(
    modules=[base_model, dense_1, dense_2, dense_3],
    document_length=300,
    query_length=32,
)
````