### PR TITLE
Update CI to Python 3.10/3.14, bump fast-plaid to 1.4.6.2110, extend FastPlaid API

### DIFF
--- a/.github/workflows/plaid-tests.yml
+++ b/.github/workflows/plaid-tests.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [windows-latest, macos-latest]
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.10", "3.14"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/plaid-tests.yml
+++ b/.github/workflows/plaid-tests.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [windows-latest, macos-latest]
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.14"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.10", "3.14"]
         test-target: ["tests", "pylate"]
 
     steps:
@@ -38,4 +38,4 @@ jobs:
         run: uv run --extra dev pytest tests -m "model_loading" --durations=5
 
       - name: Run other tests
-        run: uv run --extra dev --extra voyager pytest ${{ matrix.test-target }} -m "not model_loading" -n auto --durations=5
+        run: uv run --extra dev pytest ${{ matrix.test-target }} -m "not model_loading" -n auto --durations=5

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.14"]
         test-target: ["tests", "pylate"]
 
     steps:

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,6 @@
+collect_ignore = []
+
+try:
+    import voyager  # noqa: F401
+except ImportError:
+    collect_ignore.append("pylate/indexes/voyager.py")

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,11 @@
+collect_ignore = []
+
+try:
+    import voyager  # noqa: F401
+except ImportError:
+    collect_ignore.append("pylate/indexes/voyager.py")
+
+try:
+    import scann  # noqa: F401
+except ImportError:
+    collect_ignore.append("pylate/retrieve/xtr.py")

--- a/pylate/indexes/fast_plaid.py
+++ b/pylate/indexes/fast_plaid.py
@@ -87,6 +87,10 @@ class FastPlaid(Base):
         Can be a list of device strings (e.g., ["cuda:0", "cuda:1"]).
     use_triton
         Whether to use triton kernels when computing kmeans using fast-plaid. Triton kernels are faster, but yields some variance due to race condition, set to false to get 100% reproducible results. If unset, will use triton kernels if possible.
+    low_memory
+        If True, index tensors are kept on CPU and moved to the target device only when needed,
+        reducing VRAM usage at the cost of slower search. If False (default), tensors stay on GPU
+        for faster search but higher VRAM usage. No effect when device is "cpu".
 
     """
 
@@ -105,6 +109,7 @@ class FastPlaid(Base):
         show_progress: bool = True,
         device: str | list[str] | None = None,
         use_triton: bool | None = None,
+        low_memory: bool = False,
     ) -> None:
         self.index_folder = index_folder
         self.index_name = index_name
@@ -141,7 +146,7 @@ class FastPlaid(Base):
 
         # Initialize or load the fast-plaid index
         self.fast_plaid = search.FastPlaid(
-            index=self.fast_plaid_index_path, device=device
+            index=self.fast_plaid_index_path, device=device, low_memory=low_memory
         )
         # Check if index already exists
         self.is_indexed = os.path.exists(self.documents_ids_to_plaid_ids_path)

--- a/pylate/indexes/fast_plaid.py
+++ b/pylate/indexes/fast_plaid.py
@@ -48,9 +48,16 @@ class FastPlaid(Base):
         The number of samples to use for K-means clustering.
         If None, it defaults to a value based on the number of documents.
         This parameter can be adjusted to balance between speed, memory usage and clustering quality.
+    seed
+        Random seed for K-means reproducibility.
+    use_triton
+        Whether to use triton kernels when computing kmeans using fast-plaid. Triton kernels are faster, but yields some variance due to race condition, set to false to get 100% reproducible results. If unset, will use triton kernels if possible.
     batch_size
         The internal batch size used for processing queries.
         A larger batch size might improve throughput on powerful GPUs but can consume more memory.
+    num_threads
+        Number of CPU worker processes used during search. Ignored on CUDA.
+        If None, fast-plaid's default is used.
     show_progress
         If set to True, a progress bar will be displayed during search operations.
     device
@@ -59,8 +66,10 @@ class FastPlaid(Base):
         If CUDA is not available, it defaults to "cpu".
         Can be a single device string (e.g., "cuda:0" or "cpu").
         Can be a list of device strings (e.g., ["cuda:0", "cuda:1"]).
-    use_triton
-        Whether to use triton kernels when computing kmeans using fast-plaid. Triton kernels are faster, but yields some variance due to race condition, set to false to get 100% reproducible results. If unset, will use triton kernels if possible.
+    low_memory
+        If True, index tensors are kept on CPU and moved to the target device only when needed,
+        reducing VRAM usage at the cost of slower search. If False (default), tensors stay on GPU
+        for faster search but higher VRAM usage. No effect when device is "cpu".
 
     """
 
