### PR TITLE
Add XTR retriever with token-level scoring and imputation

### DIFF
--- a/examples/evaluation/beir_dataset_xtr.py
+++ b/examples/evaluation/beir_dataset_xtr.py
@@ -1,0 +1,225 @@
+"""Evaluation script for BEIR datasets with ColBERT or XTR retrieval."""
+
+from __future__ import annotations
+
+import argparse
+
+from pylate import evaluation, indexes, models, retrieve
+
+if __name__ == "__main__":
+    query_len = {
+        "quora": 32,
+        "climate-fever": 64,
+        "nq": 32,
+        "msmarco": 32,
+        "hotpotqa": 32,
+        "nfcorpus": 32,
+        "scifact": 48,
+        "trec-covid": 48,
+        "fiqa": 32,
+        "arguana": 64,
+        "scidocs": 48,
+        "dbpedia-entity": 32,
+        "webis-touche2020": 32,
+        "fever": 32,
+        "cqadupstack/android": 32,
+        "cqadupstack/english": 32,
+        "cqadupstack/gaming": 32,
+        "cqadupstack/gis": 32,
+        "cqadupstack/mathematica": 32,
+        "cqadupstack/physics": 32,
+        "cqadupstack/programmers": 32,
+        "cqadupstack/stats": 32,
+        "cqadupstack/tex": 32,
+        "cqadupstack/unix": 32,
+        "cqadupstack/webmasters": 32,
+        "cqadupstack/wordpress": 32,
+    }
+
+    parser = argparse.ArgumentParser(
+        description="Evaluate ColBERT or XTR retrieval on BEIR datasets."
+    )
+    parser.add_argument(
+        "--dataset_name",
+        type=str,
+        default="nfcorpus",
+        help="Name of the BEIR dataset (default: nfcorpus)",
+    )
+    parser.add_argument(
+        "--model_name",
+        type=str,
+        default="lightonai/GTE-ModernColBERT-v1",
+        help="HuggingFace model name or path",
+    )
+    parser.add_argument(
+        "--retrieval",
+        type=str,
+        choices=["colbert", "xtr"],
+        default="colbert",
+        help="Retrieval strategy: 'colbert' (full reranking) or 'xtr' (token-level imputation)",
+    )
+    parser.add_argument(
+        "--index",
+        type=str,
+        choices=["plaid", "scann", "voyager"],
+        default=None,
+        help="Index backend. Defaults to 'plaid' for colbert, 'scann' for xtr.",
+    )
+    parser.add_argument(
+        "--k",
+        type=int,
+        default=20,
+        help="Number of documents to retrieve (default: 20)",
+    )
+    parser.add_argument(
+        "--k_token",
+        type=int,
+        default=None,
+        help="Token-level candidates per query token. "
+        "Defaults to 100 for colbert, 10000 for xtr.",
+    )
+    parser.add_argument(
+        "--imputation",
+        type=str,
+        default="min",
+        choices=["min", "zero", "mean", "percentile", "power_law"],
+        help="XTR imputation strategy (default: min). Only used with --retrieval xtr.",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=2000,
+        help="Batch size for document encoding (default: 2000)",
+    )
+    parser.add_argument(
+        "--query_batch_size",
+        type=int,
+        default=32,
+        help="Batch size for query encoding (default: 32)",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default=None,
+        help="Device for retrieval scoring (e.g. 'cpu', 'cuda')",
+    )
+    parser.add_argument(
+        "--document_length",
+        type=int,
+        default=300,
+        help="Document length for the model (default: 300)",
+    )
+    parser.add_argument(
+        "--lowercase",
+        action="store_true",
+        help="Lowercase all documents and queries before encoding.",
+    )
+
+    args = parser.parse_args()
+    dataset_name = args.dataset_name
+    model_name = args.model_name
+
+    # Resolve defaults that depend on retrieval strategy.
+    index_type = args.index or ("plaid" if args.retrieval == "colbert" else "scann")
+    k_token = args.k_token or (100 if args.retrieval == "colbert" else 10_000)
+
+    if args.retrieval == "xtr" and index_type == "plaid":
+        parser.error("XTR retrieval does not support the PLAID index.")
+
+    model = models.ColBERT(
+        model_name_or_path=model_name,
+        document_length=args.document_length,
+        query_length=query_len.get(dataset_name),
+    )
+
+    # Load dataset.
+    if "cqadupstack" in dataset_name:
+        from beir import util
+
+        data_path = util.download_and_unzip(
+            url="https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/cqadupstack.zip",
+            out_dir="./evaluation_datasets/",
+        )
+        documents, queries, qrels = evaluation.load_custom_dataset(
+            f"evaluation_datasets/{dataset_name}",
+            split="test",
+        )
+        index_dataset_name = dataset_name.replace("/", "_")
+    else:
+        documents, queries, qrels = evaluation.load_beir(
+            dataset_name=dataset_name,
+            split="dev" if "msmarco" in dataset_name else "test",
+        )
+        index_dataset_name = dataset_name
+
+    # Optionally lowercase all text.
+    if args.lowercase:
+        for doc in documents:
+            doc["text"] = doc["text"].lower()
+        queries = {qid: text.lower() for qid, text in queries.items()}
+
+    # Build index.
+    index_name = f"{index_dataset_name}_{model_name.split('/')[-1]}_{args.retrieval}"
+    if index_type == "plaid":
+        index = indexes.PLAID(override=True, index_name=index_name)
+    elif index_type == "scann":
+        index = indexes.ScaNN(
+            override=True,
+            index_name=index_name,
+            store_embeddings=False,
+        )
+    else:
+        index = indexes.Voyager(override=True, index_name=index_name)
+
+    # Encode and index documents.
+    documents_embeddings = model.encode(
+        sentences=[document["text"] for document in documents],
+        batch_size=args.batch_size,
+        is_query=False,
+        show_progress_bar=True,
+    )
+
+    index.add_documents(
+        documents_ids=[document["id"] for document in documents],
+        documents_embeddings=documents_embeddings,
+    )
+
+    # Encode queries.
+    queries_embeddings = model.encode(
+        sentences=list(queries.values()),
+        is_query=True,
+        show_progress_bar=True,
+        batch_size=args.query_batch_size,
+    )
+
+    # Retrieve.
+    retrieve_kwargs = dict(
+        queries_embeddings=queries_embeddings,
+        k=args.k,
+        k_token=k_token,
+    )
+    if args.device is not None:
+        retrieve_kwargs["device"] = args.device
+
+    if args.retrieval == "colbert":
+        retriever = retrieve.ColBERT(index=index)
+        scores = retriever.retrieve(**retrieve_kwargs)
+    else:
+        retriever = retrieve.XTR(index=index, verbose=True)
+        retrieve_kwargs["imputation"] = args.imputation
+        scores = retriever.retrieve(**retrieve_kwargs)
+
+    # Remove self-matches (needed for e.g. FiQA).
+    for (query_id, query), query_scores in zip(queries.items(), scores):
+        for score in query_scores:
+            if score["id"] == query_id:
+                query_scores.remove(score)
+
+    evaluation_scores = evaluation.evaluate(
+        scores=scores,
+        qrels=qrels,
+        queries=list(queries.keys()),
+        metrics=["map", "ndcg@10", "ndcg@100", "recall@10", "recall@100"],
+    )
+
+    print(evaluation_scores)

