### PR TITLE
Bump tachiom pin to 0.3.3 and add small-corpus test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ api = ["fastapi >= 0.114.1", "uvicorn >= 0.30.6", "batched >= 0.1.2"]
 voyager = ["voyager >= 2.0.9; python_version < '3.14'"]
 scann = ["scann >= 1.4.2; python_version < '3.14'"]
 warp = ["xtr-warp-rs == 2.0.3.*"]
-tachiom = ["tachiom >=0.3.1,<0.4.0"]
+tachiom = ["tachiom >=0.3.3,<0.4.0"]
 flash-maxsim = ["flash-maxsim >= 0.2.1"]
 lik = [
     "late-interaction-kernels >=0.4.0,<0.5.0",

--- a/tests/test_tachiom.py
+++ b/tests/test_tachiom.py
@@ -278,3 +278,24 @@ def test_tachiom_empty_index_raises(tachiom_index, model):
 
     with pytest.raises(ValueError, match="index is empty"):
         index.get_documents_embeddings([["0"]])
+
+
+def test_tachiom_add_documents_too_few_tokens_raises(tachiom_index, model):
+    """Test that a corpus with too few tokens for PQ training raises ValueError."""
+    index, _ = tachiom_index
+
+    # Far fewer than the 256 tokens PQ codebook training requires.
+    documents = [
+        "Document about apples and their nutritional benefits.",
+        "Document about bananas and their vitamin content.",
+        "Document about cherries and antioxidants.",
+        "Document about dates and natural sugars.",
+        "Document about elderberries and immune support.",
+    ]
+    embeddings = model.encode(documents, is_query=False, output_value=None)
+
+    with pytest.raises(ValueError, match="256"):
+        index.add_documents(documents_ids=DOCUMENT_IDS, documents_embeddings=embeddings)
+
+    # The failed build must not leave the index in a partially-built state.
+    assert index.is_indexed is False


### PR DESCRIPTION
## Summary
- Bump `tachiom` pin to `>=0.3.3,<0.4.0`
- Add a test covering the new `ValueError` for corpora with <256 tokens

## Why
Follow-up to #223. tachiom 0.3.3:
- Fixes a process abort (Rust panic crossing the PyO3 boundary) when the
  corpus has fewer than 256 tokens (PQ codebook training requires 256
  centroids/subspace). Now raises a clear `ValueError`.
- Restores ~2x performance on PyPI release wheels (AVX2 codegen via
  `target-cpu=x86-64-v3`), which had regressed vs locally-built wheels.

## Test plan
- [x] `make lint` (clean)
- [x] `pytest tests/test_tachiom.py` — 10 passed