### PR TITLE
Optimized hierarchical pooling function

### DIFF
--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -839,7 +839,9 @@ class ColBERT(SentenceTransformer):
 
             # Hierarchical clustering
             linkage_matrix = hierarchy.linkage(condensed, method="ward")
-            labels = hierarchy.fcluster(linkage_matrix, t=num_clusters, criterion="maxclust")
+            labels = hierarchy.fcluster(
+                linkage_matrix, t=num_clusters, criterion="maxclust"
+            )
 
             # Vectorized cluster mean via scatter_add_
             labels_tensor = torch.from_numpy(labels.astype(np.int64)) - 1  # 0-indexed


### PR DESCRIPTION
This PR optimize a bit the hierarchical pooling function.
The original code was messy code made during the paper exploration, but it's actually hella slow.
Worked a bit with Claude to make it faster, we ended up keeping a few:

**1. Condensed distance matrix** (biggest win)
- Extract upper triangle of the cosine distance matrix and pass as a condensed 1D array to `linkage()`.
- This is both a correctness fix (scipy now uses the actual precomputed distances) and a performance win (avoids scipy internally recomputing pdist on the square matrix).

**2. CPU-only processing**
- Call `.cpu()` once at the start and stay on CPU throughout.
- Avoids GPU->CPU->GPU transfers since all operations (distance matrix, clustering, aggregation) are CPU-bound.

**3. Vectorized cluster aggregation**
- Replace the per-cluster Python loop with `scatter_add_` to accumulate cluster sums and counts in a single pass, then divide.

**4. Early exit**
- Skip the entire clustering pipeline when `num_clusters >= num_embeddings`.

Tried also a bunch of other things but did not keep it in the end (prefered to keep cleaner code/no dep)
## Approaches Explored But Not Kept

| Approach | pf=2 time (nfcorpus) | Why not kept |
|---|---|---|
| `scipy.spatial.distance.pdist` instead of `torch.mm` + triu | 18.30s | scipy's pair-by-pair C loop is slower than BLAS matrix multiply |
| `ThreadPoolExecutor` parallelization | 16.85-21.67s | GIL contention + BLAS threading conflicts; tuning thread counts made it worse |
| `fastcluster.linkage_vector` (observations directly) | 22.78s | Euclidean distance default; less efficient than precomputed cosine |
| `fastcluster` (optional dependency) | 12.95s | Marginal gain (~2s) doesn't justify adding a dependency |
| Full numpy pipeline + triu_indices cache | 11.67s | Marginal gain (~1.3s) over the torch-based version |



Ran a few tests for correctness:
### Encoding time (seconds)

| Dataset | pool_factor | Original | Optimized | Speedup |
|---|---|---|---|---|
| nfcorpus | 1 | 7.89 | 7.81 | 1.0x |
| nfcorpus | 2 | 44.01 | 14.72 | **3.0x** |
| scifact | 1 | 10.28 | 10.31 | 1.0x |
| scifact | 2 | 60.18 | 20.43 | **2.9x** |
| fiqa | 1 | 65.46 | 65.32 | 1.0x |
| fiqa | 2 | 373.04 | 142.67 | **2.6x** |

### Pooling overhead (encoding time minus pf=1 baseline)

| Dataset | Docs | Original overhead | Optimized overhead | Overhead reduction |
|---|---|---|---|---|
| nfcorpus | 3,633 | 36.12s | 6.91s | **5.2x** |
| scifact | 5,183 | 49.90s | 10.12s | **4.9x** |
| fiqa | 57,638 | 307.58s | 77.35s | **4.0x** |

### Retrieval quality (ndcg@10)

| Dataset | pool_factor | Original | Optimized | Delta |
|---|---|---|---|---|
| nfcorpus | 1 | 0.3809 | 0.3813 | +0.0004 |
| nfcorpus | 2 | 0.3779 | 0.3792 | +0.0013 |
| scifact | 1 | 0.7606 | 0.7598 | -0.0008 |
| scifact | 2 | 0.7605 | 0.7592 | -0.0013 |
| fiqa | 1 | 0.4538 | 0.4510 | -0.0028 |
| fiqa | 2 | 0.4489 | 0.4479 | -0.0010 |

I should have run the bench withotu triton to reduce variance but honestly lgtm

Just two things to note:
- I removed GPU computation (as it was causing gpu -> cpu overhead anyways), we might want to reconsider this for very large documents but I think it's fine and not the bottleneck anyways
- I fixed the order of tokens, now the protected tokens are in the beginning of the sequence (their og place actually). It's more logical, it's breaking change but honestly I am pretty sure no one did use the position in pooling o/ (sorry if you did and it breaks your experiments, but I think it's for the best in the future)

cc @bclavie 