--- a/pylate/indexes/__init__.py
+++ b/pylate/indexes/__init__.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from .base import Base
 from .plaid import PLAID
 from .scann import ScaNN
 from .voyager import Voyager
 
-__all__ = ["Voyager", "PLAID", "ScaNN"]
+__all__ = ["Base", "Voyager", "PLAID", "ScaNN"]

--- a/pylate/rank/__init__.py
+++ b/pylate/rank/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from .rank import RerankResult, rerank
+from .rank import RerankResult, rerank, score_xtr
 
-__all__ = ["rerank", "RerankResult"]
+__all__ = ["rerank", "score_xtr", "RerankResult"]

--- a/pylate/rank/rank.py
+++ b/pylate/rank/rank.py
@@ -155,3 +155,346 @@ def rerank(
         )
 
     return results
+
+
+def _compute_imputation_scores(
+    query_scores: list[list[float]],
+    imputation: str,
+    percentile: float,
+    power_law_multiplier: float,
+    device: str,
+    is_rectangular: bool | None = None,
+) -> torch.Tensor:
+    """Compute imputation scores for each query token.
+
+    Parameters
+    ----------
+    query_scores
+        List of length q_tok, where each element is a list of scores.
+    imputation
+        Imputation strategy: "min", "zero", "mean", "percentile", or "power_law".
+    percentile
+        Percentile value (0-100) for percentile imputation.
+    power_law_multiplier
+        Multiplier for k' when extrapolating power-law (e.g., 100 means extrapolate to rank 100*k').
+    device
+        Device for tensor computation.
+    is_rectangular
+        If provided, skip the per-row length check and use the given value
+        to choose the rectangular fast-path (True) or ragged fallback (False).
+
+    Returns
+    -------
+    torch.Tensor
+        Imputation score for each query token, shape (q_tok,).
+    """
+    q_tok = len(query_scores)
+    allowed_imputations = {"min", "zero", "mean", "percentile", "power_law"}
+    if imputation not in allowed_imputations:
+        raise ValueError(
+            f"Unknown imputation strategy: {imputation}. "
+            f"Expected one of: 'min', 'zero', 'mean', 'percentile', 'power_law'."
+        )
+
+    if imputation == "zero":
+        return torch.zeros(q_tok, dtype=torch.float32, device=device)
+
+    def _to_tensor(values: np.ndarray | list[float]) -> torch.Tensor:
+        return torch.as_tensor(values, dtype=torch.float32, device=device)
+
+    def _power_law_row(scores: np.ndarray | list[float]) -> float:
+        """Compute per-token power-law imputation score with robust fallbacks."""
+        if len(scores) == 0:
+            return 0.0
+
+        scores_arr = np.asarray(scores, dtype=np.float64)
+        min_score = float(scores_arr.min())
+        if len(scores_arr) < 2:
+            return min_score
+
+        # Rank 1 corresponds to the highest score.
+        sorted_scores = np.sort(scores_arr)[::-1]
+        valid_scores = sorted_scores[sorted_scores > 0]
+        if len(valid_scores) < 2:
+            return min_score
+
+        ranks = np.arange(1, len(valid_scores) + 1, dtype=np.float64)
+        try:
+            neg_b, log_a = np.polyfit(np.log(ranks), np.log(valid_scores), 1)
+            extrapolate_rank = power_law_multiplier * len(sorted_scores)
+            log_imputed = log_a + neg_b * np.log(extrapolate_rank)
+            imputed = float(np.exp(log_imputed))
+            # Keep imputed value in a stable range.
+            return max(0.0, min(imputed, min_score))
+        except (np.linalg.LinAlgError, ValueError):
+            return min_score
+
+    # Rectangular fast path (common for fixed-k retrieval outputs).
+    if is_rectangular is None:
+        is_rectangular = q_tok > 0 and all(
+            len(scores) == len(query_scores[0]) for scores in query_scores
+        )
+    if is_rectangular:
+        # Avoid list-of-ndarray -> tensor conversion warnings by materializing
+        # a contiguous ndarray once.
+        scores_np = np.asarray(query_scores, dtype=np.float32)
+        if scores_np.shape[1] == 0:
+            return torch.zeros(q_tok, dtype=torch.float32, device=device)
+
+        if imputation == "min":
+            return _to_tensor(scores_np.min(axis=1))
+        if imputation == "mean":
+            return _to_tensor(scores_np.mean(axis=1))
+        if imputation == "percentile":
+            return _to_tensor(np.percentile(scores_np, percentile, axis=1))
+        return _to_tensor([_power_law_row(row) for row in scores_np])
+
+    # Ragged fallback.
+    if imputation == "min":
+        return _to_tensor(
+            [min(scores) if len(scores) > 0 else 0.0 for scores in query_scores]
+        )
+    if imputation == "mean":
+        return _to_tensor(
+            [
+                sum(scores) / len(scores) if len(scores) > 0 else 0.0
+                for scores in query_scores
+            ]
+        )
+    if imputation == "percentile":
+        return _to_tensor(
+            [
+                float(np.percentile(scores, percentile)) if len(scores) > 0 else 0.0
+                for scores in query_scores
+            ]
+        )
+    return _to_tensor([_power_law_row(scores) for scores in query_scores])
+
+
+def score_xtr(
+    query_doc_ids: list[list[str | int]],
+    query_scores: list[list[float]],
+    k: int,
+    device: str = "cpu",
+    imputation: str = "min",
+    percentile: float = 10.0,
+    power_law_multiplier: float = 100.0,
+) -> list[RerankResult]:
+    """Score documents using XTR (eXact Token Retrieval) scoring.
+
+    XTR scoring differs from ColBERT in that it doesn't do full reranking.
+    Instead, it only scores documents using initially retrieved tokens, and
+    imputes missing token scores based on the chosen imputation strategy.
+
+    Parameters
+    ----------
+    query_doc_ids
+        List of length q_tok, where each element is a list of k_token document IDs
+        retrieved for that query token. Document IDs can be strings or integers.
+    query_scores
+        List of length q_tok, where each element is a list of k_token scores
+        corresponding to the retrieved document IDs.
+    k
+        Number of top documents to return.
+    device
+        Device to use for computation ('cpu', 'cuda', etc.).
+    imputation
+        Strategy for imputing missing scores. Options:
+        - "min": Use minimum retrieved score per query token (default, original XTR).
+        - "zero": Impute with zero (missing tokens contribute nothing).
+        - "mean": Use mean of retrieved scores per query token.
+        - "percentile": Use specified percentile of retrieved scores.
+        - "power_law": Fit power-law curve to retrieved scores and extrapolate
+          to rank (power_law_multiplier * k') as per Lee et al., 2023.
+    percentile
+        Percentile value (0-100) for percentile imputation. Default is 10.0.
+    power_law_multiplier
+        Multiplier for k' when extrapolating power-law. Default is 100.0 (extrapolate
+        to rank 100*k' as in the original XTR paper).
+
+    Returns
+    -------
+    list[RerankResult]
+        Top-k documents sorted by score (descending).
+
+    Notes
+    -----
+    The XTR scoring algorithm:
+    1. For each document, sum scores across all query tokens
+    2. If a document's token wasn't retrieved for a query token, use the
+       imputed score based on the chosen strategy
+    3. If multiple tokens from the same document were retrieved for a query token,
+       use the maximum score
+
+    Examples
+    --------
+    >>> from pylate.rank import score_xtr
+    >>> query_doc_ids = [
+    ...     ["doc1", "doc2", "doc3"],  # Retrieved for query token 0
+    ...     ["doc2", "doc3", "doc4"],  # Retrieved for query token 1
+    ... ]
+    >>> query_scores = [
+    ...     [0.9, 0.7, 0.5],  # Scores for query token 0
+    ...     [0.8, 0.6, 0.4],  # Scores for query token 1
+    ... ]
+    >>> results = score_xtr(query_doc_ids, query_scores, k=3)
+    >>> assert len(results) == 3
+    >>> assert results[0]["id"] == "doc2"  # Has high scores for both tokens
+
+    >>> # Using zero imputation
+    >>> results_zero = score_xtr(query_doc_ids, query_scores, k=3, imputation="zero")
+
+    >>> # Using power-law imputation
+    >>> results_pl = score_xtr(query_doc_ids, query_scores, k=3, imputation="power_law")
+
+    """
+    if len(query_doc_ids) != len(query_scores):
+        raise ValueError(
+            "query_doc_ids and query_scores must have the same number of query tokens. "
+            f"Got {len(query_doc_ids)} and {len(query_scores)}."
+        )
+
+    q_tok = len(query_doc_ids)
+
+    if q_tok == 0:
+        return []
+
+    # Validate lengths and compute total size for pre-allocation.
+    sizes = []
+    for q_idx, (token_docs, token_scores) in enumerate(
+        zip(query_doc_ids, query_scores)
+    ):
+        if len(token_docs) != len(token_scores):
+            raise ValueError(
+                "Each query token must have matching document IDs and scores lengths. "
+                f"Token {q_idx} has {len(token_docs)} IDs and {len(token_scores)} scores."
+            )
+        sizes.append(len(token_docs))
+
+    total = sum(sizes)
+    if total == 0:
+        return []
+
+    # Pre-allocate flat numpy arrays and fill via slice assignment (avoids
+    # repeated list resizing and gives faster torch.from_numpy conversion).
+    all_scores_np = np.empty(total, dtype=np.float32)
+    q_tok_indices_np = np.empty(total, dtype=np.int64)
+
+    # Determine doc-ID type from the first non-empty token list.
+    doc_id_is_string = isinstance(
+        query_doc_ids[0][0]
+        if sizes[0] > 0
+        else query_doc_ids[next(i for i, s in enumerate(sizes) if s > 0)][0],
+        str,
+    )
+
+    if doc_id_is_string:
+        # Build string→int mapping while filling the flat arrays in one pass.
+        # Preserves insertion order for deterministic tie handling.
+        doc_id_to_int: dict[str, int] = {}
+        all_doc_ids_np = np.empty(total, dtype=np.int64)
+        offset = 0
+        for q_idx, (token_docs, token_scores) in enumerate(
+            zip(query_doc_ids, query_scores)
+        ):
+            n = sizes[q_idx]
+            if n == 0:
+                continue
+            for i, did in enumerate(token_docs):
+                if did not in doc_id_to_int:
+                    doc_id_to_int[did] = len(doc_id_to_int)
+                all_doc_ids_np[offset + i] = doc_id_to_int[did]
+            all_scores_np[offset : offset + n] = token_scores
+            q_tok_indices_np[offset : offset + n] = q_idx
+            offset += n
+
+        # Invert the mapping for final output.
+        unique_doc_id_strings = list(doc_id_to_int.keys())
+        num_docs = len(unique_doc_id_strings)
+
+        # The integer IDs are already in [0, num_docs), so inverse_indices
+        # IS the doc-id tensor — no torch.unique() needed.
+        inverse_indices = torch.from_numpy(all_doc_ids_np).to(device=device)
+    else:
+        # Integer doc IDs — need torch.unique to discover the unique set.
+        all_doc_ids_list: list[int] = []
+        offset = 0
+        for q_idx, (token_docs, token_scores) in enumerate(
+            zip(query_doc_ids, query_scores)
+        ):
+            n = sizes[q_idx]
+            if n == 0:
+                continue
+            all_doc_ids_list.extend(token_docs)
+            all_scores_np[offset : offset + n] = token_scores
+            q_tok_indices_np[offset : offset + n] = q_idx
+            offset += n
+
+        all_doc_ids_t = torch.tensor(all_doc_ids_list, dtype=torch.long, device=device)
+        unique_doc_ids, inverse_indices = torch.unique(
+            all_doc_ids_t, return_inverse=True, sorted=False
+        )
+        num_docs = len(unique_doc_ids)
+
+    all_scores_t = torch.from_numpy(all_scores_np).to(device=device)
+    q_tok_indices_t = torch.from_numpy(q_tok_indices_np).to(device=device)
+
+    # Compute imputation scores based on chosen strategy.
+    # We already know whether all token lists are the same length from `sizes`.
+    rect_hint = len(set(sizes)) <= 1
+    imputation_scores = _compute_imputation_scores(
+        query_scores=query_scores,
+        imputation=imputation,
+        percentile=percentile,
+        power_law_multiplier=power_law_multiplier,
+        device=device,
+        is_rectangular=rect_hint,
+    )  # Shape: (q_tok,)
+
+    # Step 1: Compute max actual score per (doc, query_token) pair
+    # Initialize with -inf so we can detect which pairs have no retrieved score
+    NEG_INF = float("-inf")
+    doc_scores = torch.full(
+        (num_docs, q_tok), NEG_INF, dtype=torch.float32, device=device
+    )
+
+    # Flatten for 1D scatter, then reshape
+    doc_scores_flat = doc_scores.reshape(-1)
+    flat_indices = inverse_indices * q_tok + q_tok_indices_t
+
+    # Use scatter_reduce with reduce='amax' to keep max score when multiple tokens
+    # from the same document are retrieved for a single query token
+    doc_scores_flat.scatter_reduce_(
+        0, flat_indices, all_scores_t, reduce="amax", include_self=False
+    )
+    doc_scores = doc_scores_flat.reshape(num_docs, q_tok)
+
+    # Step 2: Replace -inf (no retrieved score) with imputation scores
+    missing_mask = doc_scores == NEG_INF
+    doc_scores = torch.where(missing_mask, imputation_scores, doc_scores)
+
+    # Sum across query tokens to get final document scores
+    final_scores = doc_scores.sum(dim=1)
+
+    # Get top k documents
+    top_k_scores, top_k_indices = torch.topk(
+        final_scores, k=min(k, num_docs), largest=True
+    )
+
+    # Bulk-convert to Python lists (single C-to-Python transition).
+    top_k_scores_list = top_k_scores.tolist()
+
+    if doc_id_is_string:
+        # top_k_indices index into [0, num_docs) which maps directly to
+        # unique_doc_id_strings -- no intermediate tensor lookup needed.
+        top_k_idx_list = top_k_indices.tolist()
+        return [
+            RerankResult(id=unique_doc_id_strings[idx], score=score)
+            for idx, score in zip(top_k_idx_list, top_k_scores_list)
+        ]
+
+    top_k_doc_ids_list = unique_doc_ids[top_k_indices].tolist()
+    return [
+        RerankResult(id=doc_id, score=score)
+        for doc_id, score in zip(top_k_doc_ids_list, top_k_scores_list)
+    ]

