### PR TITLE
Bump fast-plaid version 1.2.5, Torch 2.9.0 compatibility

### DIFF
--- a/pylate/indexes/plaid.py
+++ b/pylate/indexes/plaid.py
@@ -90,6 +90,8 @@ class PLAID(Base):
     ...    documents_ids=range(len(documents_embeddings)),
     ...    documents_embeddings=documents_embeddings
     ... )
+    Computing centroids of embeddings.
+    Creating FastPlaid index.
 
     >>> queries_embeddings = model.encode(
     ...     ["search query", "hello world"],

--- a/pylate/retrieve/colbert.py
+++ b/pylate/retrieve/colbert.py
@@ -48,6 +48,8 @@ class ColBERT:
     ...     documents_ids=documents_ids,
     ...     documents_embeddings=documents_embeddings,
     ... )
+    Computing centroids of embeddings.
+    Creating FastPlaid index.
 
     >>> retriever = retrieve.ColBERT(index=index)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "ujson == 5.10.0",
     "ninja == 1.11.1.4",
     "fastkmeans == 0.5.0",
-    "fast-plaid>=1.2.4.260,<=1.2.4.280",
+    "fast-plaid>=1.2.4.260,<=1.2.5.290",
 ]
 keywords = []
 


### PR DESCRIPTION
This MR bumps Fast-Plaid version. New fast-plaid version will reduce GPU VRAM usage #160. It will also accelerate search on large index by pre-loading the set of centroids. It add compatibility with torch 2.9.0. 