### PR TITLE
Bump fast-plaid version 1.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "ujson == 5.10.0",
     "ninja == 1.11.1.4",
     "fastkmeans == 0.5.0",
-    "fast-plaid>=1.2.4.260,<=1.2.5.290",
+    "fast-plaid>=1.2.4.260,<=1.3.0.290",
 ]
 keywords = []
 

--- a/tests/test_plaid.py
+++ b/tests/test_plaid.py
@@ -90,4 +90,5 @@ def test_plaid():
     assert len(matches[0]) == 2
     assert matches[0][0].keys() == {"id", "score"}
 
+    del index
     shutil.rmtree(f"test_indexes_{random_hash}")


### PR DESCRIPTION
This MR update fast-plaid version to 1.3.0 for reduced memory usage and various improvements: 

https://github.com/lightonai/fast-plaid/releases