--- a/pylate/rank/rank.py
+++ b/pylate/rank/rank.py
@@ -220,9 +220,9 @@ def _compute_imputation_scores(
 
         ranks = np.arange(1, len(valid_scores) + 1, dtype=np.float64)
         try:
-            neg_b, log_a = np.polyfit(np.log(ranks), np.log(valid_scores), 1)
+            slope, log_a = np.polyfit(np.log(ranks), np.log(valid_scores), 1)
             extrapolate_rank = power_law_multiplier * len(sorted_scores)
-            log_imputed = log_a + neg_b * np.log(extrapolate_rank)
+            log_imputed = log_a + slope * np.log(extrapolate_rank)
             imputed = float(np.exp(log_imputed))
             # Keep imputed value in a stable range.
             return max(0.0, min(imputed, min_score))
@@ -470,7 +470,7 @@ def score_xtr(
     doc_scores = doc_scores_flat.reshape(num_docs, q_tok)
 
     # Step 2: Replace -inf (no retrieved score) with imputation scores
-    missing_mask = doc_scores == NEG_INF
+    missing_mask = torch.isinf(doc_scores) & (doc_scores < 0)
     doc_scores = torch.where(missing_mask, imputation_scores, doc_scores)
 
     # Sum across query tokens to get final document scores

--- a/pylate/retrieve/__init__.py
+++ b/pylate/retrieve/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
 from .colbert import ColBERT
+from .xtr import XTR
 
-__all__ = ["ColBERT"]
+__all__ = ["ColBERT", "XTR"]

--- a/pylate/retrieve/colbert.py
+++ b/pylate/retrieve/colbert.py
@@ -5,8 +5,7 @@ import logging
 import numpy as np
 import torch
 
-from ..indexes.base import Base
-from ..indexes.plaid import PLAID
+from ..indexes import PLAID, Base
 from ..rank import RerankResult, rerank
 from ..utils import iter_batch
 

--- a/pylate/retrieve/xtr.py
+++ b/pylate/retrieve/xtr.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import logging
+import time
+
+import numpy as np
+import torch
+from tqdm.auto import tqdm
+
+from .. import indexes
+from ..rank import RerankResult, score_xtr
+from ..utils import iter_batch
+
+logger = logging.getLogger(__name__)
+
+
+class XTR:
+    """XTR retriever.
+
+    Parameters
+    ----------
+    index:
+        The index to use for retrieval.
+
+    Examples
+    --------
+    >>> from pylate import indexes, models, retrieve
+
+    >>> model = models.ColBERT(
+    ...     model_name_or_path="sentence-transformers/all-MiniLM-L6-v2",
+    ...     device="cpu",
+    ... )
+
+    >>> documents_ids = [f"document_id_{i}" for i in range(20)]
+    >>> documents = [f"This is the content of document {i}." for i in range(20)]
+
+    >>> documents_embeddings = model.encode(
+    ...     sentences=documents,
+    ...     batch_size=1,
+    ...     is_query=False,
+    ... )
+
+    >>> index = indexes.ScaNN(
+    ...     override=True,
+    ...     name="xtr_scann",
+    ...     store_embeddings=False,
+    ... )
+
+    >>> retriever = retrieve.XTR(index=index)
+
+    >>> queries_embeddings = model.encode(
+    ...     ["fruits are healthy.", "fruits are good for health."],
+    ...     batch_size=1,
+    ...     is_query=True,
+    ... )
+
+    >>> results = retriever.retrieve(
+    ...     queries_embeddings=queries_embeddings,
+    ...     k=2,
+    ...     device="cpu",
+    ... )
+
+    >>> assert isinstance(results, list)
+    >>> assert len(results) == 2
+
+    >>> queries_embeddings = model.encode(
+    ...     "fruits are healthy.",
+    ...     batch_size=1,
+    ...     is_query=True,
+    ... )
+
+    >>> results = retriever.retrieve(
+    ...     queries_embeddings=queries_embeddings,
+    ...     k=2,
+    ...     device="cpu",
+    ... )
+
+    >>> assert isinstance(results, list)
+    >>> assert len(results) == 1
+
+    """
+
+    def __init__(self, index: indexes.Base, verbose: bool = False) -> None:
+        if isinstance(index, indexes.PLAID):
+            raise ValueError(
+                "XTR retriever requires token-level index outputs "
+                "(`documents_ids` and `distances`). PLAID-style end-to-end indices "
+                "are not supported."
+            )
+        self.index = index
+        self.verbose = verbose
+
+    def retrieve(
+        self,
+        queries_embeddings: list[list | np.ndarray | torch.Tensor],
+        k: int = 10,
+        k_token: int = 10_000,
+        device: str = "cpu",
+        batch_size: int = 1,
+        subset: list[list[str]] | list[str] | None = None,
+        imputation: str = "min",
+        percentile: float = 10.0,
+        power_law_multiplier: float = 100.0,
+        return_timing: bool = False,
+    ) -> list[list[RerankResult]] | tuple[list[list[RerankResult]], dict[str, float]]:
+        """Retrieve documents using XTR (eXact Token Retrieval) scoring.
+
+        XTR differs from standard ColBERT retrieval in that it doesn't do a full
+        reranking step. Instead, it only scores documents using initially retrieved
+        tokens and imputes missing scores based on the chosen imputation strategy.
+
+        Parameters
+        ----------
+        queries_embeddings
+            The queries embeddings.
+        k
+            The number of documents to retrieve.
+        k_token
+            The number of documents to retrieve from the index per query token.
+        device
+            The device to use for XTR scoring computation. Defaults to 'cpu'.
+        batch_size
+            The batch size to use for retrieval.
+        subset
+            Optional subset of document IDs to restrict search to.
+            Only supported with certain index types.
+        imputation
+            Strategy for imputing missing scores. Options:
+            - "min": Use minimum retrieved score per query token (default, original XTR).
+            - "zero": Impute with zero (missing tokens contribute nothing).
+            - "mean": Use mean of retrieved scores per query token.
+            - "percentile": Use specified percentile of retrieved scores.
+            - "power_law": Fit power-law curve to retrieved scores and extrapolate.
+        percentile
+            Percentile value (0-100) for percentile imputation. Default is 10.0.
+        power_law_multiplier
+            Multiplier for k' when extrapolating power-law. Default is 100.0.
+        return_timing
+            If True, return tuple of (results, timing_dict) with per-stage timing data.
+
+        Returns
+        -------
+        list[list[RerankResult]]
+            List of results for each query, where each result contains
+            document IDs and scores sorted by score (descending).
+
+        """
+        if subset is not None:
+            raise NotImplementedError(
+                "Subset filtering is not implemented for XTR retrieval yet."
+            )
+
+        total_retrieval_time = 0.0
+        total_scoring_time = 0.0
+        num_batches = 0
+
+        results = []
+
+        progress_bar = tqdm(
+            iter_batch(queries_embeddings, batch_size=batch_size, tqdm_bar=False),
+            desc="Retrieving documents (XTR)",
+            disable=not self.verbose,
+            total=len(queries_embeddings) // batch_size,
+        )
+        for batch_queries_embeddings in progress_bar:
+            # Initial retrieval from index
+            retrieval_start = time.time()
+            index_results = self.index(batch_queries_embeddings, k=k_token)
+            if not isinstance(index_results, dict):
+                raise ValueError(
+                    "XTR retriever expects token-level dict outputs from the index "
+                    "with `documents_ids` and `distances`."
+                )
+            if "documents_ids" not in index_results or "distances" not in index_results:
+                raise ValueError(
+                    "XTR retriever received invalid index output. Expected keys: "
+                    "`documents_ids` and `distances`."
+                )
+            token_doc_ids = index_results["documents_ids"]
+            token_distances = index_results["distances"]
+            if len(token_doc_ids) != len(token_distances):
+                raise ValueError(
+                    "XTR retriever received invalid index output. "
+                    "`documents_ids` and `distances` must have the same batch length."
+                )
+            retrieval_time = time.time() - retrieval_start
+            total_retrieval_time += retrieval_time
+
+            # XTR scoring
+            scoring_start = time.time()
+            for query_doc_ids, query_scores in zip(token_doc_ids, token_distances):
+                # Use the score_xtr helper function to compute XTR scores
+                query_results = score_xtr(
+                    query_doc_ids=query_doc_ids,
+                    query_scores=query_scores,
+                    k=k,
+                    device=device,
+                    imputation=imputation,
+                    percentile=percentile,
+                    power_law_multiplier=power_law_multiplier,
+                )
+
+                results.append(query_results)
+            scoring_time = time.time() - scoring_start
+            total_scoring_time += scoring_time
+            num_batches += 1
+
+            batch_count = max(1, len(batch_queries_embeddings))
+            per_query_retrieval = retrieval_time / batch_count  # seconds per query
+            per_query_scoring = scoring_time / batch_count  # seconds per query
+            per_query_total = (
+                per_query_retrieval + per_query_scoring
+            )  # seconds per query
+            if not progress_bar.disable:
+                progress_bar.set_postfix(
+                    {
+                        "per_query_retrieval (s)": f"{per_query_retrieval:.3f} ({per_query_retrieval / (per_query_total + 1e-12) * 100:.1f}%)",
+                        "per_query_scoring (s)": f"{per_query_scoring:.3f} ({per_query_scoring / (per_query_total + 1e-12) * 100:.1f}%)",
+                        "per_query_total (s)": f"{per_query_total:.3f}",
+                    }
+                )
+
+        total_time = total_retrieval_time + total_scoring_time
+        # Log timing breakdown if verbose
+        if self.verbose:
+            denom = max(total_time, 1e-12)
+            logger.info(
+                f"XTR retrieval timing breakdown (total: {total_time:.4f}s, {num_batches} batches of {batch_size} queries):"
+            )
+            logger.info(
+                f"  - Index retrieval: {total_retrieval_time:.4f}s ({total_retrieval_time / denom * 100:.1f}%)"
+            )
+            logger.info(
+                f"  - XTR scoring:      {total_scoring_time:.4f}s ({total_scoring_time / denom * 100:.1f}%)"
+            )
+            if len(queries_embeddings) > 0:
+                logger.info(
+                    f"  - Per query:        {total_time / len(queries_embeddings) * 1000:.2f}ms"
+                )
+
+        if return_timing:
+            num_queries = len(queries_embeddings)
+            timing_dict = {
+                "token_retrieval": total_retrieval_time / num_queries
+                if num_queries > 0
+                else 0.0,
+                "score_imputation": total_scoring_time / num_queries
+                if num_queries > 0
+                else 0.0,
+                "total_time": total_time / num_queries if num_queries > 0 else 0.0,
+            }
+            return results, timing_dict
+        return results

--- a/pylate/retrieve/xtr.py
+++ b/pylate/retrieve/xtr.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import time
 
 import numpy as np
@@ -44,6 +45,12 @@ class XTR:
     ...     override=True,
     ...     name="xtr_scann",
     ...     store_embeddings=False,
+    ... )
+
+    >>> index = index.add_documents(
+    ...     documents_ids=documents_ids,
+    ...     documents_embeddings=documents_embeddings,
+    ...     batch_size=1,
     ... )
 
     >>> retriever = retrieve.XTR(index=index)
@@ -160,7 +167,7 @@ class XTR:
             iter_batch(queries_embeddings, batch_size=batch_size, tqdm_bar=False),
             desc="Retrieving documents (XTR)",
             disable=not self.verbose,
-            total=len(queries_embeddings) // batch_size,
+            total=math.ceil(len(queries_embeddings) / batch_size),
         )
         for batch_queries_embeddings in progress_bar:
             # Initial retrieval from index

