### PR TITLE
Release v1.5.1

### DIFF
--- a/pylate/__version__.py
+++ b/pylate/__version__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-VERSION = (1, 5, 0)
+VERSION = (1, 5, 1)
 
 __version__ = ".".join(map(str, VERSION))


### PR DESCRIPTION
Bump version `1.5.0` → `1.5.1` for a new patch release.

Changes included since `v1.5.0`:
- Add support for late-interaction-kernels (LIK) (#222)
- Add optional flash-maxsim backend to pylate.scores (#212)
- Update CI to Python 3.10/3.14, bump fast-plaid to 1.4.6.2110, extend FastPlaid API (#204)
- Bump ujson 5.10.0 → 5.12.0 (#218)
- Add Agent-ModernColBERT boilerplate (#220)

Once merged, tag the merge commit `v1.5.1` to trigger the PyPI publish workflow.