### PR TITLE
Add support for WARP

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -38,4 +38,4 @@ jobs:
         run: uv run --extra dev pytest tests -m "model_loading" --durations=5
 
       - name: Run other tests
-        run: uv run --extra dev --extra voyager --extra scann pytest ${{ matrix.test-target }} -m "not model_loading" -n auto --durations=5
+        run: uv run --extra dev --extra voyager --extra scann --extra warp pytest ${{ matrix.test-target }} -m "not model_loading" -n auto --durations=5

--- a/README.md
+++ b/README.md
@@ -409,6 +409,8 @@ Sample Output:
 ]
 ```
 
+Also note that a [WARP](https://github.com/pau-mensa/xtr-warp-rs) backend is also available via `indexes.WARP` (install with `pip install "pylate[warp]"`). WARP is an index to be used with [XTR-trained models](https://lightonai.github.io/pylate/documentation/training/#xtr-training) and might not work well with every model. It uses approximations that make retrieval faster and cheaper but can degrade performance on models that were not trained for them; see the [retrieval documentation](https://lightonai.github.io/pylate/documentation/retrieval/#xtr-retrieval) for the model compatibility notes and a concrete example.
+
 &nbsp;
 
 ## Reranking

--- a/docs/documentation/retrieval.md
+++ b/docs/documentation/retrieval.md
@@ -246,40 +246,131 @@ index = indexes.PLAID(
 )
 ```
 
+---
 
 ## XTR Retrieval
 