@@ -74,26 +83,36 @@ class FastPlaid(Base):
         nbits: int = 4,
         kmeans_niters: int = 4,
         max_points_per_centroid: int = 256,
+        n_samples_kmeans: int | None = None,
+        seed: int = 42,
+        use_triton: bool | None = None,
         n_ivf_probe: int = 8,
         n_full_scores: int = 8192,
-        n_samples_kmeans: int | None = None,
         batch_size: int = 1 << 18,
+        num_threads: int | None = None,
         show_progress: bool = True,
         device: str | list[str] | None = None,
-        use_triton: bool | None = None,
+        low_memory: bool = False,
     ) -> None:
         self.index_folder = index_folder
         self.index_name = index_name
+
+        # Indexing hyperparameters
         self.nbits = nbits
         self.kmeans_niters = kmeans_niters
         self.max_points_per_centroid = max_points_per_centroid
+        self.n_samples_kmeans = n_samples_kmeans
+        self.seed = seed
+        self.use_triton = use_triton
+
+        # Search hyperparameters
         self.n_ivf_probe = n_ivf_probe
         self.n_full_scores = n_full_scores
-        self.n_samples_kmeans = n_samples_kmeans
         self.batch_size = batch_size
+        self.num_threads = num_threads
+
         self.show_progress = show_progress
         self.device = device
-        self.use_triton = use_triton
 
         # Create the index directory structure
         self.index_path = os.path.join(index_folder, index_name)
@@ -117,7 +136,7 @@ class FastPlaid(Base):
 
         # Initialize or load the fast-plaid index
         self.fast_plaid = search.FastPlaid(
-            index=self.fast_plaid_index_path, device=device
+            index=self.fast_plaid_index_path, device=device, low_memory=low_memory
         )
         # Check if index already exists
         self.is_indexed = os.path.exists(self.documents_ids_to_plaid_ids_path)
@@ -177,6 +196,7 @@ class FastPlaid(Base):
                 max_points_per_centroid=self.max_points_per_centroid,
                 nbits=self.nbits,
                 n_samples_kmeans=self.n_samples_kmeans,
+                seed=self.seed,
                 use_triton_kmeans=self.use_triton,
             )
             plaid_ids = list(range(len(documents_embeddings_torch)))
@@ -187,7 +207,14 @@ class FastPlaid(Base):
                 "Adding documents to existing index. This uses fast-plaid's update method "
                 "which does not recompute centroids and may result in slightly lower accuracy."
             )
