### PR TITLE
Replace sqlitedict by pickle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "sentence-transformers == 5.1.1",
     "datasets >= 2.20.0",
     "accelerate >= 0.31.0",
-    "sqlitedict >= 2.1.0",
     "pandas >= 2.2.1",
     "transformers >= 4.41.0, <= 4.56.2",
     "ujson == 5.10.0",


### PR DESCRIPTION
This PR swap sqlitedict by pickle for managing the ids of documents.

Reason: sqlitedict has become a bottleneck in our evaluation pipelines, noticed that when running FastPlaid in either PyLate or directly and the diff was huge.
Replacing with pickle solve most of the overhead.
Tried thinking of alternatives:
<img width="796" height="911" alt="image" src="https://github.com/user-attachments/assets/1d5788df-86d8-4ef5-806f-040aac54ef6d" />


So all in all, I think pickle is a very solid alternative.
While building, I realized there are some "improvements" we can make or not, whether you think it's important/needed:
1. Right now, we lost the atomic operation, which means if it crashed mid operation, the index will be corrupted. One solution is to write the files to a temp file then rename once it's done. That said, it uses twice the storage during write (although it's dict, so not that big). Also, writing should be fast-ish so the probability of a crash is pretty small. Finally, we need our other part of the index to be resillient, I know stanford nlp is probably not.

2. We are _loading_ the dict for every search. Right now, most of my setup are a single search setup (evaluation), but maybe it adds overhead for multiple search. We could add the possibility of keep the dicts in RAM, but I think it's a bad default as it consume quite some RAM for very large indexes (1-2GB).

3. Should be noted that, for fast-plaid, at some point, Claude came with a design to lower the memory usage even more. One of the dict can be swapped by a list, because the fast-plaid indexes are dense. The other has to stay a dict, and this cannot work for stanford-nlp. Also allows to get rid of the bisect when deleting.