--- a/tests/test_imputation.py
+++ b/tests/test_imputation.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from pylate.rank.rank import _compute_imputation_scores
+
+
+class TestComputeImputationScores:
+    """Unit tests for _compute_imputation_scores()."""
+
+    def test_zero_imputation(self) -> None:
+        scores = [[0.9, 0.7], [0.8, 0.6]]
+        result = _compute_imputation_scores(scores, "zero", 10.0, 100.0, "cpu")
+        assert torch.allclose(result, torch.zeros(2))
+
+    def test_min_imputation_rectangular(self) -> None:
+        scores = [[0.9, 0.7, 0.5], [0.8, 0.6, 0.4]]
+        result = _compute_imputation_scores(scores, "min", 10.0, 100.0, "cpu")
+        assert result[0] == pytest.approx(0.5, abs=1e-5)
+        assert result[1] == pytest.approx(0.4, abs=1e-5)
+
+    def test_mean_imputation_rectangular(self) -> None:
+        scores = [[0.9, 0.3], [0.8, 0.4]]
+        result = _compute_imputation_scores(scores, "mean", 10.0, 100.0, "cpu")
+        assert result[0] == pytest.approx(0.6, abs=1e-5)
+        assert result[1] == pytest.approx(0.6, abs=1e-5)
+
+    def test_percentile_imputation_rectangular(self) -> None:
+        scores = [[0.1, 0.5, 0.9], [0.2, 0.6, 1.0]]
+        result = _compute_imputation_scores(scores, "percentile", 50.0, 100.0, "cpu")
+        assert result[0] == pytest.approx(0.5, abs=1e-5)
+        assert result[1] == pytest.approx(0.6, abs=1e-5)
+
+    def test_power_law_imputation_executes(self) -> None:
+        scores = [[0.9, 0.7, 0.5, 0.3], [0.8, 0.6, 0.4, 0.2]]
+        result = _compute_imputation_scores(scores, "power_law", 10.0, 100.0, "cpu")
+        assert result.shape == (2,)
+        # Power-law imputed value should be non-negative and <= min of row.
+        assert all(0.0 <= result[i].item() <= min(scores[i]) for i in range(2))
+
+    def test_power_law_single_score_falls_back_to_min(self) -> None:
+        scores = [[0.5]]
+        result = _compute_imputation_scores(scores, "power_law", 10.0, 100.0, "cpu")
+        assert result[0] == pytest.approx(0.5, abs=1e-5)
+
+    def test_power_law_all_negative_falls_back_to_min(self) -> None:
+        scores = [[-0.3, -0.5, -0.7]]
+        result = _compute_imputation_scores(scores, "power_law", 10.0, 100.0, "cpu")
+        # All scores <= 0, so valid_scores is empty → fallback to min.
+        assert result[0] == pytest.approx(-0.7, abs=1e-5)
+
+    def test_unknown_imputation_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown imputation strategy"):
+            _compute_imputation_scores([[0.5]], "bogus", 10.0, 100.0, "cpu")
+
+    # --- Ragged (non-rectangular) paths ---
+
+    def test_min_imputation_ragged(self) -> None:
+        scores = [[0.9, 0.7], [0.5]]
+        result = _compute_imputation_scores(
+            scores, "min", 10.0, 100.0, "cpu", is_rectangular=False
+        )
+        assert result[0] == pytest.approx(0.7, abs=1e-5)
+        assert result[1] == pytest.approx(0.5, abs=1e-5)
+
+    def test_mean_imputation_ragged(self) -> None:
+        scores = [[0.9, 0.3], [0.4]]
+        result = _compute_imputation_scores(
+            scores, "mean", 10.0, 100.0, "cpu", is_rectangular=False
+        )
+        assert result[0] == pytest.approx(0.6, abs=1e-5)
+        assert result[1] == pytest.approx(0.4, abs=1e-5)
+
+    def test_percentile_imputation_ragged(self) -> None:
+        scores = [[0.1, 0.5, 0.9], [0.2]]
+        result = _compute_imputation_scores(
+            scores, "percentile", 50.0, 100.0, "cpu", is_rectangular=False
+        )
+        assert result[0] == pytest.approx(0.5, abs=1e-5)
+        assert result[1] == pytest.approx(0.2, abs=1e-5)
+
+    def test_power_law_ragged(self) -> None:
+        scores = [[0.9, 0.7, 0.5, 0.3], [0.8]]
+        result = _compute_imputation_scores(
+            scores, "power_law", 10.0, 100.0, "cpu", is_rectangular=False
+        )
+        assert result.shape == (2,)
+        assert 0.0 <= result[0].item() <= min(scores[0])
+        # Single element → fallback to min.
+        assert result[1] == pytest.approx(0.8, abs=1e-5)
+
+    # --- Empty / degenerate inputs ---
+
+    def test_empty_rows_ragged(self) -> None:
+        scores = [[], [0.5, 0.3]]
+        result = _compute_imputation_scores(
+            scores, "min", 10.0, 100.0, "cpu", is_rectangular=False
+        )
+        assert result[0] == pytest.approx(0.0, abs=1e-5)
+        assert result[1] == pytest.approx(0.3, abs=1e-5)
+
+    def test_all_empty_rectangular(self) -> None:
+        scores = [[], []]
+        result = _compute_imputation_scores(
+            scores, "min", 10.0, 100.0, "cpu", is_rectangular=True
+        )
+        assert torch.allclose(result, torch.zeros(2))
+
+    def test_is_rectangular_auto_detection(self) -> None:
+        # Same-length rows should be auto-detected as rectangular.
+        scores = [[0.9, 0.7], [0.8, 0.6]]
+        rect = _compute_imputation_scores(scores, "min", 10.0, 100.0, "cpu")
+        forced = _compute_imputation_scores(
+            scores, "min", 10.0, 100.0, "cpu", is_rectangular=True
+        )
+        assert torch.allclose(rect, forced)
+
+    def test_output_shape_matches_num_tokens(self) -> None:
+        scores = [[0.5], [0.3], [0.1]]
+        for imp in ["min", "zero", "mean", "percentile", "power_law"]:
+            result = _compute_imputation_scores(scores, imp, 10.0, 100.0, "cpu")
+            assert result.shape == (3,), f"Failed for imputation={imp}"

