### PR TITLE
Add LateOn Code boilerplates

### DIFF
--- a/examples/train/lateon_code/fine_tuning.py
+++ b/examples/train/lateon_code/fine_tuning.py
@@ -133,7 +133,7 @@ class ColBERTCollatorSampleNeg:
             if prompt:
                 try:
                     inputs = [prompt + row[column] for row in features]
-                except:
+                except KeyError:
                     key = "document" if "document" in features[0][column] else "query"
                     inputs = [prompt + row[column][key] for row in features]
             else:

--- a/examples/train/lateon_code/pre-training.py
+++ b/examples/train/lateon_code/pre-training.py
@@ -165,7 +165,7 @@ def load_train_datasets():
         try:
             dataset = Dataset.load_from_disk(f"{cache_dir}/{split}")
             print(f"Loaded {split}")
-        except:
+        except FileNotFoundError:
             print(f"{split} missing")
 
             dataset = load_dataset(


### PR DESCRIPTION
Hey,
This PR just adds the example of boilerplates used to train LateOn-code models, both pre-training and fine-tuning.
It's a bit messy as we did not merge the evaluator yet and also I should work on upstreaming the multinomial sampler in sentence transformers (cc @tomaarsen) + fix the collators properly, but we need this for the release, so I'll clean up when we get more time, it's not that bad.