-            self.fast_plaid.update(documents_embeddings=documents_embeddings_torch)
+            self.fast_plaid.update(
+                documents_embeddings=documents_embeddings_torch,
+                kmeans_niters=self.kmeans_niters,
+                max_points_per_centroid=self.max_points_per_centroid,
+                n_samples_kmeans=self.n_samples_kmeans,
+                seed=self.seed,
+                use_triton_kmeans=self.use_triton,
+            )
             # Assign new plaid IDs starting from current_max_id + 1
             plaid_ids = list(
                 range(
@@ -248,6 +275,41 @@ class FastPlaid(Base):
         )
 
         return self
+
+    def update_documents(
+        self,
+        documents_ids: list[str],
+        documents_embeddings: list[np.ndarray | torch.Tensor],
+    ) -> "FastPlaid":
+        """Update document embeddings for the given document IDs.
+
+        fast-plaid does not provide an in-place update by passage ID, so this
+        is implemented as ``remove_documents`` followed by ``add_documents``:
+        document IDs are preserved (callers can keep using the same keys),
+        but the underlying plaid IDs may change. Documents in
+        ``documents_ids`` that are not yet in the index are simply added.
+
+        Parameters
+        ----------
+        documents_ids
+            The document IDs to update.
+        documents_embeddings
+            The new embeddings for each document, in the same order as
+            ``documents_ids``.
+        """
+        if isinstance(documents_ids, str):
+            documents_ids = [documents_ids]
+        documents_ids = list(documents_ids)
+
+        existing = self._load_documents_ids_to_plaid_ids()
+        to_remove = [doc_id for doc_id in documents_ids if doc_id in existing]
+        if to_remove:
+            self.remove_documents(to_remove)
+
+        return self.add_documents(
+            documents_ids=documents_ids,
+            documents_embeddings=documents_embeddings,
+        )
 
     def __call__(
         self,
@@ -322,6 +384,7 @@ class FastPlaid(Base):
             n_full_scores=self.n_full_scores,
             show_progress=self.show_progress,
             subset=plaid_subset,
+            n_processes=self.num_threads,
         )
 
         # Convert results to expected format

--- a/pylate/indexes/plaid.py
+++ b/pylate/indexes/plaid.py
@@ -90,8 +90,6 @@ class PLAID(Base):
     ...    documents_ids=range(len(documents_embeddings)),
     ...    documents_embeddings=documents_embeddings
     ... )
-    Computing centroids of embeddings.
-    Creating FastPlaid index.
 
     >>> queries_embeddings = model.encode(
     ...     ["search query", "hello world"],

--- a/pylate/indexes/plaid.py
+++ b/pylate/indexes/plaid.py
@@ -49,9 +49,16 @@ class PLAID(Base):
         The number of samples to use for K-means clustering.
         If None, it defaults to a value based on the number of documents.
         This parameter can be adjusted to balance between speed, memory usage and clustering quality.
+    seed
+        Random seed for K-means reproducibility. FastPlaid backend only.
+    use_triton
+        Whether to use triton kernels when computing kmeans using fast-plaid. Triton kernels are faster, but yields some variance due to race condition, set to false to get 100% reproducible results. If unset, will use triton kernels if possible.
     batch_size
         The internal batch size used for processing queries.
         A larger batch size might improve throughput on powerful GPUs but can consume more memory.
+    num_threads
+        Number of CPU worker processes used during search. Ignored on CUDA and
+        with the Stanford PLAID backend. If None, fast-plaid's default is used.
     show_progress
         If set to True, a progress bar will be displayed during search operations.
     device
@@ -60,8 +67,12 @@ class PLAID(Base):
         If CUDA is not available, it defaults to "cpu".
         Can be a single device string (e.g., "cuda:0" or "cpu").
         Can be a list of device strings (e.g., ["cuda:0", "cuda:1"]).
-    use_triton
-        Whether to use triton kernels when computing kmeans using fast-plaid. Triton kernels are faster, but yields some variance due to race condition, set to false to get 100% reproducible results. If unset, will use triton kernels if possible.
+    low_memory
+        If True, index tensors are kept on CPU and moved to the target device
+        only when needed, reducing VRAM usage at the cost of slower search.
+        If False (default), tensors stay on the search device for faster
+        search but higher VRAM usage. No effect when device is "cpu" or with
+        the Stanford PLAID backend. FastPlaid backend only.
     **kwargs
         Additional arguments. Stanford PLAID specific parameters (embedding_size, nranks,
         index_bsize, ndocs, centroid_score_threshold, ncells, search_batch_size) are
@@ -90,8 +101,6 @@ class PLAID(Base):
     ...    documents_ids=range(len(documents_embeddings)),
     ...    documents_embeddings=documents_embeddings
     ... )