--- a/tests/test_xtr_retriever.py
+++ b/tests/test_xtr_retriever.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from pylate import indexes, retrieve
+
+pytest.importorskip("scann")
+
+
+def _build_tiny_scann_index() -> indexes.ScaNN:
+    index = indexes.ScaNN(
+        name="xtr_test_index",
+        store_embeddings=False,
+        override=True,
+        verbose=False,
+    )
+    # Keep enough vectors for ScaNN AH training on tiny tests.
+    docs = [
+        torch.randn(10, 8, dtype=torch.float32),
+        torch.randn(8, 8, dtype=torch.float32),
+        torch.randn(9, 8, dtype=torch.float32),
+    ]
+    index.add_documents(
+        documents_ids=["d1", "d2", "d3"],
+        documents_embeddings=docs,
+        batch_size=3,
+    )
+    return index
+
+
+def test_xtr_is_exported() -> None:
+    assert hasattr(retrieve, "XTR")
+
+
+def test_xtr_constructor_rejects_plaid_style_indices() -> None:
+    # Use __new__ to avoid expensive backend initialization while still testing
+    # the isinstance check against PLAID-style indices.
+    plaid_like = indexes.PLAID.__new__(indexes.PLAID)
+    with pytest.raises(ValueError, match="PLAID-style end-to-end indices"):
+        retrieve.XTR(index=plaid_like)
+
+
+def test_xtr_retrieve_subset_not_supported() -> None:
+    retriever = retrieve.XTR(index=_build_tiny_scann_index())
+    with pytest.raises(
+        NotImplementedError, match="Subset filtering is not implemented"
+    ):
+        retriever.retrieve(
+            queries_embeddings=[torch.randn(2, 8, dtype=torch.float32)],
+            k=2,
+            k_token=5,
+            subset=["d1"],
+        )
+
+
+def test_xtr_retrieve_e2e_with_scann_and_timing() -> None:
+    retriever = retrieve.XTR(index=_build_tiny_scann_index(), verbose=False)
+    queries = [
+        torch.randn(3, 8, dtype=torch.float32),
+        torch.randn(2, 8, dtype=torch.float32),
+    ]
+
+    # Validate the full retrieval path and timing output together.
+    results, timing = retriever.retrieve(
+        queries_embeddings=queries,
+        k=2,
+        k_token=5,
+        return_timing=True,
+    )
+
+    # E2E shape check: one result list per query.
+    assert len(results) == 2
+
+    # Content check: each query returns at most k documents.
+    assert all(len(r) <= 2 for r in results)
+
+    # Schema check: every item is a dict with id/score fields.
+    for query_results in results:
+        for item in query_results:
+            assert isinstance(item, dict)
+            assert "id" in item
+            assert "score" in item
+
+    # Timing check: expected keys and float values are returned when requested.
+    expected_keys = {"token_retrieval", "score_imputation", "total_time"}
+    assert set(timing.keys()) == expected_keys
+    assert all(isinstance(timing[k], float) for k in expected_keys)

