### PR TITLE
Add tests for 3.13 and 3.14 python

### DIFF
--- a/.github/workflows/plaid-tests.yml
+++ b/.github/workflows/plaid-tests.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [windows-latest, macos-latest]
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.9", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.9", "3.12", "3.13", "3.14"]
         test-target: ["tests", "pylate"]
 
     steps:


### PR DESCRIPTION
Now this can't be run, because voyager in `dev`. Maybe use it only `voyager` group or test it seperatly?