-    Computing centroids of embeddings.
-    Creating FastPlaid index.
 
     >>> queries_embeddings = model.encode(
     ...     ["search query", "hello world"],
@@ -126,13 +135,16 @@ class PLAID(Base):
         nbits: int = 4,
         kmeans_niters: int = 4,
         max_points_per_centroid: int = 256,
+        n_samples_kmeans: int | None = None,
+        seed: int = 42,
+        use_triton: bool | None = None,
         n_ivf_probe: int = 8,
         n_full_scores: int = 8192,
-        n_samples_kmeans: int | None = None,
         batch_size: int = 1 << 18,
+        num_threads: int | None = None,
         show_progress: bool = True,
         device: str | list[str] | None = None,
-        use_triton: bool | None = None,
+        low_memory: bool = False,
         **kwargs,
     ) -> None:
         self.use_fast = use_fast
@@ -174,13 +186,16 @@ class PLAID(Base):
                 nbits=nbits,
                 kmeans_niters=kmeans_niters,
                 max_points_per_centroid=max_points_per_centroid,
+                n_samples_kmeans=n_samples_kmeans,
+                seed=seed,
+                use_triton=use_triton,
                 n_ivf_probe=n_ivf_probe,
                 n_full_scores=n_full_scores,
-                n_samples_kmeans=n_samples_kmeans,
                 batch_size=batch_size,
+                num_threads=num_threads,
                 show_progress=show_progress,
                 device=device,
-                use_triton=use_triton,
+                low_memory=low_memory,
             )
         else:
             logging.info("📚 Index with Stanford backend.")