--- a/tests/test_xtr_retriever.py
+++ b/tests/test_xtr_retriever.py
@@ -10,7 +10,7 @@ pytest.importorskip("scann")
 
 def _build_tiny_scann_index() -> indexes.ScaNN:
     index = indexes.ScaNN(
-        name="xtr_test_index",
+        index_name="xtr_test_index",
         store_embeddings=False,
         override=True,
         verbose=False,

--- a/tests/test_xtr_scoring.py
+++ b/tests/test_xtr_scoring.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from pylate.rank import score_xtr
+
+
+class TestScoreXTR:
+    """Comprehensive unit tests for score_xtr()."""
+
+    def test_basic_scoring_no_overlap(self) -> None:
+        query_doc_ids = [
+            ["doc1", "doc2", "doc3"],
+            ["doc4", "doc5", "doc6"],
+        ]
+        query_scores = [
+            [0.9, 0.7, 0.5],
+            [0.8, 0.6, 0.4],
+        ]
+
+        results = score_xtr(query_doc_ids, query_scores, k=6)
+        assert len(results) == 6
+        assert results[0]["score"] == pytest.approx(1.3, abs=1e-5)
+        assert results[0]["id"] in ["doc1", "doc4"]
+
+    def test_overlapping_documents(self) -> None:
+        query_doc_ids = [
+            ["doc1", "doc2", "doc3"],
+            ["doc2", "doc3", "doc4"],
+        ]
+        query_scores = [
+            [0.9, 0.7, 0.5],
+            [0.8, 0.6, 0.4],
+        ]
+
+        results = score_xtr(query_doc_ids, query_scores, k=4)
+        assert len(results) == 4
+        assert results[0]["id"] == "doc2"
+        assert results[0]["score"] == pytest.approx(1.5, abs=1e-5)
+        assert results[1]["id"] == "doc1"
+        assert results[1]["score"] == pytest.approx(1.3, abs=1e-5)
+
+    def test_duplicate_doc_in_same_query_token_uses_max(self) -> None:
+        query_doc_ids = [
+            ["doc1", "doc2", "doc1"],
+            ["doc2", "doc3"],
+        ]
+        query_scores = [
+            [0.9, 0.7, 0.6],
+            [0.8, 0.5],
+        ]
+
+        results = score_xtr(query_doc_ids, query_scores, k=3)
+        doc1 = next(r for r in results if r["id"] == "doc1")
+        assert doc1["score"] == pytest.approx(1.4, abs=1e-5)
+
+    def test_integer_doc_ids(self) -> None:
+        query_doc_ids = [[1, 2, 3], [2, 3, 4]]
+        query_scores = [[0.9, 0.7, 0.5], [0.8, 0.6, 0.4]]
+
+        results = score_xtr(query_doc_ids, query_scores, k=4)
+        assert len(results) == 4
+        assert isinstance(results[0]["id"], int)
+        assert results[0]["id"] == 2
+        assert results[0]["score"] == pytest.approx(1.5, abs=1e-5)
+
+    def test_single_query_token(self) -> None:
+        query_doc_ids = [["doc1", "doc2", "doc3"]]
+        query_scores = [[0.9, 0.7, 0.5]]
+        results = score_xtr(query_doc_ids, query_scores, k=3)
+        assert len(results) == 3
+        assert results[0]["id"] == "doc1"
+        assert results[0]["score"] == pytest.approx(0.9, abs=1e-5)
+
+    def test_k_larger_than_unique_docs(self) -> None:
+        query_doc_ids = [["doc1", "doc2"], ["doc2", "doc3"]]
+        query_scores = [[0.9, 0.7], [0.8, 0.5]]
+        results = score_xtr(query_doc_ids, query_scores, k=10)
+        assert len(results) == 3
+
+    def test_empty_query(self) -> None:
+        assert score_xtr([], [], k=5) == []
+
+    def test_cuda_device(self) -> None:
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        query_doc_ids = [["doc1", "doc2"], ["doc2", "doc3"]]
+        query_scores = [[0.9, 0.7], [0.8, 0.5]]
+        results = score_xtr(query_doc_ids, query_scores, k=3, device="cuda")
+        assert len(results) == 3
+        assert results[0]["id"] == "doc2"
+
+    def test_score_imputation_min(self) -> None:
+        query_doc_ids = [["doc1"], ["doc2"]]
+        query_scores = [[0.9], [0.5]]
+        results = score_xtr(query_doc_ids, query_scores, k=2, imputation="min")
+        assert len(results) == 2
+        assert results[0]["score"] == pytest.approx(1.4, abs=1e-5)
+        assert results[1]["score"] == pytest.approx(1.4, abs=1e-5)
+
+    def test_imputation_modes_execute(self) -> None:
+        query_doc_ids = [
+            ["doc1", "doc2", "doc3"],
+            ["doc2", "doc3", "doc4"],
+        ]
+        query_scores = [
+            [0.9, 0.7, 0.5],
+            [0.8, 0.6, 0.4],
+        ]
+        for imputation in ["zero", "mean", "percentile", "power_law"]:
+            results = score_xtr(
+                query_doc_ids=query_doc_ids,
+                query_scores=query_scores,
+                k=4,
+                imputation=imputation,
+                percentile=10.0,
+                power_law_multiplier=100.0,
+            )
+            assert len(results) == 4
+
+    def test_many_query_tokens(self) -> None:
+        n_tokens = 10
+        query_doc_ids = [
+            [f"doc{i}", f"doc{i + 1}", f"doc{i + 2}"] for i in range(n_tokens)
+        ]
+        query_scores = [[0.9, 0.7, 0.5] for _ in range(n_tokens)]
+        results = score_xtr(query_doc_ids, query_scores, k=5)
+        assert len(results) == 5
+        for result in results:
+            assert "id" in result
+            assert "score" in result
+            assert result["score"] > 0
+
+    def test_result_structure(self) -> None:
+        query_doc_ids = [["doc1", "doc2"]]
+        query_scores = [[0.9, 0.7]]
+        results = score_xtr(query_doc_ids, query_scores, k=2)
+        assert isinstance(results, list)
+        assert len(results) == 2
+        for result in results:
+            assert isinstance(result, dict)
+            assert "id" in result
+            assert "score" in result
+            assert isinstance(result["score"], float)
+
+    def test_descending_order(self) -> None:
+        query_doc_ids = [["doc1", "doc2", "doc3", "doc4", "doc5"]]
+        query_scores = [[0.3, 0.9, 0.5, 0.1, 0.7]]
+        results = score_xtr(query_doc_ids, query_scores, k=5)
+        assert [r["id"] for r in results] == ["doc2", "doc5", "doc3", "doc1", "doc4"]
+        for i in range(len(results) - 1):
+            assert results[i]["score"] >= results[i + 1]["score"]
+
+
+class TestScoreXTREdgeCases:
+    def test_negative_scores(self) -> None:
+        query_doc_ids = [["doc1", "doc2"], ["doc2", "doc3"]]
+        query_scores = [[0.5, -0.3], [0.2, -0.5]]
+        results = score_xtr(query_doc_ids, query_scores, k=3)
+        assert len(results) == 3
+
+    def test_all_same_scores(self) -> None:
+        query_doc_ids = [
+            ["doc1", "doc2", "doc3"],
+            ["doc4", "doc5", "doc6"],
+        ]
+        query_scores = [
+            [0.5, 0.5, 0.5],
+            [0.5, 0.5, 0.5],
+        ]
+        results = score_xtr(query_doc_ids, query_scores, k=6)
+        assert len(results) == 6
+        for result in results:
+            assert result["score"] == pytest.approx(1.0, abs=1e-5)
+
+    def test_very_small_k(self) -> None:
+        query_doc_ids = [
+            ["doc1", "doc2", "doc3"],
+            ["doc2", "doc3", "doc4"],
+        ]
+        query_scores = [
+            [0.9, 0.7, 0.5],
+            [0.8, 0.6, 0.4],
+        ]
+        results = score_xtr(query_doc_ids, query_scores, k=1)
+        assert len(results) == 1
+        assert results[0]["id"] == "doc2"
+
+    def test_raises_on_mismatched_query_lengths(self) -> None:
+        with pytest.raises(ValueError, match="same number of query tokens"):
+            score_xtr(
+                query_doc_ids=[["doc1"], ["doc2"]],
+                query_scores=[[0.9]],
+                k=2,
+            )
+
+    def test_raises_on_token_length_mismatch(self) -> None:
+        with pytest.raises(
+            ValueError, match="matching document IDs and scores lengths"
+        ):
+            score_xtr(
+                query_doc_ids=[["doc1", "doc2"]],
+                query_scores=[[0.9]],
+                k=2,
+            )


### PR DESCRIPTION
## Summary
- Add `retrieve.XTR` class for XTR retrieval on non-PLAID indexes (e.g. ScaNN)
- Add `score_xtr()` scoring function with multiple imputation strategies (`min`, `zero`, `mean`, `percentile`, `power_law`)
- Optimized scoring path: pre-allocated numpy arrays, skipped `torch.unique()` for string doc IDs, bulk `.tolist()` conversion, `is_rectangular` hint for imputation
- Export `score_xtr` from `pylate.rank` and `XTR` from `pylate.retrieve`
- Update `examples/evaluation/beir_dataset.py` to support XTR retrieval and configurable model/index options
- Add unit tests for XTR scoring (`test_xtr_scoring.py`) and retriever (`test_xtr_retriever.py`)

**Depends on #195 and #196**

## Test plan
- [ ] `python -m pytest tests/test_xtr_scoring.py -v`
- [ ] `python -m pytest tests/test_xtr_retriever.py -v`
- [ ] `python examples/evaluation/beir_dataset.py --model_name robro612/xtr-base-en-pylate --index_type scann --retrieval_type xtr --dataset_name nfcorpus --do_encode_and_index` — nDCG@10 should be ~33.1