-PyLate's two-stage indexes (e.g. `retrieve.ColBERT` on a `ScaNN` or `Voyager` index) all share the same first stage: for each query token, the index returns its top-`k_token` document tokens with similarity scores. What differs is the **scoring step that turns those hits into a per-document score**. `retrieve.ColBERT` pools the candidate documents from the hits, fetches their embeddings from the index, and re-scores them with the full MaxSim. [XTR](https://arxiv.org/abs/2304.01982) (conteXtual Token Retrieval) instead **scores documents directly from the per-token-hit scores** themselves. For each query token, a document gets credit for the maximum score it received in that token's top-`k_token` list, summed across query tokens, with the **minimum retrieved score** imputed for query tokens that didn't surface any of its tokens (matching the original XTR paper).
+[XTR](https://arxiv.org/abs/2304.01982) (conteXtual Token Retrieval, Lee et al. NeurIPS 2023) is a multi-vector retrieval approach that changes both how the model is trained and how documents are scored. PyLate exposes XTR retrieval through the **WARP** backend, which packages it as a fast end-to-end IVF index via the [`xtr-warp-rs`](https://github.com/pau-mensa/xtr-warp-rs) Rust engine ([Jha et al., SIGIR 2025](https://arxiv.org/abs/2501.17788)). For best results, pair WARP with a model trained on the XTR objective via `pylate.scores.XTRScores`. See [XTR Training](training.md#xtr-training) for the training side.
 
-Swapping `retrieve.ColBERT` for `retrieve.XTR` on the same token index gives you XTR-style scoring with no re-embedding step, no full MaxSim rerank, and no need for the index to keep the original document embeddings around in `ScaNN`. Due to the coarser approximation of the scores, XTR extends its default token retrieval parameter `k_token` to `10_000`, greater than ColBERT's `100`:
+### How XTR scoring works
 
-```python
-from pylate import indexes, retrieve
+The classic ColBERT scoring step pools the candidate documents returned by a first-stage index, fetches their full embeddings, and re-scores them with the full MaxSim. [XTR](https://arxiv.org/abs/2605.00646) instead **scores documents directly from the per-token-hit scores** themselves: for each query token, a document gets credit for the maximum score it received in that token's top-`k_token` list, summed across query tokens, with the **minimum retrieved score** imputed for query tokens that did not surface any of its tokens (matching the original XTR paper). In PyLate, you can select between using ColBERT (full MaxSim scoring) or XTR (min score imputation) simply by using `retrieve.ColBERT` or `retrieve.XTR`.
 
-index = indexes.ScaNN(
-    index_folder="pylate-xtr-index",
-    index_name="my_documents",
-    override=True,
-    store_embeddings=False,  # XTR does not need cached document embeddings, ColBERT does.
-)
+WARP implements this scoring natively, with aggressive IVF-based approximations on top.
 
-# Encode and add documents to the index...
+### WARP (end-to-end)
 
-retriever = retrieve.XTR(index=index)
+WARP is the equivalent of PLAID for XTR retrieval, and `xtr-warp-rs` is an implementation of WARP based on FastPLAID. It is faster than FastPLAID because it uses more approximations. Latency and memory footprint at retrieval time go down, and retrieval quality stays competitive on standard IR benchmarks. Use WARP when search latency or RAM is your bottleneck.
 
-# Encode queries...
+#### Model compatibility
 
-results = retriever.retrieve(
-    queries_embeddings=queries_embeddings,
-    k=100,
-    k_token=10_000,
-)
+Unlike PLAID, WARP does not work equally well with every multi-vector model: its centroid-pruning approximations rely on a relatively flat token-score distribution, which standard ColBERT training does not always produce. When the model fits, WARP is both fast and accurate; when it does not, recall can drop noticeably.
 
-print(results)
+[Jha et al. (2026)](https://arxiv.org/abs/2605.00646) show that training with the [XTR](https://arxiv.org/abs/2304.01982) objective flattens the score distribution and recovers the model's retrieval quality on IVF-based engines, WARP included. PyLate supports XTR training natively as a drop-in replacement for ColBERT's score function. See [XTR Training](training.md#xtr-training) for how to wire `scores.XTRScores` (or `scores.XTRKDScores` for distillation) into your loss.
+
+In practice, you should benchmark both PLAID and WARP on your own data with your own model and pick whichever gives you the best speed/recall trade-off for your use case.
+
+#### Installation
+
+WARP is an optional dependency; install it explicitly:
+
+```bash
+pip install "pylate[warp]"
 ```
 
-???+ info "`store_embeddings=False`"
-    Because XTR scores documents straight from the index hits, the original document embeddings are never read again at retrieval time. Setting `store_embeddings=False` keeps the on-disk index much smaller — no need for `ScaNN` tostore the original document embeddings.
+Wheels are torch-version-suffixed (`xtr-warp-rs == 2.0.2.290` ships against torch 2.9.0, `2.0.2.280` against 2.8.0, etc.). The pylate extra resolves to the build that matches your installed torch.
+
+#### Indexing and retrieval
+
+The API mirrors `indexes.PLAID`. The `add_documents` / `__call__` contract is the same, so the only line that changes from a PLAID setup is the index constructor:
+
+```python
+from pylate import indexes, models, retrieve
+
+documents_ids = ["doc_001", "doc_002", "doc_003"]
+documents = [
+    "ColBERT computes a contextualized embedding for each token of the query and document, then performs a fast late interaction between them.",
+    "PLAID compresses ColBERT token vectors via product quantization to deliver sub-200 ms latency on large corpora.",
+    "WARP is a multi-vector retrieval engine that prunes the centroid space per token and uses an error-aware merge to cut per-query work.",
+]
+
+# 1. Load an XTR-trained model. WARP works with any ColBERT model, but
+#    XTR-trained checkpoints recover the recall WARP would otherwise lose
+#    on its centroid-pruning approximations (see "Model compatibility" above).
+model = models.ColBERT(model_name_or_path="robro612/ModernBERT-XTR")
+
+# 2. Initialize the WARP index
+index = indexes.WARP(
+    index_folder="pylate-warp-index",
+    index_name="my_documents",
+    override=True,
+)
+
+# 3. Encode and add documents
+documents_embeddings = model.encode(
+    documents,
+    batch_size=32,
+    is_query=False,
+    show_progress_bar=True,
+)
+index.add_documents(
+    documents_ids=documents_ids,
+    documents_embeddings=documents_embeddings,
+)
+
+# 4. Retrieve. retrieve.XTR / retrieve.ColBERT are interchangeable on
+#    end-to-end indexes like WARP. Both short-circuit to the index's
+#    own scoring path. retrieve.XTR is named here to make intent explicit.
+retriever = retrieve.XTR(index=index)
+queries_embeddings = model.encode(
+    ["What is late interaction?", "How does WARP differ from PLAID?"],
+    batch_size=32,
+    is_query=True,
+)
+scores = retriever.retrieve(queries_embeddings=queries_embeddings, k=10)
+print(scores)
+```
+
+#### Tuning
+
+All search and indexing hyperparameters are flat keyword arguments on `indexes.WARP(...)`, the same constructor style as `indexes.PLAID`. `n_ivf_probe` shares its name and meaning with the PLAID parameter; the others are WARP-specific.
+
+PyLate ships with conservative defaults for the search knobs (`n_ivf_probe=32`, `t_prime=100_000`) that prioritize retrieval quality. This is slower than what the engine can do at full tilt, but avoids the situation where a user gets a low nDCG number on a fresh install and assumes either WARP or their model is broken.
+
+##### Search-time parameters
+
+| Parameter | Default | Higher value | Lower value | When to change |
+|---|---|---|---|---|
+| `n_ivf_probe` | `32` | More inverted-list probes per token → higher recall, slower | Fewer probes → faster, lower recall | Drop to `None` (auto-tune) for the fastest preset; raise toward `64+` only if recall is lagging on hard queries |
+| `t_prime` | `100_000` | Larger candidate pool before scoring → higher recall, slower | Smaller pool → faster, lower recall | Same as `n_ivf_probe`. The two are usually tuned together |
+| `bound` | `None` | More centroids considered per query token → higher recall, slower | n/a | Leave on auto unless profiling shows the per-token centroid step dominates |
+| `max_candidates` | `None` | Larger final-sort window → higher recall, slower | n/a | Cap if final-sort latency is the bottleneck |
+| `centroid_score_threshold` | `None` | Stricter pruning → faster, may drop recall | Looser pruning → higher recall, slower | Tune empirically on a held-out query set |
+
+##### Going faster
+
+Setting both `n_ivf_probe` and `t_prime` back to `None` switches WARP to its full auto-tune mode, which is significantly faster (roughly 5–10× on a typical corpus) at a small recall cost (around 2–3% relative drop on standard IR benchmarks):
+
+```python
+index = indexes.WARP(
+    index_folder="pylate-warp-index",
+    index_name="my_documents",
+    n_ivf_probe=None,
+    t_prime=None,
+)
+```
+
+The auto-tuner derives the values from index density (`num_embeddings / num_partitions`), `top_k`, and the per-query token count. See the [upstream source](https://github.com/pau-mensa/xtr-warp-rs/blob/main/python/xtr_warp/hyperparams.py) for the formulas.
+
+##### Indexing parameters
+
+| Parameter | Default | Higher value | Lower value | When to change |
+|---|---|---|---|---|
+| `nbits` | `4` | More bits per code → higher precision, larger index | Fewer bits → smaller index, lower precision | Lower (e.g. `2`) when on-disk size matters more than the last bit of recall |
+| `kmeans_niters` | `4` | Better centroid placement → marginally higher recall, slower index build | Faster build, slightly worse centroids | Raise for production indexes that you build once and serve for a long time |
+| `max_points_per_centroid` | `256` | Larger / less-balanced clusters | Smaller / more-balanced clusters, slower build | Rarely needed; touches K-means cluster size |
+
+`min_outliers` and `max_growth_rate` only matter for incremental `add_documents` calls on an already-built index; they control when WARP grows its centroid codebook to absorb out-of-distribution embeddings. Defaults are fine for most workloads.
 
 ## Reranking
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -409,6 +409,8 @@ Sample Output:
 ]
 ```
 
+Also note that a [WARP](https://github.com/pau-mensa/xtr-warp-rs) backend is also available via `indexes.WARP` (install with `pip install "pylate[warp]"`). WARP is an index to be used with [XTR-trained models](documentation/training.md#xtr-training) and might not work well with every model. It uses approximations that make retrieval faster and cheaper but can degrade performance on models that were not trained for them; see the [retrieval documentation](documentation/retrieval.md#xtr-retrieval) for the model compatibility notes and a concrete example.
+
 &nbsp;
 
 ## Reranking

--- a/examples/evaluation/beir_dataset_xtr.py
+++ b/examples/evaluation/beir_dataset_xtr.py
@@ -1,4 +1,9 @@
-"""Evaluation script for BEIR datasets using XTR retrieval over a ScaNN index.
+"""Evaluation script for BEIR datasets using a WARP index, paired with an
+XTR-trained model.
+
+WARP is an end-to-end multi-vector retrieval engine (like PLAID), so the
+`retrieve.XTR` wrapper short-circuits to the index's own scoring rather than
+running a separate XTR scoring pass on top of token-level hits.
 
 For the ColBERT + PLAID pipeline, see `beir_dataset.py`.
 """
@@ -50,7 +55,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     dataset_name = args.dataset_name
-    model_name = "lightonai/GTE-ModernColBERT-v1"
+    model_name = "robro612/ModernBERT-XTR"
     model = models.ColBERT(
         model_name_or_path=model_name,
         document_length=300,
@@ -76,10 +81,9 @@ if __name__ == "__main__":
             split="dev" if "msmarco" in dataset_name else "test",
         )
 
-    index = indexes.ScaNN(
+    index = indexes.WARP(
         override=True,
         index_name=f"{dataset_name}_{model_name.split('/')[-1]}",
-        store_embeddings=False,
     )
 
     retriever = retrieve.XTR(index=index)

--- a/pylate/indexes/__init__.py
+++ b/pylate/indexes/__init__.py
@@ -3,5 +3,11 @@ from __future__ import annotations
 from .plaid import PLAID
 from .scann import ScaNN
 from .voyager import Voyager
+from .warp import WARP
 
-__all__ = ["Voyager", "PLAID", "ScaNN"]
+__all__ = [
+    "Voyager",
+    "PLAID",
+    "ScaNN",
+    "WARP",
+]

--- a/pylate/indexes/fast_plaid.py
+++ b/pylate/indexes/fast_plaid.py
@@ -12,35 +12,9 @@ from fast_plaid import search
 
 from ..rank import RerankResult
 from .base import Base
+from .utils import convert_embeddings_to_torch
 
 logger = logging.getLogger(__name__)
-
-
-def convert_embeddings_to_torch(
-    embeddings: np.ndarray | torch.Tensor | list,
-) -> list[torch.Tensor]:
-    """Convert embeddings to list of torch tensors as expected by fast-plaid."""
-    if isinstance(embeddings, list):
-        if len(embeddings) == 0:
-            return []
-        if isinstance(embeddings[0], torch.Tensor):
-            return embeddings
-        elif isinstance(embeddings[0], np.ndarray):
-            return [torch.from_numpy(emb) for emb in embeddings]
-
-    if isinstance(embeddings, np.ndarray):
-        if len(embeddings.shape) == 3:  # batch_size, n_tokens, embedding_size
-            return [torch.from_numpy(embeddings[i]) for i in range(embeddings.shape[0])]
-        elif len(embeddings.shape) == 2:  # n_tokens, embedding_size
-            return [torch.from_numpy(embeddings)]
-
-    if isinstance(embeddings, torch.Tensor):
-        if len(embeddings.shape) == 3:  # batch_size, n_tokens, embedding_size
-            return [embeddings[i] for i in range(embeddings.shape[0])]
-        elif len(embeddings.shape) == 2:  # n_tokens, embedding_size
-            return [embeddings]
-
-    return embeddings
 
 
 class FastPlaid(Base):

--- a/pylate/indexes/utils.py
+++ b/pylate/indexes/utils.py
@@ -21,6 +21,33 @@ def reshape_embeddings(
     return embeddings
 
 
+def convert_embeddings_to_torch(
+    embeddings: np.ndarray | torch.Tensor | list,
+) -> list[torch.Tensor]:
+    """Convert embeddings to list of torch tensors as expected by fast-plaid and WARP."""
+    if isinstance(embeddings, list):
+        if len(embeddings) == 0:
+            return []
+        if isinstance(embeddings[0], torch.Tensor):
+            return embeddings
+        elif isinstance(embeddings[0], np.ndarray):
+            return [torch.from_numpy(emb) for emb in embeddings]
+
+    if isinstance(embeddings, np.ndarray):
+        if len(embeddings.shape) == 3:  # batch_size, n_tokens, embedding_size
+            return [torch.from_numpy(embeddings[i]) for i in range(embeddings.shape[0])]
+        elif len(embeddings.shape) == 2:  # n_tokens, embedding_size
+            return [torch.from_numpy(embeddings)]
+
+    if isinstance(embeddings, torch.Tensor):
+        if len(embeddings.shape) == 3:  # batch_size, n_tokens, embedding_size
+            return [embeddings[i] for i in range(embeddings.shape[0])]
+        elif len(embeddings.shape) == 2:  # n_tokens, embedding_size
+            return [embeddings]
+
+    return embeddings
+
+
 def np_dtype_for(
     dtype: object,
 ) -> type[np.float16] | type[np.float32] | None:

--- a/pylate/indexes/warp.py
+++ b/pylate/indexes/warp.py
@@ -1,0 +1,443 @@
+from __future__ import annotations
+
+import logging
+import os
+import pickle
+import shutil
+
+import numpy as np
+import torch
+
+from ..rank import RerankResult
+from .base import Base
+from .utils import convert_embeddings_to_torch
+
+logger = logging.getLogger(__name__)
+
+
+class WARP(Base):
+    """WARP index using the xtr-warp-rs backend for high-performance multi-vector search.
+
+    Parameters
+    ----------
+    index_folder
+        The folder where the index will be stored.
+    index_name
+        The name of the index.
+    override
+        Whether to override the collection if it already exists.
+    nbits
+        The number of bits to use for product quantization.
+        Lower values mean more compression and potentially faster searches but
+        can reduce accuracy.
+    kmeans_niters
+        The number of iterations for the K-means algorithm used during index
+        creation. This influences the quality of the initial centroid
+        assignments.
+    max_points_per_centroid
+        The maximum number of points (token embeddings) that can be assigned to
+        a single centroid during K-means. Helps balance the clusters.
+    n_samples_kmeans
+        The number of samples to use for K-means clustering. If None, defaults
+        to a value chosen by xtr-warp based on the number of documents.
+    seed
+        Random seed for K-means reproducibility.
+    use_triton
+        Whether to use Triton kernels when computing K-means. Triton kernels are
+        faster but yield some variance due to race conditions; set to False for
+        100% reproducible results. If None, uses Triton when available on GPU.
+    min_outliers
+        Minimum number of outlier embeddings required to trigger centroid
+        expansion during incremental ``add_documents`` calls.
+    max_growth_rate
+        Maximum ratio of new centroids relative to the existing codebook size
+        during centroid expansion on incremental adds.
+    n_ivf_probe
+        The number of inverted file list probes to perform during search. This
+        parameter controls the number of clusters to search within the index
+        for each query. Higher values improve recall but increase search time.
+        Same parameter as `n_ivf_probe` on `indexes.PLAID`. If None, xtr-warp
+        auto-tunes based on index characteristics.
+    bound
+        Number of centroids to consider per query token. If None, auto-tuned.
+    t_prime
+        Value for the t_prime scoring policy. If None, auto-tuned.
+    max_candidates
+        Maximum number of candidate documents to consider before the final
+        sort. If None, auto-tuned.
+    centroid_score_threshold
+        Threshold on centroid scores (between 0 and 1) used to prune candidates
+        during search. If None, auto-tuned.
+    batch_size
+        The internal batch size used when computing the query × centroids
+        matmul during search.
+    num_threads
+        Upper bound on threads for CPU search. Ignored on CUDA.
+    show_progress
+        If set to True, a progress bar is displayed during indexing and search
+        operations.
+    device
+        Device for computation (e.g. "cpu", "cuda", "cuda:0"). If None,
+        defaults to "cuda" when available, else "cpu".
+    dtype
+        Precision used for centroids and bucket weights when the index is
+        loaded for search (e.g. ``torch.float32``, ``torch.float16``). Affects
+        memory footprint and search speed.
+    mmap
+        Memory-map large index tensors (codes and residuals) to reduce memory
+        usage. Only supported on CPU.
+
+    """
+
+    is_end_to_end_index = True
+
+    def __init__(
+        self,
+        index_folder: str = "indexes",
+        index_name: str = "warp",
+        override: bool = False,
+        nbits: int = 4,
+        kmeans_niters: int = 4,
+        max_points_per_centroid: int = 256,
+        n_samples_kmeans: int | None = None,
+        seed: int = 42,
+        use_triton: bool | None = None,
+        min_outliers: int = 50,
+        max_growth_rate: float = 0.1,
+        n_ivf_probe: int | None = 32,
+        bound: int | None = None,
+        t_prime: int | None = 100_000,
+        max_candidates: int | None = None,
+        centroid_score_threshold: float | None = None,
+        batch_size: int = 8192,
+        num_threads: int | None = 1,
+        show_progress: bool = True,
+        device: str | None = None,
+        dtype: torch.dtype = torch.float32,
+        mmap: bool = True,
+    ) -> None:
+        try:
+            from xtr_warp import search as warp_search
+        except ImportError:
+            raise ImportError(
+                "xtr-warp-rs is not installed. Please install it with: "
+                '`pip install "pylate[warp]"` or `pip install xtr-warp-rs`.'
+            )
+
+        self.index_folder = index_folder
+        self.index_name = index_name
+
+        # Indexing hyperparameters
+        self.nbits = nbits
+        self.kmeans_niters = kmeans_niters
+        self.max_points_per_centroid = max_points_per_centroid
+        self.n_samples_kmeans = n_samples_kmeans
+        self.seed = seed
+        self.use_triton = use_triton
+        self.min_outliers = min_outliers
+        self.max_growth_rate = max_growth_rate
+
+        # Search hyperparameters
+        self.n_ivf_probe = n_ivf_probe
+        self.bound = bound
+        self.t_prime = t_prime
+        self.max_candidates = max_candidates
+        self.centroid_score_threshold = centroid_score_threshold
+        self.batch_size = batch_size
+        self.num_threads = num_threads
+
+        # Runtime / loading
+        self.show_progress = show_progress
+        self.dtype = dtype
+        self.mmap = mmap
+        self.device = (
+            device
+            if device is not None
+            else ("cuda" if torch.cuda.is_available() else "cpu")
+        )
+
+        # Create the index directory structure
+        self.index_path = os.path.join(index_folder, index_name)
+        self.warp_index_path = os.path.join(self.index_path, "warp_index")
+        if override and os.path.exists(self.index_path):
+            shutil.rmtree(self.index_path)
+
+        os.makedirs(self.index_path, exist_ok=True)
+
+        # Pickle mappings for document IDs
+        self.documents_ids_to_warp_ids_path = os.path.join(
+            self.index_path, "documents_ids_to_warp_ids.pkl"
+        )
+        self.warp_ids_to_documents_ids_path = os.path.join(
+            self.index_path, "warp_ids_to_documents_ids.pkl"
+        )
+
+        # Initialize the XTRWarp instance
+        self.warp = warp_search.XTRWarp(index=self.warp_index_path, device=self.device)
+        self._loaded = False
+
+        # Check if index already exists on disk
+        self.is_indexed = os.path.exists(self.documents_ids_to_warp_ids_path)
+        if self.is_indexed:
+            self._ensure_loaded()
+
+    def _ensure_loaded(self) -> None:
+        """Load the WARP index into memory if not already loaded."""
+        if not self._loaded:
+            self.warp.load(device=self.device, dtype=self.dtype, mmap=self.mmap)
+            self._loaded = True
+
+    def _load_documents_ids_to_warp_ids(self) -> dict:
+        """Load the pickle file that maps document IDs to WARP passage IDs."""
+        if os.path.exists(self.documents_ids_to_warp_ids_path):
+            with open(self.documents_ids_to_warp_ids_path, "rb") as f:
+                return pickle.load(f)
+        return {}
+
+    def _load_warp_ids_to_documents_ids(self) -> dict:
+        """Load the pickle file that maps WARP passage IDs to document IDs."""
+        if os.path.exists(self.warp_ids_to_documents_ids_path):
+            with open(self.warp_ids_to_documents_ids_path, "rb") as f:
+                return pickle.load(f)
+        return {}
+
+    def _save_mappings(
+        self,
+        documents_ids_to_warp_ids: dict,
+        warp_ids_to_documents_ids: dict,
+    ) -> None:
+        """Save the ID mappings to pickle files."""
+        with open(self.documents_ids_to_warp_ids_path, "wb") as f:
+            pickle.dump(documents_ids_to_warp_ids, f)
+        with open(self.warp_ids_to_documents_ids_path, "wb") as f:
+            pickle.dump(warp_ids_to_documents_ids, f)
+
+    def add_documents(
+        self,
+        documents_ids: str | list[str],
+        documents_embeddings: list[np.ndarray | torch.Tensor],
+        **kwargs,
+    ) -> "WARP":
+        """Add documents to the index.
+
+        On the first call this creates the WARP index. Subsequent calls use
+        WARP's incremental add which appends documents and may expand the
+        centroid codebook if many new embeddings are outliers.
+
+        Parameters
+        ----------
+        documents_ids
+            Document IDs to associate with the embeddings.
+        documents_embeddings
+            The document embeddings to index.
+        **kwargs
+            Accepted for compatibility with the base ``Index`` interface
+            (e.g. ``batch_size``). Ignored by WARP, which manages batching
+            internally.
+        """
+        if isinstance(documents_ids, str):
+            documents_ids = [documents_ids]
+
+        documents_embeddings_torch = convert_embeddings_to_torch(documents_embeddings)
+
+        documents_ids_to_warp_ids = self._load_documents_ids_to_warp_ids()
+        warp_ids_to_documents_ids = self._load_warp_ids_to_documents_ids()
+
+        if not self.is_indexed:
+            self.warp.create(
+                embeddings_source=documents_embeddings_torch,
+                device=self.device,
+                kmeans_niters=self.kmeans_niters,
+                max_points_per_centroid=self.max_points_per_centroid,
+                nbits=self.nbits,
+                n_samples_kmeans=self.n_samples_kmeans,
+                seed=self.seed,
+                use_triton_kmeans=self.use_triton,
+                show_progress=self.show_progress,
+            )
+            warp_ids = list(range(len(documents_embeddings_torch)))
+            self.is_indexed = True
+        else:
+            warp_ids = self.warp.add(
+                embeddings_source=documents_embeddings_torch,
+                reload=True,
+                min_outliers=self.min_outliers,
+                max_growth_rate=self.max_growth_rate,
+                max_points_per_centroid=self.max_points_per_centroid,
+                show_progress=self.show_progress,
+            )
+
+        self._ensure_loaded()
+
+        documents_ids_to_warp_ids.update(zip(documents_ids, warp_ids))
+        warp_ids_to_documents_ids.update(zip(warp_ids, documents_ids))
+        self._save_mappings(documents_ids_to_warp_ids, warp_ids_to_documents_ids)
+
+        return self
+
+    def remove_documents(self, documents_ids: list[str]) -> "WARP":
+        """Remove documents from the index.
+
+        Uses WARP's tombstone deletion followed by an immediate compaction so
+        that disk space is reclaimed and tombstoned passages are physically
+        removed on every call.
+
+        Parameters
+        ----------
+        documents_ids
+            The document IDs to remove.
+        """
+        documents_ids_to_warp_ids = self._load_documents_ids_to_warp_ids()
+        warp_ids_to_documents_ids = self._load_warp_ids_to_documents_ids()
+
+        warp_ids_to_remove = []
+        for document_id in documents_ids:
+            if document_id in documents_ids_to_warp_ids:
+                warp_id = documents_ids_to_warp_ids[document_id]
+                warp_ids_to_remove.append(warp_id)
+                del documents_ids_to_warp_ids[document_id]
+                del warp_ids_to_documents_ids[warp_id]
+
+        if warp_ids_to_remove:
+            self.warp.delete(warp_ids_to_remove)
+            self.warp.compact(reload=True, show_progress=self.show_progress)
+
+        self._save_mappings(documents_ids_to_warp_ids, warp_ids_to_documents_ids)
+        return self
+
+    def update_documents(
+        self,
+        documents_ids: list[str],
+        documents_embeddings: list[np.ndarray | torch.Tensor],
+    ) -> "WARP":
+        """Update document embeddings in-place, preserving passage IDs.
+
+        More efficient than delete + add when re-indexing changed documents.
+
+        Parameters
+        ----------
+        documents_ids
+            The document IDs to update. Must already exist in the index.
+        documents_embeddings
+            The new embeddings for each document.
+        """
+        documents_embeddings_torch = convert_embeddings_to_torch(documents_embeddings)
+        documents_ids_to_warp_ids = self._load_documents_ids_to_warp_ids()
+
+        warp_ids = [
+            documents_ids_to_warp_ids[doc_id]
+            for doc_id in documents_ids
+            if doc_id in documents_ids_to_warp_ids
+        ]
+
+        if warp_ids:
+            self.warp.update(
+                passage_ids=warp_ids,
+                embeddings_source=documents_embeddings_torch,
+                reload=True,
+                show_progress=self.show_progress,
+            )
+
+        return self
+
+    def __call__(
+        self,
+        queries_embeddings: np.ndarray
+        | torch.Tensor
+        | list[np.ndarray]
+        | list[torch.Tensor],
+        k: int = 10,
+        subset: list[list[str]] | list[str] | None = None,
+    ) -> list[list[RerankResult]]:
+        """Query the index for the nearest neighbors of the query embeddings.
+
+        Parameters
+        ----------
+        queries_embeddings
+            The query embeddings.
+        k
+            The number of nearest neighbors to return.
+        subset
+            Optional subset of document IDs to restrict search to.
+            Can be a single list (same filter applied to all queries) or
+            a list of lists (per-query filter; must match the number of queries).
+
+        Returns
+        -------
+        List of lists containing RerankResult with 'id' and 'score' keys.
+        """
+        if not self.is_indexed:
+            raise ValueError(
+                "The index is empty. Please add documents before querying."
+            )
+
+        self._ensure_loaded()
+
+        warp_ids_to_documents_ids = self._load_warp_ids_to_documents_ids()
+        documents_ids_to_warp_ids = self._load_documents_ids_to_warp_ids()
+
+        queries_embeddings = convert_embeddings_to_torch(queries_embeddings)
+
+        # Convert subset from document IDs to WARP passage IDs
+        warp_subset = None
+        if subset is not None:
+            if len(subset) == 0:
+                warp_subset = []
+            elif isinstance(subset[0], list):
+                # Per-query subsets
+                warp_subset = [
+                    [
+                        documents_ids_to_warp_ids[doc_id]
+                        for doc_id in query_subset
+                        if doc_id in documents_ids_to_warp_ids
+                    ]
+                    for query_subset in subset
+                ]
+            else:
+                # Shared subset for all queries
+                warp_subset = [
+                    documents_ids_to_warp_ids[doc_id]
+                    for doc_id in subset
+                    if doc_id in documents_ids_to_warp_ids
+                ]
+
+        search_results = self.warp.search(
+            queries_embeddings=queries_embeddings,
+            top_k=k,
+            nprobe=self.n_ivf_probe,
+            bound=self.bound,
+            t_prime=self.t_prime,
+            max_candidates=self.max_candidates,
+            centroid_score_threshold=self.centroid_score_threshold,
+            batch_size=self.batch_size,
+            num_threads=self.num_threads,
+            subset=warp_subset,
+            show_progress=self.show_progress,
+        )
+
+        results = []
+        for query_results in search_results:
+            query_docs = []
+            seen = set()
+            for warp_id, score in query_results:
+                if warp_id in warp_ids_to_documents_ids:
+                    doc_id = warp_ids_to_documents_ids[warp_id]
+                    if doc_id not in seen:
+                        seen.add(doc_id)
+                        query_docs.append(RerankResult(id=doc_id, score=float(score)))
+            results.append(query_docs)
+
+        return results
+
+    def get_documents_embeddings(
+        self, document_ids: list[list[str]]
+    ) -> list[list[list[int | float]]]:
+        """Get document embeddings by their IDs.
+
+        Not supported — WARP stores embeddings in compressed/quantized form.
+        """
+        raise NotImplementedError(
+            "WARP does not provide direct access to document embeddings. "
+            "The embeddings are stored in compressed/quantized form and cannot "
+            "be retrieved."
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ eval = ["ranx >= 0.3.16", "beir >= 2.0.0"]
 api = ["fastapi >= 0.114.1", "uvicorn >= 0.30.6", "batched >= 0.1.2"]
 voyager = ["voyager >= 2.0.9"]
 scann = ["scann >= 1.4.2"]
+warp = ["xtr-warp-rs == 2.0.2.*"]
 
 
 [dependency-groups]

--- a/tests/test_delete_parity.py
+++ b/tests/test_delete_parity.py
@@ -1,0 +1,151 @@
+"""Parity tests asserting that ``FastPlaid`` and ``WARP`` produce the same
+user-facing behavior across delete + re-add sequences.
+
+The internal numeric passage IDs of the two engines diverge under deletion
+(FastPlaid renumbers, WARP tombstones), but the user-facing string IDs the
+caller passed to ``add_documents`` must remain stable and consistent across
+both backends. These tests pin that contract so a future change to either
+backend cannot silently break swap-in compatibility.
+"""
+
+import shutil
+import uuid
+
+import pytest
+
+from pylate import indexes, models
+
+pytest.importorskip("xtr_warp")
+
+
+def _make_model():
+    return models.ColBERT(
+        model_name_or_path="lightonai/GTE-ModernColBERT-v1",
+        device="cpu",
+        model_kwargs={"attn_implementation": "eager"},
+    )
+
+
+def _make_index(backend: str, folder: str, name: str):
+    if backend == "plaid":
+        return indexes.PLAID(
+            index_folder=folder,
+            index_name=name,
+            override=True,
+            use_fast=True,
+            nbits=2,
+            kmeans_niters=1,
+        )
+    if backend == "warp":
+        return indexes.WARP(
+            index_folder=folder,
+            index_name=name,
+            override=True,
+            device="cpu",
+            n_ivf_probe=32,
+            centroid_score_threshold=0.0,
+            nbits=2,
+            kmeans_niters=1,
+        )
+    raise ValueError(backend)
+
+
+def _ids(matches):
+    """Flatten a single-query ``__call__`` result into a set of doc IDs."""
+    return {m["id"] for m in matches[0]}
+
+
+@pytest.mark.parametrize("backend", ["plaid", "warp"])
+def test_delete_keeps_higher_ids_addressable(backend):
+    """Deleting a document with a lower passage-id must not invalidate
+    higher-id documents on either backend.
+
+    Scenario:
+      1. Add A, B, C, D, E.
+      2. Delete B (the second-lowest internal id).
+      3. The remaining A, C, D, E must all be findable by their original
+         user-facing ids — even though FastPlaid will renumber internally
+         and WARP will tombstone.
+      4. Add F. F must be findable; B must not reappear.
+      5. Delete A (the lowest remaining). C, D, E, F must still be findable.
+    """
+    random_hash = uuid.uuid4().hex
+    folder = f"test_indexes_{random_hash}"
+    name = f"{backend}_{random_hash}"
+
+    try:
+        index = _make_index(backend, folder, name)
+        model = _make_model()
+
+        documents = [
+            "Document about apples and their nutritional benefits.",
+            "Document about bananas and their vitamin content.",
+            "Document about cherries and antioxidants.",
+            "Document about dates and natural sugars.",
+            "Document about elderberries and immune support.",
+        ]
+        embeddings = model.encode(documents, is_query=False)
+        index.add_documents(
+            documents_ids=["A", "B", "C", "D", "E"],
+            documents_embeddings=embeddings,
+        )
+
+        query = model.encode(["fruit nutrition"], is_query=True)
+
+        # Step 1: all five present.
+        assert _ids(index(query, k=10)) == {"A", "B", "C", "D", "E"}
+
+        # Step 2: delete a lower-id document (B).
+        index.remove_documents(["B"])
+        # Step 3: higher-id documents stay addressable, B is gone.
+        assert _ids(index(query, k=10)) == {"A", "C", "D", "E"}
+
+        # Step 4: add a new document. Its user-facing id must work
+        # regardless of how the backend assigns the internal id.
+        f_embedding = model.encode(
+            ["Document about figs and dietary fiber."], is_query=False
+        )
+        index.add_documents(documents_ids=["F"], documents_embeddings=f_embedding)
+        assert _ids(index(query, k=10)) == {"A", "C", "D", "E", "F"}
+
+        # Step 5: delete the lowest remaining id and check the rest.
+        index.remove_documents(["A"])
+        assert _ids(index(query, k=10)) == {"C", "D", "E", "F"}
+    finally:
+        shutil.rmtree(folder, ignore_errors=True)
+
+
+@pytest.mark.parametrize("backend", ["plaid", "warp"])
+def test_delete_then_readd_same_id(backend):
+    """A user-facing id that has been deleted must be re-usable: re-adding
+    it should make it findable again on both backends, regardless of the
+    internal renumbering scheme.
+    """
+    random_hash = uuid.uuid4().hex
+    folder = f"test_indexes_{random_hash}"
+    name = f"{backend}_{random_hash}"
+
+    try:
+        index = _make_index(backend, folder, name)
+        model = _make_model()
+
+        documents = [
+            "Document about apples.",
+            "Document about bananas.",
+            "Document about cherries.",
+        ]
+        embeddings = model.encode(documents, is_query=False)
+        index.add_documents(
+            documents_ids=["A", "B", "C"], documents_embeddings=embeddings
+        )
+
+        index.remove_documents(["B"])
+
+        # Re-add an id that was just deleted, with new content.
+        new_embedding = model.encode(["Document about blueberries."], is_query=False)
+        index.add_documents(documents_ids=["B"], documents_embeddings=new_embedding)
+
+        query = model.encode(["fruit"], is_query=True)
+        assert _ids(index(query, k=10)) == {"A", "B", "C"}
+    finally:
+        shutil.rmtree(folder, ignore_errors=True)

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -1,0 +1,359 @@
+"""Test suite for WARP index."""
+
+import shutil
+import uuid
+
+import pytest
+
+from pylate import indexes, models
+
+pytest.importorskip("xtr_warp")
+
+
+@pytest.fixture()
+def warp_index(request):
+    """Create a WARP index with test-friendly defaults and clean up afterwards.
+
+    Pass extra kwargs via ``@pytest.mark.parametrize`` indirect or
+    ``request.param``; otherwise uses aggressive search parameters to
+    ensure full recall on tiny test indexes.
+    """
+    extra = getattr(request, "param", {}) or {}
+    random_hash = uuid.uuid4().hex
+    folder = f"test_indexes_{random_hash}"
+    defaults = dict(
+        index_folder=folder,
+        index_name=f"warp_{random_hash}",
+        override=True,
+        device="cpu",
+        n_ivf_probe=32,
+        centroid_score_threshold=0.0,
+        nbits=2,
+        kmeans_niters=1,
+    )
+    defaults.update(extra)
+    index = indexes.WARP(**defaults)
+    yield index, folder
+    shutil.rmtree(folder, ignore_errors=True)
+
+
+def _make_model():
+    return models.ColBERT(
+        model_name_or_path="lightonai/GTE-ModernColBERT-v1",
+        device="cpu",
+        model_kwargs={"attn_implementation": "eager"},
+    )
+
+
+def test_warp_add_and_search(warp_index):
+    """Test basic add + search workflow."""
+    index, _ = warp_index
+    model = _make_model()
+
+    documents = [
+        "Document about apples and their nutritional benefits.",
+        "Document about bananas and their vitamin content.",
+        "Document about cherries and antioxidants.",
+        "Document about dates and natural sugars.",
+        "Document about elderberries and immune support.",
+    ]
+    embeddings = model.encode(documents, is_query=False)
+    index.add_documents(
+        documents_ids=["0", "1", "2", "3", "4"], documents_embeddings=embeddings
+    )
+
+    query_embedding = model.encode(["fruits and nutrition"], is_query=True)
+    matches = index(query_embedding, k=10)
+
+    assert len(matches[0]) == 5, "Should return all 5 documents"
+    returned_ids = {m["id"] for m in matches[0]}
+    assert returned_ids == {"0", "1", "2", "3", "4"}
+
+
+def test_warp_delete_single(warp_index):
+    """Test deleting a single document."""
+    index, _ = warp_index
+    model = _make_model()
+
+    documents = [
+        "Document about apples and their nutritional benefits.",
+        "Document about bananas and their vitamin content.",
+        "Document about cherries and antioxidants.",
+        "Document about dates and natural sugars.",
+        "Document about elderberries and immune support.",
+    ]
+    embeddings = model.encode(documents, is_query=False)
+    index.add_documents(
+        documents_ids=["0", "1", "2", "3", "4"], documents_embeddings=embeddings
+    )
+
+    index.remove_documents(["1"])
+
+    query_embedding = model.encode(["fruits and nutrition"], is_query=True)
+    matches = index(query_embedding, k=10)
+
+    assert len(matches[0]) == 4
+    returned_ids = {m["id"] for m in matches[0]}
+    assert returned_ids == {"0", "2", "3", "4"}
+
+
+def test_warp_delete_multiple_at_once(warp_index):
+    """Test deleting multiple documents in one call."""
+    index, _ = warp_index
+    model = _make_model()
+
+    documents = [
+        "Document A about nutrition.",
+        "Document B about health.",
+        "Document C about wellness.",
+        "Document D about fitness.",
+        "Document E about diet.",
+    ]
+    embeddings = model.encode(documents, is_query=False)
+    index.add_documents(
+        documents_ids=["A", "B", "C", "D", "E"], documents_embeddings=embeddings
+    )
+
+    index.remove_documents(["B", "D"])
+
+    query_embedding = model.encode(["health and wellness"], is_query=True)
+    matches = index(query_embedding, k=10)
+
+    assert len(matches[0]) == 3
+    returned_ids = {m["id"] for m in matches[0]}
+    assert returned_ids == {"A", "C", "E"}
+
+
+def test_warp_delete_sequential(warp_index):
+    """Test multiple sequential deletions."""
+    index, _ = warp_index
+    model = _make_model()
+
+    documents = [
+        "Document about apples and their nutritional benefits.",
+        "Document about bananas and their vitamin content.",
+        "Document about cherries and antioxidants.",
+        "Document about dates and natural sugars.",
+        "Document about elderberries and immune support.",
+    ]
+    embeddings = model.encode(documents, is_query=False)
+    index.add_documents(
+        documents_ids=["0", "1", "2", "3", "4"], documents_embeddings=embeddings
+    )
+
+    query_embedding = model.encode(["fruits and nutrition"], is_query=True)
+
+    index.remove_documents(["1"])
+    matches = index(query_embedding, k=10)
+    assert {m["id"] for m in matches[0]} == {"0", "2", "3", "4"}
+
+    index.remove_documents(["3"])
+    matches = index(query_embedding, k=10)
+    assert {m["id"] for m in matches[0]} == {"0", "2", "4"}
+
+    index.remove_documents(["0"])
+    matches = index(query_embedding, k=10)
+    assert {m["id"] for m in matches[0]} == {"2", "4"}
+
+
+def test_warp_delete_and_add(warp_index):
+    """Test that adding documents after deletion works correctly."""
+    index, _ = warp_index
+    model = _make_model()
+
+    documents = [
+        "First document about fruits.",
+        "Second document about vegetables.",
+        "Third document about grains.",
+    ]
+    embeddings = model.encode(documents, is_query=False)
+    index.add_documents(documents_ids=["1", "2", "3"], documents_embeddings=embeddings)
+
+    index.remove_documents(["2"])
+
+    new_doc = ["Fourth document about legumes."]
+    new_embedding = model.encode(new_doc, is_query=False)
+    index.add_documents(documents_ids=["4"], documents_embeddings=new_embedding)
+
+    query_embedding = model.encode(["food and nutrition"], is_query=True)
+    matches = index(query_embedding, k=10)
+
+    assert len(matches[0]) == 3
+    returned_ids = {m["id"] for m in matches[0]}
+    assert returned_ids == {"1", "3", "4"}
+
+
+def test_warp_delete_nonexistent(warp_index):
+    """Test that deleting a non-existent document doesn't cause errors."""
+    index, _ = warp_index
+    model = _make_model()
+
+    documents = ["Document 1", "Document 2"]
+    embeddings = model.encode(documents, is_query=False)
+    index.add_documents(documents_ids=["1", "2"], documents_embeddings=embeddings)
+
+    index.remove_documents(["999"])
+
+    query_embedding = model.encode(["document"], is_query=True)
+    matches = index(query_embedding, k=10)
+    returned_ids = {m["id"] for m in matches[0]}
+    assert returned_ids == {"1", "2"}
+
+
+def test_warp_reload_after_delete():
+    """Test that a fresh WARP instance correctly loads state after deletion."""
+    random_hash = uuid.uuid4().hex
+    folder = f"test_indexes_{random_hash}"
+    name = f"warp_{random_hash}"
+
+    try:
+        index = indexes.WARP(
+            index_folder=folder,
+            index_name=name,
+            override=True,
+            device="cpu",
+            n_ivf_probe=32,
+            centroid_score_threshold=0.0,
+            nbits=2,
+            kmeans_niters=1,
+        )
+        model = _make_model()
+
+        documents = [
+            "Document X about machine learning.",
+            "Document Y about artificial intelligence.",
+            "Document Z about deep learning.",
+        ]
+        embeddings = model.encode(documents, is_query=False)
+        index.add_documents(
+            documents_ids=["X", "Y", "Z"], documents_embeddings=embeddings
+        )
+
+        index.remove_documents(["Y"])
+        del index
+
+        # Reload from disk
+        index = indexes.WARP(
+            index_folder=folder,
+            index_name=name,
+            override=False,
+            device="cpu",
+            n_ivf_probe=32,
+            centroid_score_threshold=0.0,
+            nbits=2,
+            kmeans_niters=1,
+        )
+
+        query_embedding = model.encode(["AI and ML"], is_query=True)
+        matches = index(query_embedding, k=10)
+
+        returned_ids = {m["id"] for m in matches[0]}
+        assert returned_ids == {"X", "Z"}
+
+        del index
+    finally:
+        shutil.rmtree(folder, ignore_errors=True)
+
+
+def test_warp_subset_search(warp_index):
+    """Test searching with a subset filter."""
+    index, _ = warp_index
+    model = _make_model()
+
+    documents = [
+        "Document about apples.",
+        "Document about bananas.",
+        "Document about cherries.",
+        "Document about dates.",
+    ]
+    embeddings = model.encode(documents, is_query=False)
+    index.add_documents(
+        documents_ids=["A", "B", "C", "D"], documents_embeddings=embeddings
+    )
+
+    query_embedding = model.encode(["fruit"], is_query=True)
+
+    # Search only within subset
+    matches = index(query_embedding, k=10, subset=["A", "C"])
+    returned_ids = {m["id"] for m in matches[0]}
+    assert returned_ids <= {"A", "C"}, (
+        f"Results should only contain subset documents, got {returned_ids}"
+    )
+
+
+def test_warp_update_documents(warp_index):
+    """Test updating document embeddings in-place."""
+    index, _ = warp_index
+    model = _make_model()
+
+    documents = [
+        "Document about apples and their nutritional benefits.",
+        "Document about bananas and their vitamin content.",
+        "Document about cherries and antioxidants.",
+    ]
+    embeddings = model.encode(documents, is_query=False)
+    index.add_documents(documents_ids=["A", "B", "C"], documents_embeddings=embeddings)
+
+    # Replace B's embedding with something about space
+    new_embedding = model.encode(
+        ["Document about rockets and space exploration."], is_query=False
+    )
+    index.update_documents(documents_ids=["B"], documents_embeddings=new_embedding)
+
+    # B should now rank higher for a space query than a fruit query
+    space_query = model.encode(["rockets and space"], is_query=True)
+    matches = index(space_query, k=3)
+    returned_ids = [m["id"] for m in matches[0]]
+    assert "B" in returned_ids
+
+    # All three documents should still be present
+    fruit_query = model.encode(["fruits and nutrition"], is_query=True)
+    matches = index(fruit_query, k=10)
+    assert {m["id"] for m in matches[0]} == {"A", "B", "C"}
+
+
+def test_warp_per_query_subset(warp_index):
+    """Test searching with per-query subset filters."""
+    index, _ = warp_index
+    model = _make_model()
+
+    documents = [
+        "Document about apples.",
+        "Document about bananas.",
+        "Document about cherries.",
+        "Document about dates.",
+    ]
+    embeddings = model.encode(documents, is_query=False)
+    index.add_documents(
+        documents_ids=["A", "B", "C", "D"], documents_embeddings=embeddings
+    )
+
+    queries = model.encode(["apples", "dates"], is_query=True)
+
+    # Each query gets its own subset
+    matches = index(queries, k=10, subset=[["A", "B"], ["C", "D"]])
+    assert {m["id"] for m in matches[0]} <= {"A", "B"}
+    assert {m["id"] for m in matches[1]} <= {"C", "D"}
+
+
+@pytest.mark.parametrize(
+    "warp_index",
+    [{"dtype": __import__("torch").float32, "mmap": True}],
+    indirect=True,
+)
+def test_warp_dtype_and_mmap(warp_index):
+    """Test that dtype and mmap parameters are accepted and work."""
+    index, _ = warp_index
+    model = _make_model()
+
+    documents = [
+        "Document about apples.",
+        "Document about bananas.",
+        "Document about cherries.",
+    ]
+    embeddings = model.encode(documents, is_query=False)
+    index.add_documents(documents_ids=["A", "B", "C"], documents_embeddings=embeddings)
+
+    query_embedding = model.encode(["fruit"], is_query=True)
+    matches = index(query_embedding, k=10)
+    assert {m["id"] for m in matches[0]} == {"A", "B", "C"}


### PR DESCRIPTION
## Summary

- Add a new **WARP** index backend wrapping [xtr-warp-rs](https://github.com/pau-mensa/xtr-warp-rs) and export it from `pylate.indexes`
- Implement `add_documents`, `remove_documents` (with auto-compaction), and search with optional document ID filtering (shared or per-query)
- Add `update_documents` and `compact` as new public methods not present in the base Index class. `update_documents` replaces embeddings in-place without delete+add, `compact` physically removes tombstoned passages, empty centroids and reclaims disk space
- Expose all xtr-warp-rs hyperparameters via two config dataclasses (`WARPSearchConfig`, `WARPIndexingConfig`) to keep the constructor clean
- Extract shared embedding conversion utilities (`convert_embeddings_to_torch`) into `pylate/indexes/utils.py` for reuse across WARP and FastPLAID
- Add xtr-warp-rs as an optional dependency
- Add 12 focused WARP unit tests

## Tests

- `python -m pytest tests/test_warp.py`