@@ -234,6 +249,33 @@ class PLAID(Base):
             The document IDs to remove.
         """
         self._index.remove_documents(documents_ids)
+        return self
+
+    def update_documents(
+        self,
+        documents_ids: list[str],
+        documents_embeddings: list[np.ndarray | torch.Tensor],
+    ) -> "PLAID":
+        """Update document embeddings for the given document IDs.
+
+        Only supported with the FastPlaid backend (``use_fast=True``).
+
+        Parameters
+        ----------
+        documents_ids
+            The document IDs to update.
+        documents_embeddings
+            The new embeddings for each document.
+        """
+        if not self.use_fast:
+            raise NotImplementedError(
+                "update_documents is only supported with the FastPlaid backend. "
+                "Set use_fast=True to use it."
+            )
+        self._index.update_documents(
+            documents_ids=documents_ids,
+            documents_embeddings=documents_embeddings,
+        )
         return self
 
     def __call__(

--- a/pylate/retrieve/colbert.py
+++ b/pylate/retrieve/colbert.py
@@ -50,8 +50,6 @@ class ColBERT:
     ...     documents_ids=documents_ids,
     ...     documents_embeddings=documents_embeddings,
     ... )
-    Computing centroids of embeddings.
-    Creating FastPlaid index.
 
     >>> retriever = retrieve.ColBERT(index=index)
 

--- a/pylate/retrieve/colbert.py
+++ b/pylate/retrieve/colbert.py
@@ -44,8 +44,6 @@ class ColBERT(BaseRetriever):
     ...     documents_ids=documents_ids,
     ...     documents_embeddings=documents_embeddings,
     ... )
-    Computing centroids of embeddings.
-    Creating FastPlaid index.
 
     >>> retriever = retrieve.ColBERT(index=index)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "A library for training and retrieval with ColBERT."
 readme = "README.md"
 authors = [{ name = "LightOn" }]
 license = "MIT"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "ujson == 5.10.0",
     "ninja == 1.11.1.4",
     "fastkmeans == 0.5.0",
-    "fast-plaid>=1.2.4.260,<=1.3.0.290",
+    "fast-plaid>=1.4.4.270,<=1.4.4.290",
 ]
 keywords = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,12 +49,12 @@ dev = [
     "fastapi >= 0.114.1",
     "uvicorn >= 0.30.6",
     "batched >= 0.1.2",
-    "voyager >= 2.0.9",
+    "voyager >= 2.0.9; python_version < '3.14'",
     "typos >= 0.11.0",
 ]
 eval = ["ranx >= 0.3.16", "beir >= 2.0.0"]
 api = ["fastapi >= 0.114.1", "uvicorn >= 0.30.6", "batched >= 0.1.2"]
-voyager = ["voyager >= 2.0.9"]
+voyager = ["voyager >= 2.0.9; python_version < '3.14'"]
 scann = ["scann >= 1.4.2"]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "ujson == 5.10.0",
     "ninja == 1.11.1.4",
     "fastkmeans == 0.5.0",
-    "fast-plaid>=1.2.4.260,<=1.3.0.290",
+    "fast-plaid>=1.4.6.270,<=1.4.6.2110",
 ]
 keywords = []
 
@@ -49,14 +49,14 @@ dev = [
     "fastapi >= 0.114.1",
     "uvicorn >= 0.30.6",
     "batched >= 0.1.2",
-    "voyager >= 2.0.9",
+    "voyager >= 2.0.9; python_version < '3.14'",
     "typos >= 0.11.0",
 ]
 eval = ["ranx >= 0.3.16", "beir >= 2.0.0"]
 api = ["fastapi >= 0.114.1", "uvicorn >= 0.30.6", "batched >= 0.1.2"]
-voyager = ["voyager >= 2.0.9"]
-scann = ["scann >= 1.4.2"]
-warp = ["xtr-warp-rs == 2.0.2.*"]
+voyager = ["voyager >= 2.0.9; python_version < '3.14'"]
+scann = ["scann >= 1.4.2; python_version < '3.14'"]
+warp = ["xtr-warp-rs == 2.0.3.*"]
 
 
 [dependency-groups]

--- a/tests/test_fast_plaid.py
+++ b/tests/test_fast_plaid.py
@@ -350,6 +350,55 @@ def test_fast_plaid_reload_after_delete():
     shutil.rmtree(f"test_indexes_{random_hash}")
 
 
+def test_fast_plaid_update_documents():
+    """Test updating document embeddings while preserving document IDs."""
+    random_hash = uuid.uuid4().hex
+
+    index = indexes.PLAID(
+        index_folder=f"test_indexes_{random_hash}",
+        index_name=f"fast_plaid_{random_hash}",
+        override=True,
+        use_fast=True,
+        nbits=2,
+        kmeans_niters=1,
+    )
+
+    model = models.ColBERT(
+        model_name_or_path="lightonai/GTE-ModernColBERT-v1",
+        device="cpu",
+        model_kwargs={"attn_implementation": "eager"},
+    )
+
+    documents = [
+        "Document about apples and their nutritional benefits.",
+        "Document about bananas and their vitamin content.",
+        "Document about cherries and antioxidants.",
+    ]
+    embeddings = model.encode(documents, is_query=False)
+    index.add_documents(documents_ids=["A", "B", "C"], documents_embeddings=embeddings)
+
+    # Replace B's embedding with something about space
+    new_embedding = model.encode(
+        ["Document about rockets and space exploration."], is_query=False
+    )
+    index.update_documents(documents_ids=["B"], documents_embeddings=new_embedding)
+
+    # B should rank for a space query
+    space_query = model.encode(["rockets and space"], is_query=True)
+    matches = index(space_query, k=3)
+    returned_ids = [m["id"] for m in matches[0]]
+    assert "B" in returned_ids
+
+    # All three documents should still be present
+    fruit_query = model.encode(["fruits and nutrition"], is_query=True)
+    matches = index(fruit_query, k=10)
+    assert {m["id"] for m in matches[0]} == {"A", "B", "C"}
+
+    # Cleanup
+    del index
+    shutil.rmtree(f"test_indexes_{random_hash}")
+
+
 if __name__ == "__main__":
     # Run tests
     test_fast_plaid_delete_reindexing()
@@ -363,3 +412,5 @@ if __name__ == "__main__":
     test_fast_plaid_delete_nonexistent()
 
     test_fast_plaid_reload_after_delete()
+
+    test_fast_plaid_update_documents()

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import pytest
+
+pytest.importorskip("voyager")
+
 from pylate import indexes, models, retrieve
 
 


### PR DESCRIPTION
## Summary

### CI / packaging

- Test matrix bumped to Python 3.10 and 3.14 only (was 3.10 / 3.12).
- `fast-plaid` bumped to `1.4.6.2110` (was `1.4.4`); FastPlaid index gains a `low_memory` parameter.
- `xtr-warp-rs` bumped to `2.0.3.*`. The `python_version < '3.14'` marker is dropped now that cp314 wheels exist on PyPI (via [pau-mensa/xtr-warp-rs#16](https://github.com/pau-mensa/xtr-warp-rs/pull/16) + [#17](https://github.com/pau-mensa/xtr-warp-rs/pull/17)).
- `voyager` and `scann` extras are restricted to `python_version < '3.14'` — neither ships cp314 wheels yet (voyager 2.1.0 maxes at cp312, scann 1.4.2 at cp313).
- `conftest.py` skips `pylate/indexes/voyager.py` and `pylate/retrieve/xtr.py` doctests when the corresponding optional backend is not installed. `tests/test_retriever.py::test_voyager_index` gains a `pytest.importorskip("voyager")` guard.
- Doctest expectations cleaned up to drop Rust stdout lines that don't appear in the new fast-plaid release.

### FastPlaid wrapper symmetry with WARP

`FastPlaid` and `WARP` now offer the same end-to-end API surface (`add_documents` / `remove_documents` / `update_documents` / `__call__`):

- **`update_documents(documents_ids, documents_embeddings)`** added to `FastPlaid` (and exposed via `PLAID`). fast-plaid's backend has no per-passage update API, so the wrapper implements update as `remove_documents` → `add_documents`: document IDs are preserved (callers keep the same keys), underlying plaid IDs may shift — same external contract WARP gives.
- **`seed` and `num_threads`** added to `FastPlaid.__init__` (and plumbed through `PLAID`), mirroring WARP's parameter names. These are now forwarded to fast-plaid's `create` / `update` / `search` calls. Previously `update` was called with only `documents_embeddings`, so `kmeans_niters` / `max_points_per_centroid` / `n_samples_kmeans` / `seed` / `use_triton_kmeans` silently fell back to backend defaults instead of the values the user configured at index construction.
- **`low_memory`** also exposed on the `PLAID` wrapper (already existed on `FastPlaid` but `PLAID` didn't forward it). Default `False`.

### Tests

- `test_fast_plaid_update_documents` mirroring `test_warp_update_documents` (add A/B/C → replace B's embedding with a space-themed one → assert B ranks for "rockets and space" and all three doc IDs still appear).

## Test plan

- [x] PyLate CI matrix passes on Python 3.10 and 3.14 (ubuntu / macos / windows where applicable).
- [x] Lint, documentation, and existing PLAID / fast-plaid / warp tests still pass.
- [ ] `test_fast_plaid_update_documents` runs in the ubuntu 3.10/3.14 `tests` jobs.

## Related

- [pau-mensa/xtr-warp-rs#16](https://github.com/pau-mensa/xtr-warp-rs/pull/16) — Python 3.14 support via PyO3 ABI3 forward compatibility (merged).
- [pau-mensa/xtr-warp-rs#17](https://github.com/pau-mensa/xtr-warp-rs/pull/17) — cibuildwheel bump + cp314 scoped to torch ≥2.9 (merged; cp314 wheels now on PyPI for `xtr-warp-rs == 2.0.3.{290,2100,2110}`).