### PR TITLE
ColPali rebase

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -38,4 +38,4 @@ jobs:
         run: uv run --extra dev pytest tests -m "model_loading" --durations=5
 
       - name: Run other tests
-        run: uv run --extra dev --extra voyager --extra scann --extra warp --extra lik pytest ${{ matrix.test-target }} -m "not model_loading" -n auto --durations=5
+        run: uv run --extra dev --extra image --extra voyager --extra scann --extra warp --extra lik pytest ${{ matrix.test-target }} -m "not model_loading" -n auto --durations=5

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ trainer = SentenceTransformerTrainer(
     eval_dataset=eval_dataset,
     loss=train_loss,
     evaluator=dev_evaluator,
-    data_collator=utils.ColBERTCollator(model.tokenize),
+    data_collator=utils.ColBERTCollator(model.preprocess),
 )
 # Start the training process
 trainer.train()
@@ -214,7 +214,7 @@ trainer = SentenceTransformerTrainer(
     args=args,
     train_dataset=train,
     loss=train_loss,
-    data_collator=utils.ColBERTCollator(tokenize_fn=model.tokenize),
+    data_collator=utils.ColBERTCollator(preprocess_fn=model.preprocess),
 )
 
 # Start the training process

--- a/docs/documentation/training.md
+++ b/docs/documentation/training.md
@@ -83,7 +83,7 @@ trainer = SentenceTransformerTrainer(
     eval_dataset=eval_dataset,
     loss=train_loss,
     evaluator=dev_evaluator,
-    data_collator=utils.ColBERTCollator(model.tokenize),
+    data_collator=utils.ColBERTCollator(model.preprocess),
 )
 # Start the training process
 trainer.train()
@@ -179,7 +179,7 @@ trainer = SentenceTransformerTrainer(
     args=args,
     train_dataset=train,
     loss=train_loss,
-    data_collator=utils.ColBERTCollator(tokenize_fn=model.tokenize),
+    data_collator=utils.ColBERTCollator(preprocess_fn=model.preprocess),
 )
 
 # Start the training process

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,7 +108,7 @@ trainer = SentenceTransformerTrainer(
     eval_dataset=eval_dataset,
     loss=train_loss,
     evaluator=dev_evaluator,
-    data_collator=utils.ColBERTCollator(model.tokenize),
+    data_collator=utils.ColBERTCollator(model.preprocess),
 )
 # Start the training process
 trainer.train()
@@ -214,7 +214,7 @@ trainer = SentenceTransformerTrainer(
     args=args,
     train_dataset=train,
     loss=train_loss,
-    data_collator=utils.ColBERTCollator(tokenize_fn=model.tokenize),
+    data_collator=utils.ColBERTCollator(preprocess_fn=model.preprocess),
 )
 
 # Start the training process

--- a/docs/models/models.md
+++ b/docs/models/models.md
@@ -50,7 +50,7 @@ If you do not want to use the dense layers of the ST model (but still want to us
 ```python
 
 import torch
-from sentence_transformers.models import Transformer
+from sentence_transformers.base.modules import Transformer
 from pylate import models
 
 base_model = Transformer("answerdotai/ModernBERT-base")
@@ -122,7 +122,7 @@ ColBERT(
     [MixedBread study](https://arxiv.org/abs/2510.12327) showed that it is beneficial to use MLPs to do the projection rather than a simple dense layer. The study explores different depths, activation functions and the use of residual layers. Please check the paper for a more thorough analysis.
     ```python
     import torch
-    from sentence_transformers.models import Transformer
+    from sentence_transformers.base.modules import Transformer
     from pylate import models
 
     base_model = Transformer("jhu-clsp/ettin-encoder-32m")

--- a/examples/train/ColBERT-zero/distillation.py
+++ b/examples/train/ColBERT-zero/distillation.py
@@ -140,7 +140,7 @@ def main():
         loss=train_loss,
         evaluator=dev_evaluator,
         data_collator=utils.ColBERTCollator(
-            tokenize_fn=model.tokenize,
+            preprocess_fn=model.preprocess,
             prompts=(
                 {"query": QUERY_PROMPT, "documents": CORPUS_PROMPT}
                 if not args.no_prompts

--- a/examples/train/ColBERT-zero/supervised.py
+++ b/examples/train/ColBERT-zero/supervised.py
@@ -7,7 +7,9 @@ from sentence_transformers import (
     SentenceTransformerTrainer,
     SentenceTransformerTrainingArguments,
 )
-from sentence_transformers.sentence_transformer.training_args import MultiDatasetBatchSamplers
+from sentence_transformers.sentence_transformer.training_args import (
+    MultiDatasetBatchSamplers,
+)
 
 from pylate import evaluation, losses, models, utils
 

--- a/examples/train/ColBERT-zero/supervised.py
+++ b/examples/train/ColBERT-zero/supervised.py
@@ -7,7 +7,7 @@ from sentence_transformers import (
     SentenceTransformerTrainer,
     SentenceTransformerTrainingArguments,
 )
-from sentence_transformers.training_args import MultiDatasetBatchSamplers
+from sentence_transformers.sentence_transformer.training_args import MultiDatasetBatchSamplers
 
 from pylate import evaluation, losses, models, utils
 

--- a/examples/train/ColBERT-zero/supervised.py
+++ b/examples/train/ColBERT-zero/supervised.py
@@ -189,7 +189,7 @@ def main():
         loss=train_loss,
         evaluator=dev_evaluator,
         data_collator=utils.ColBERTCollator(
-            tokenize_fn=model.tokenize,
+            preprocess_fn=model.preprocess,
             prompts=(
                 {
                     "query": QUERY_PROMPT,

--- a/examples/train/ColBERT-zero/unsupervised.py
+++ b/examples/train/ColBERT-zero/unsupervised.py
@@ -7,7 +7,9 @@ from sentence_transformers import (
     SentenceTransformerTrainer,
     SentenceTransformerTrainingArguments,
 )
-from sentence_transformers.sentence_transformer.training_args import MultiDatasetBatchSamplers
+from sentence_transformers.sentence_transformer.training_args import (
+    MultiDatasetBatchSamplers,
+)
 
 from pylate import evaluation, losses, models, utils
 

--- a/examples/train/ColBERT-zero/unsupervised.py
+++ b/examples/train/ColBERT-zero/unsupervised.py
@@ -7,7 +7,7 @@ from sentence_transformers import (
     SentenceTransformerTrainer,
     SentenceTransformerTrainingArguments,
 )
-from sentence_transformers.training_args import MultiDatasetBatchSamplers
+from sentence_transformers.sentence_transformer.training_args import MultiDatasetBatchSamplers
 
 from pylate import evaluation, losses, models, utils
 

--- a/examples/train/ColBERT-zero/unsupervised.py
+++ b/examples/train/ColBERT-zero/unsupervised.py
@@ -195,7 +195,7 @@ def main():
         loss=train_loss,
         evaluator=dev_evaluator,
         data_collator=utils.ColBERTCollator(
-            tokenize_fn=model.tokenize,
+            preprocess_fn=model.preprocess,
             prompts=(
                 {"query": QUERY_PROMPT, "document": CORPUS_PROMPT}
                 if not args.no_prompts

--- a/examples/train/contrastive.py
+++ b/examples/train/contrastive.py
@@ -61,7 +61,7 @@ trainer = SentenceTransformerTrainer(
     eval_dataset=eval_dataset,
     loss=train_loss,
     evaluator=dev_evaluator,
-    data_collator=utils.ColBERTCollator(model.tokenize),
+    data_collator=utils.ColBERTCollator(model.preprocess),
 )
 # Start the training process
 trainer.train()

--- a/examples/train/gte_modern_colbert.py
+++ b/examples/train/gte_modern_colbert.py
@@ -69,7 +69,7 @@ trainer = SentenceTransformerTrainer(
     train_dataset=train,
     loss=train_loss,
     evaluator=dev_evaluator,
-    data_collator=utils.ColBERTCollator(tokenize_fn=model.tokenize),
+    data_collator=utils.ColBERTCollator(preprocess_fn=model.preprocess),
 )
 
 # Start the training process

--- a/examples/train/knowledge_distillation.py
+++ b/examples/train/knowledge_distillation.py
@@ -64,7 +64,7 @@ trainer = SentenceTransformerTrainer(
     args=args,
     train_dataset=train,
     loss=train_loss,
-    data_collator=utils.ColBERTCollator(tokenize_fn=model.tokenize),
+    data_collator=utils.ColBERTCollator(preprocess_fn=model.preprocess),
 )
 
 # Start the training process

--- a/examples/train/lateon_code/fine_tuning.py
+++ b/examples/train/lateon_code/fine_tuning.py
@@ -15,7 +15,9 @@ from sentence_transformers import (
     SentenceTransformerTrainingArguments,
 )
 from sentence_transformers.base.sampler import MultiDatasetDefaultBatchSampler
-from sentence_transformers.sentence_transformer.training_args import MultiDatasetBatchSamplers
+from sentence_transformers.sentence_transformer.training_args import (
+    MultiDatasetBatchSamplers,
+)
 
 from pylate import losses, models
 

--- a/examples/train/lateon_code/fine_tuning.py
+++ b/examples/train/lateon_code/fine_tuning.py
@@ -15,7 +15,7 @@ from sentence_transformers import (
     SentenceTransformerTrainingArguments,
 )
 from sentence_transformers.base.sampler import MultiDatasetDefaultBatchSampler
-from sentence_transformers.training_args import MultiDatasetBatchSamplers
+from sentence_transformers.sentence_transformer.training_args import MultiDatasetBatchSamplers
 
 from pylate import losses, models
 

--- a/examples/train/lateon_code/fine_tuning.py
+++ b/examples/train/lateon_code/fine_tuning.py
@@ -14,7 +14,7 @@ from sentence_transformers import (
     SentenceTransformerTrainer,
     SentenceTransformerTrainingArguments,
 )
-from sentence_transformers.sampler import MultiDatasetDefaultBatchSampler
+from sentence_transformers.base.sampler import MultiDatasetDefaultBatchSampler
 from sentence_transformers.training_args import MultiDatasetBatchSamplers
 
 from pylate import losses, models
@@ -381,7 +381,7 @@ def main():
     )
 
     data_collator = ColBERTCollatorSampleNeg(
-        tokenize_fn=model.tokenize, num_negatives=15
+        tokenize_fn=model.preprocess, num_negatives=15
     )
     trainer = SentenceTransformerTrainer(
         model=model,

--- a/examples/train/lateon_code/fine_tuning.py
+++ b/examples/train/lateon_code/fine_tuning.py
@@ -383,7 +383,7 @@ def main():
     )
 
     data_collator = ColBERTCollatorSampleNeg(
-        tokenize_fn=model.preprocess, num_negatives=15
+        preprocess_fn=model.preprocess, num_negatives=15
     )
     trainer = SentenceTransformerTrainer(
         model=model,

--- a/examples/train/lateon_code/pre-training.py
+++ b/examples/train/lateon_code/pre-training.py
@@ -237,7 +237,7 @@ def main():
         },
     )
     data_collator = ColBERTCollatorSampleNeg(
-        tokenize_fn=model.tokenize, num_negatives=15
+        tokenize_fn=model.preprocess, num_negatives=15
     )
     # Initialize and run trainer
     trainer = SentenceTransformerTrainer(

--- a/examples/train/lateon_code/pre-training.py
+++ b/examples/train/lateon_code/pre-training.py
@@ -12,7 +12,9 @@ from sentence_transformers import (
     SentenceTransformerTrainer,
     SentenceTransformerTrainingArguments,
 )
-from sentence_transformers.sentence_transformer.training_args import MultiDatasetBatchSamplers
+from sentence_transformers.sentence_transformer.training_args import (
+    MultiDatasetBatchSamplers,
+)
 
 from pylate import losses, models
 

--- a/examples/train/lateon_code/pre-training.py
+++ b/examples/train/lateon_code/pre-training.py
@@ -12,7 +12,7 @@ from sentence_transformers import (
     SentenceTransformerTrainer,
     SentenceTransformerTrainingArguments,
 )
-from sentence_transformers.training_args import MultiDatasetBatchSamplers
+from sentence_transformers.sentence_transformer.training_args import MultiDatasetBatchSamplers
 
 from pylate import losses, models
 

--- a/examples/train/lateon_code/pre-training.py
+++ b/examples/train/lateon_code/pre-training.py
@@ -239,7 +239,7 @@ def main():
         },
     )
     data_collator = ColBERTCollatorSampleNeg(
-        tokenize_fn=model.preprocess, num_negatives=15
+        preprocess_fn=model.preprocess, num_negatives=15
     )
     # Initialize and run trainer
     trainer = SentenceTransformerTrainer(

--- a/examples/train/multimodal_colbert.py
+++ b/examples/train/multimodal_colbert.py
@@ -1,0 +1,74 @@
+"""Example script for training a multimodal ColBERT model (ColPali/ColQwen style).
+
+This demonstrates visual document retrieval where queries are text and documents are images,
+using a Vision-Language Model (VLM) as the backbone.
+"""
+
+from __future__ import annotations
+
+from datasets import load_dataset
+from sentence_transformers import (
+    SentenceTransformerTrainer,
+    SentenceTransformerTrainingArguments,
+)
+
+from pylate import losses, models, utils
+
+# Define the base VLM model
+model_name = "Qwen/Qwen2-VL-2B-Instruct"  # Replace with your VLM of choice
+batch_size = 4  # VLMs require smaller batch sizes due to memory
+num_train_epochs = 1
+run_name = "multimodal-colbert-qwen2vl"
+output_dir = f"output/{run_name}"
+
+# Initialize the ColBERT model from a VLM
+# processor_kwargs controls image processing parameters
+model = models.ColBERT(
+    model_name_or_path=model_name,
+    processor_kwargs={"min_pixels": 28 * 28, "max_pixels": 600 * 600},
+    document_length=1024,  # VLMs produce more tokens per image
+    trust_remote_code=True,
+)
+
+# Load a multimodal dataset with text queries and image documents
+# The dataset should have columns like: "query" (str), "positive" (PIL Image), "negative" (PIL Image)
+# Example: dataset = load_dataset("your-org/visual-retrieval-dataset", split="train")
+
+# For demonstration, we show the expected format:
+# Each row should contain:
+#   - "query": a text query string
+#   - "positive": a PIL Image (the relevant document image)
+#   - "negative": a PIL Image (an irrelevant document image)
+
+# Define the loss function
+train_loss = losses.Contrastive(model=model)
+
+# Configure training arguments
+args = SentenceTransformerTrainingArguments(
+    output_dir=output_dir,
+    num_train_epochs=num_train_epochs,
+    per_device_train_batch_size=batch_size,
+    fp16=False,
+    bf16=True,
+    run_name=run_name,
+    learning_rate=2e-5,
+    logging_steps=10,
+)
+
+# The collator handles mixed-modality batches:
+# - Text query columns are tokenized with prefix insertion and query expansion
+# - Image document columns are processed through the VLM processor
+# trainer = SentenceTransformerTrainer(
+#     model=model,
+#     args=args,
+#     train_dataset=train_dataset,
+#     loss=train_loss,
+#     data_collator=utils.ColBERTCollator(preprocess_fn=model.preprocess),
+# )
+
+# trainer.train()
+# model.save_pretrained(f"{output_dir}/final")
+
+print("Multimodal ColBERT example setup complete.")
+print(f"Model supports modalities: {model.modalities}")
+print("To train, uncomment the trainer section and provide a multimodal dataset.")

--- a/examples/train/multimodal_colbert.py
+++ b/examples/train/multimodal_colbert.py
@@ -6,13 +6,11 @@ using a Vision-Language Model (VLM) as the backbone.
 
 from __future__ import annotations
 
-from datasets import load_dataset
 from sentence_transformers import (
-    SentenceTransformerTrainer,
     SentenceTransformerTrainingArguments,
 )
 
-from pylate import losses, models, utils
+from pylate import losses, models
 
 # Define the base VLM model
 model_name = "Qwen/Qwen2-VL-2B-Instruct"  # Replace with your VLM of choice

--- a/examples/train/multimodal_colbert.py
+++ b/examples/train/multimodal_colbert.py
@@ -1,72 +1,564 @@
-"""Example script for training a multimodal ColBERT model (ColPali/ColQwen style).
+"""Train a ColPali-style late-interaction retriever on Qwen3.5-4B.
 
-This demonstrates visual document retrieval where queries are text and documents are images,
-using a Vision-Language Model (VLM) as the backbone.
+The model is trained with LoRA + contrastive loss on two KD-mined datasets:
+  - lightonai/colpali-train-fine-tuning + lightonai/colpali-train-images
+    (ViDoRe v1/v2 domains: arxiv_qa, tatdqa, docvqa, pdf, infographic_vqa)
+  - lightonai/llamaindex-vdr-fine-tuning + lightonai/llamaindex-vdr-images
+    (VDR-multilingual: de, en, es, fr, it)
+Both fine-tuning datasets share the same layout: a "queries" config
+(query_id -> text), a "documents" config (document_id -> image_filename),
+and a "scores" config where each row holds a query_id plus document_ids
+ranked by a teacher score (first document = positive, the rest are negative
+candidates). Images live in a separate dataset keyed by image_filename.
+
+For each query we keep the positive image plus up to MAX_NEGATIVES hard
+negatives whose teacher score is below NV_THRESHOLD * positive_score (to
+avoid false negatives), then sample SAMPLE_NEGATIVES of them per batch at
+transform time.
+
+Usage:
+    accelerate launch --mixed_precision=bf16 colpali_qwen_3_5_vidore_v1v2_vdr_v2_clean.py
 """
 
 from __future__ import annotations
 
+import io
+import logging
+import os
+import random
+
+from accelerate import PartialState
+from PIL import Image as PIL_Image
+from datasets import (
+    Dataset,
+    DatasetDict,
+    Image as DatasetImage,
+    load_dataset,
+    load_from_disk,
+)
+from peft import LoraConfig, TaskType
+from pylate import evaluation, losses, models, utils
 from sentence_transformers import (
+    SentenceTransformerTrainer,
     SentenceTransformerTrainingArguments,
 )
+from sentence_transformers.sampler import NoDuplicatesBatchSampler
+from transformers import AutoModelForImageTextToText
 
-from pylate import losses, models
+logging.basicConfig(level=logging.WARNING, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger(__name__)
 
-# Define the base VLM model
-model_name = "Qwen/Qwen2-VL-2B-Instruct"  # Replace with your VLM of choice
-batch_size = 4  # VLMs require smaller batch sizes due to memory
-num_train_epochs = 1
-run_name = "multimodal-colbert-qwen2vl"
-output_dir = f"output/{run_name}"
+# ── Run config ───────────────────────────────────────────────────────────────
+# "native": use the processor's built-in chat template.
+# "colpali": use the minimal ColPali-style template defined below.
+CHAT_TEMPLATE_VARIANT = "native"
 
-# Initialize the ColBERT model from a VLM
-# processor_kwargs controls image processing parameters
-model = models.ColBERT(
-    model_name_or_path=model_name,
-    processor_kwargs={"min_pixels": 28 * 28, "max_pixels": 600 * 600},
-    document_length=1024,  # VLMs produce more tokens per image
-    trust_remote_code=True,
+RUN_NAME = f"qwen3_5_4b_colpali_contrastive_vidore_v1v2_vdr_v2_{CHAT_TEMPLATE_VARIANT}_3e-5"
+OUTPUT_DIR = f"models/{RUN_NAME}"
+WANDB_PROJECT = "multimodal_pylate"
+
+# ── Model config ─────────────────────────────────────────────────────────────
+MODEL_NAME = "Qwen/Qwen3.5-4B"
+TORCH_DTYPE = "bfloat16"
+ATTN_IMPLEMENTATION = "flash_attention_3"
+EMBEDDING_SIZE = 128       # ColBERT projection dim
+QUERY_LENGTH = 48
+DOCUMENT_LENGTH = 1024
+MIN_PIXELS = 3136          # 4 x 28x28 patches minimum
+MAX_PIXELS = 1_003_520     # match ColNomic
+MAX_SEQ_LENGTH = 4096
+
+# ── Chat template ────────────────────────────────────────────────────────────
+# Text paired with every document image, so documents render as
+# "<vision tokens> + prompt" instead of vision tokens alone. Whether it must
+# be passed explicitly depends on the chat template variant:
+#   - "native": the processor's built-in template adds no text to an
+#     image-only message, so the prompt MUST be attached to each document —
+#     in the train transform ({"image": ..., "text": DOCUMENT_PROMPT}) and
+#     via the evaluator's document_prompt argument.
+#   - "colpali": the custom template below already falls back to
+#     DOCUMENT_PROMPT when the message carries no text item, so documents
+#     could be passed as bare images (drop the "text" key in the transform
+#     and set document_prompt=None in the evaluator) with identical results.
+# We always attach it explicitly so both variants see the exact same inputs;
+# whatever you choose, train and eval must be consistent.
+DOCUMENT_PROMPT = "Describe the image."
+
+# Minimal ColPali-style template: images render as
+# "<|im_start|>user\n<vision tokens>{prompt}<|im_end|><|endoftext|>",
+# text-only inputs (queries) render as the raw text with no chat wrapping.
+QWEN_VL_COLPALI_CHAT_TEMPLATE = (
+    "{%- set msg = messages[0] -%}"
+    "{%- set ns = namespace(has_image=false, text='') -%}"
+    "{%- for item in msg.content -%}"
+    "{%- if item.type == 'image' -%}{%- set ns.has_image = true -%}"
+    "{%- elif item.type == 'text' -%}{%- set ns.text = item.text -%}"
+    "{%- endif -%}"
+    "{%- endfor -%}"
+    "{%- if ns.has_image -%}"
+    "<|im_start|>user\n"
+    "<|vision_start|><|image_pad|><|vision_end|>"
+    "{{ ns.text if ns.text else '" + DOCUMENT_PROMPT + "' }}"
+    "<|im_end|><|endoftext|>"
+    "{%- else -%}"
+    "{{ ns.text }}"
+    "{%- endif -%}"
 )
 
-# Load a multimodal dataset with text queries and image documents
-# The dataset should have columns like: "query" (str), "positive" (PIL Image), "negative" (PIL Image)
-# Example: dataset = load_dataset("your-org/visual-retrieval-dataset", split="train")
+CHAT_TEMPLATE = QWEN_VL_COLPALI_CHAT_TEMPLATE if CHAT_TEMPLATE_VARIANT == "colpali" else None
 
-# For demonstration, we show the expected format:
-# Each row should contain:
-#   - "query": a text query string
-#   - "positive": a PIL Image (the relevant document image)
-#   - "negative": a PIL Image (an irrelevant document image)
+# ── LoRA config ──────────────────────────────────────────────────────────────
+# Qwen3.5 mixes full self-attention layers (q/k/v/o_proj) with linear-attention
+# layers (in_proj_qkv/in_proj_z/out_proj), so both sets must be targeted to
+# cover all 32 LM layers. The vision encoder blocks are frozen, but the
+# vision->LM merger (linear_fc1/fc2) is adapted.
+LORA_R = 32
+LORA_ALPHA = 32
+LORA_DROPOUT = 0.1
+LORA_TARGET_MODULES = [
+    # LM self-attention layers
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    # LM linear-attention layers
+    "in_proj_qkv",
+    "in_proj_z",
+    "out_proj",
+    # LM MLP (all layers)
+    "down_proj",
+    "gate_proj",
+    "up_proj",
+    # Vision merger (vision-to-LM bridge)
+    "linear_fc1",
+    "linear_fc2",
+]
+LORA_EXCLUDE_MODULES = "visual.blocks.*"  # freeze vision encoder; merger stays adapted
 
-# Define the loss function
-train_loss = losses.Contrastive(model=model)
+# ── Trainer / loss config ────────────────────────────────────────────────────
+TEMPERATURE = 0.02
+BATCH_SIZE = 32
+MINI_BATCH_SIZE = 4        # CachedContrastive gradient-cache chunk size
+LEARNING_RATE = 3e-5
+WARMUP_RATIO = 0.005
+MAX_STEPS = 3125
+SEED = 42
+EVAL_STEPS = 250
+DDP_TIMEOUT = 14400        # 4h — rank-0 ViDoRe eval on the 4B backbone blocks other ranks
 
-# Configure training arguments
-args = SentenceTransformerTrainingArguments(
-    output_dir=output_dir,
-    num_train_epochs=num_train_epochs,
-    per_device_train_batch_size=batch_size,
-    fp16=False,
-    bf16=True,
-    run_name=run_name,
-    learning_rate=2e-5,
-    logging_steps=10,
-)
+# ── Data: ColPali (ViDoRe) ───────────────────────────────────────────────────
+KD_HUB_DATASET = "lightonai/colpali-train-fine-tuning"
+IMAGE_HUB_DATASET = "lightonai/colpali-train-images"
+SPLITS = ["arxiv_qa", "tatdqa", "docvqa", "pdf", "infographic_vqa"]
 
-# The collator handles mixed-modality batches:
-# - Text query columns are tokenized with prefix insertion and query expansion
-# - Image document columns are processed through the VLM processor
-# trainer = SentenceTransformerTrainer(
-#     model=model,
-#     args=args,
-#     train_dataset=train_dataset,
-#     loss=train_loss,
-#     data_collator=utils.ColBERTCollator(preprocess_fn=model.preprocess),
-# )
+# ── Data: VDR-multilingual ───────────────────────────────────────────────────
+VDR_KD_DATASET = "lightonai/llamaindex-vdr-fine-tuning"
+VDR_IMAGE_HUB_DATASET = "lightonai/llamaindex-vdr-images"
+VDR_LANGUAGES = ["de", "en", "es", "fr", "it"]
 
-# trainer.train()
-# model.save_pretrained(f"{output_dir}/final")
+# ── Negative filtering / sampling ────────────────────────────────────────────
+NV_THRESHOLD = 0.95    # keep negatives with score < threshold * positive_score
+MAX_NEGATIVES = 20     # max negatives stored per query
+MIN_NEGATIVES = 1      # queries with fewer valid negatives are dropped
+SAMPLE_NEGATIVES = 3   # negatives sampled per query at transform time
 
-print("Multimodal ColBERT example setup complete.")
-print(f"Model supports modalities: {model.modalities}")
-print("To train, uncomment the trainer section and provide a multimodal dataset.")
+# ── Eval config ──────────────────────────────────────────────────────────────
+EVAL_BATCH_SIZE = 16
+EVAL_CORPUS_CHUNK_SIZE = 32
+
+
+# ── Model fixups ─────────────────────────────────────────────────────────────
+# I fix it has been fixed in newer version but letting it there just in case
+def fix_qwen35_backbone_weights(model: models.ColBERT) -> None:
+    """Reload the LM tower via AutoModelForImageTextToText if it loaded broken.
+
+    Some transformers versions load the Qwen3.5 multimodal checkpoint with the
+    language_model weights left uninitialised (all-zero layernorms). Detect
+    that and swap in a correctly loaded copy. Must run BEFORE adding LoRA.
+    """
+    transformer = model[0]
+    probe = transformer.model.language_model.layers[0].input_layernorm.weight
+    if float(probe.abs().sum().item()) != 0.0:
+        log.warning("Qwen3.5 LM tower loaded correctly (layernorm sum != 0) — no fix needed.")
+        return
+
+    log.warning(
+        "Qwen3.5 LM tower loaded BROKEN (layernorm sum == 0) — reloading via "
+        "AutoModelForImageTextToText."
+    )
+    wrapper = AutoModelForImageTextToText.from_pretrained(
+        MODEL_NAME,
+        torch_dtype=TORCH_DTYPE,
+        attn_implementation=ATTN_IMPLEMENTATION,
+        trust_remote_code=True,
+    )
+    target_device = next(transformer.model.parameters()).device
+    transformer.model = wrapper.to(target_device).model
+    del wrapper
+
+    probe = transformer.model.language_model.layers[0].input_layernorm.weight
+    if float(probe.abs().sum().item()) == 0.0:
+        raise RuntimeError(
+            "Qwen3.5 language_model weights still uninitialised after the "
+            "AutoModelForImageTextToText reload — the multimodal loading path "
+            "has regressed. Inspect Qwen3_5Model.base_model_prefix."
+        )
+    log.info("Applied Qwen3.5 LM-tower fix (reloaded via AutoModelForImageTextToText).")
+
+
+def verify_chat_template(model: models.ColBERT) -> None:
+    """Render a document (image + prompt) and a text-only query and log both."""
+    processor = model[0].processor
+    kwargs = getattr(model[0], "processing_kwargs", {}).get("chat_template", {})
+    dummy = PIL_Image.new("RGB", (28, 28), color="white")
+
+    doc_messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image", "image": dummy},
+                {"type": "text", "text": DOCUMENT_PROMPT},
+            ],
+        }
+    ]
+    query_messages = [
+        {"role": "user", "content": [{"type": "text", "text": "What is shown here?"}]}
+    ]
+
+    doc_render = processor.apply_chat_template(doc_messages, tokenize=False, **kwargs)
+    query_render = processor.apply_chat_template(query_messages, tokenize=False, **kwargs)
+    log.info(
+        "Chat-template render check (variant=%r):\n  DOCUMENT:\n%s\n  QUERY:\n%s",
+        CHAT_TEMPLATE_VARIANT,
+        doc_render,
+        query_render,
+    )
+
+# ── Data loading ─────────────────────────────────────────────────────────────
+
+def build_image_index(images_ds: Dataset) -> dict[str, int]:
+    """Map image_filename -> row index for fast lookup."""
+    filenames = images_ds.with_format(None)["image_filename"]
+    return {name: i for i, name in enumerate(filenames)}
+
+
+def load_seer_images() -> Dataset:
+    """Load the seer-colpali image dataset from the Hub, without decoding."""
+    log.info("Loading image dataset %s...", IMAGE_HUB_DATASET)
+    images_ds = load_dataset(IMAGE_HUB_DATASET, split="train")
+    # Keep raw bytes; PIL decoding happens lazily in the batch transform.
+    return images_ds.cast_column("image", DatasetImage(decode=False))
+
+
+def load_vdr_images() -> Dataset:
+    """Load the VDR image dataset from the Hub, without decoding."""
+    log.info("Loading VDR image dataset %s...", VDR_IMAGE_HUB_DATASET)
+    images_ds = load_dataset(VDR_IMAGE_HUB_DATASET, split="train")
+    return images_ds.cast_column("image", DatasetImage(decode=False))
+
+
+def _filter_negatives(
+    doc_ids: list[int],
+    score_values: list[float],
+    doc_index: dict[int, int],
+    all_doc_filenames: list[str],
+    image_index: dict[str, int],
+) -> list[int]:
+    """Return image indices for negatives passing the nv-threshold filter.
+
+    doc_ids[0] is the positive; negatives scoring too close to it (likely
+    false negatives) are discarded.
+    """
+    threshold = NV_THRESHOLD * score_values[0]
+    valid = []
+    for j in range(1, len(doc_ids)):
+        if score_values[j] < threshold:
+            fname = all_doc_filenames[doc_index[doc_ids[j]]]
+            if fname in image_index:
+                valid.append(image_index[fname])
+                if len(valid) >= MAX_NEGATIVES:
+                    break
+    return valid
+
+
+def load_kd_split(hub_dataset: str, split: str, image_index: dict[str, int]) -> Dataset:
+    """Load one KD split and filter negatives.
+
+    Produces rows of (query text, positive image index, candidate negative
+    image indices). Queries missing their positive image or with fewer than
+    MIN_NEGATIVES valid negatives are dropped.
+    """
+    log.info("Loading split %s/%s...", hub_dataset, split)
+    queries_ds = load_dataset(hub_dataset, "queries", split=split)
+    documents_ds = load_dataset(hub_dataset, "documents", split=split)
+    scores_ds = load_dataset(hub_dataset, "scores", split=split)
+
+    query_index = {qid: i for i, qid in enumerate(queries_ds["query_id"])}
+    doc_index = {did: i for i, did in enumerate(documents_ds["document_id"])}
+
+    all_queries = queries_ds["query"]
+    all_doc_filenames = documents_ds["image_filename"]
+    all_score_qids = scores_ds["query_id"]
+    all_score_doc_ids = scores_ds["document_ids"]
+    all_scores = scores_ds["scores"]
+
+    rows = {"query": [], "positive_image_idx": [], "negative_image_idxs": []}
+    skipped = 0
+    for i in range(len(scores_ds)):
+        doc_ids = all_score_doc_ids[i]
+        score_values = all_scores[i]
+        if len(doc_ids) < 2:
+            skipped += 1
+            continue
+
+        pos_filename = all_doc_filenames[doc_index[doc_ids[0]]]
+        if pos_filename not in image_index:
+            skipped += 1
+            continue
+
+        valid_negs = _filter_negatives(
+            doc_ids, score_values, doc_index, all_doc_filenames, image_index,
+        )
+        if len(valid_negs) < MIN_NEGATIVES:
+            skipped += 1
+            continue
+
+        rows["query"].append(all_queries[query_index[all_score_qids[i]]])
+        rows["positive_image_idx"].append(image_index[pos_filename])
+        rows["negative_image_idxs"].append(valid_negs)
+
+    log.info(
+        "Split %s: %d rows kept, %d skipped (nv_threshold=%.2f).",
+        split, len(rows["query"]), skipped, NV_THRESHOLD,
+    )
+    return Dataset.from_dict(rows)
+
+
+def make_image_transform(images_ds: Dataset):
+    """Build a set_transform callback that decodes images and samples negatives.
+
+    Rows only store image indices; here we decode the positive image and
+    SAMPLE_NEGATIVES randomly sampled negatives to PIL, pairing each with the
+    document prompt. Undecodable negatives are skipped; if fewer than
+    SAMPLE_NEGATIVES decode, the decoded ones are repeated to fill the slots.
+    """
+
+    def decode(idx: int) -> PIL_Image.Image:
+        image_bytes = images_ds[int(idx)]["image"]["bytes"]
+        return PIL_Image.open(io.BytesIO(image_bytes)).convert("RGB")
+
+    def transform(batch):
+        out = {"query": batch["query"], "image": []}
+        for n in range(SAMPLE_NEGATIVES):
+            out[f"negative_{n}"] = []
+
+        for i in range(len(batch["query"])):
+            pos_pil = decode(batch["positive_image_idx"][i])
+            out["image"].append({"image": pos_pil, "text": DOCUMENT_PROMPT})
+
+            neg_pool = batch["negative_image_idxs"][i]
+            decoded_negs = []
+            for candidate_idx in random.sample(neg_pool, len(neg_pool)):
+                if len(decoded_negs) >= SAMPLE_NEGATIVES:
+                    break
+                try:
+                    decoded_negs.append(decode(candidate_idx))
+                except Exception:
+                    continue
+            for n in range(SAMPLE_NEGATIVES):
+                neg_pil = decoded_negs[n % len(decoded_negs)]
+                out[f"negative_{n}"].append({"image": neg_pil, "text": DOCUMENT_PROMPT})
+        return out
+
+    return transform
+
+
+def prepare_splits(
+    state: PartialState,
+    cache_dir: str,
+    split_names: dict[str, str],
+    load_images_fn,
+    hub_dataset: str,
+) -> dict[str, Dataset]:
+    """Build (rank 0) and load (all ranks) the filtered splits for one source.
+
+    Rank 0 loads the raw KD data, filters negatives, and caches the resulting
+    lightweight splits to disk; the other ranks wait, then every rank
+    memory-maps the cached splits and attaches the image-decoding transform.
+
+    split_names maps the cache/train-dataset name to the Hub split name.
+    """
+    if state.is_main_process:
+        images_ds = load_images_fn()
+        image_index = build_image_index(images_ds)
+        os.makedirs(cache_dir, exist_ok=True)
+        for name, hub_split in split_names.items():
+            path = os.path.join(cache_dir, name)
+            if not os.path.exists(path):
+                log.warning("Building split cache for %s...", name)
+                ds = load_kd_split(hub_dataset, hub_split, image_index)
+                ds.save_to_disk(path)
+                log.warning("Cached %s (%d rows).", name, len(ds))
+        del image_index
+    state.wait_for_everyone()
+    if not state.is_main_process:
+        images_ds = load_images_fn()
+
+    transform = make_image_transform(images_ds)
+    datasets = {}
+    for name in split_names:
+        ds = load_from_disk(os.path.join(cache_dir, name))
+        ds.set_transform(transform)
+        datasets[name] = ds
+    return datasets
+
+
+def main() -> None:
+    os.environ["WANDB_PROJECT"] = WANDB_PROJECT
+
+    # ── 1. Model ─────────────────────────────────────────────────────────────
+    processor_kwargs = {
+        "min_pixels": MIN_PIXELS,
+        "max_pixels": MAX_PIXELS,
+        "model_max_length": MAX_SEQ_LENGTH,
+    }
+    if CHAT_TEMPLATE is not None:
+        processor_kwargs["chat_template"] = {"chat_template": CHAT_TEMPLATE}
+
+    log.info("Loading model %s (chat template: %s)...", MODEL_NAME, CHAT_TEMPLATE_VARIANT)
+    model = models.ColBERT(
+        model_name_or_path=MODEL_NAME,
+        model_kwargs={
+            "attn_implementation": ATTN_IMPLEMENTATION,
+            "torch_dtype": TORCH_DTYPE,
+        },
+        processor_kwargs=processor_kwargs,
+        trust_remote_code=True,
+        embedding_size=EMBEDDING_SIZE,
+        query_prefix="",
+        document_prefix="",
+        query_length=QUERY_LENGTH,
+        document_length=DOCUMENT_LENGTH,
+        do_query_expansion=True,
+        attend_to_expansion_tokens=True,
+    )
+
+    # Fixups must happen before LoRA wraps the modules.
+    fix_qwen35_backbone_weights(model)
+    model[0].unpad_inputs = False
+    verify_chat_template(model)
+    log.info("Model loaded.")
+
+    # ── 2. LoRA ──────────────────────────────────────────────────────────────
+    log.info("Adding LoRA adapter...")
+    lora_config = LoraConfig(
+        task_type=TaskType.FEATURE_EXTRACTION,
+        r=LORA_R,
+        lora_alpha=LORA_ALPHA,
+        lora_dropout=LORA_DROPOUT,
+        target_modules=LORA_TARGET_MODULES,
+        exclude_modules=LORA_EXCLUDE_MODULES,
+    )
+    model.add_adapter(lora_config)
+    log_lora_stats(model)
+
+    # ── 3. Data ──────────────────────────────────────────────────────────────
+    state = PartialState()
+
+    train_datasets = prepare_splits(
+        state,
+        cache_dir=os.path.join(OUTPUT_DIR, ".splits_cache"),
+        split_names={name: name for name in SPLITS},
+        load_images_fn=load_seer_images,
+        hub_dataset=KD_HUB_DATASET,
+    )
+    train_datasets.update(
+        prepare_splits(
+            state,
+            cache_dir=os.path.join(OUTPUT_DIR, ".vdr_splits_cache"),
+            split_names={f"vdr_{lang}": f"train_{lang}" for lang in VDR_LANGUAGES},
+            load_images_fn=load_vdr_images,
+            hub_dataset=VDR_KD_DATASET,
+        )
+    )
+    train_datasets = DatasetDict(train_datasets)
+    log.info(
+        "All training splits loaded: %s",
+        {name: len(ds) for name, ds in train_datasets.items()},
+    )
+
+    # ── 4. Loss ──────────────────────────────────────────────────────────────
+    # CachedContrastive = in-batch contrastive with gradient caching, so the
+    # effective batch (gathered across devices) fits in memory via mini-batches.
+    loss = losses.CachedContrastive(
+        model=model,
+        mini_batch_size=MINI_BATCH_SIZE,
+        gather_across_devices=True,
+        temperature=TEMPERATURE,
+    )
+
+    # ── 5. Trainer ───────────────────────────────────────────────────────────
+    data_collator = utils.ColBERTCollator(preprocess_fn=model.preprocess)
+
+    training_args = SentenceTransformerTrainingArguments(
+        output_dir=OUTPUT_DIR,
+        run_name=RUN_NAME,
+        num_train_epochs=1,
+        max_steps=MAX_STEPS,
+        per_device_train_batch_size=BATCH_SIZE,
+        per_device_eval_batch_size=BATCH_SIZE,
+        learning_rate=LEARNING_RATE,
+        warmup_ratio=WARMUP_RATIO,
+        lr_scheduler_type="cosine_with_min_lr",
+        lr_scheduler_kwargs={"min_lr_rate": 0.1},
+        bf16=True,
+        fp16=False,
+        batch_sampler=NoDuplicatesBatchSampler,
+        accelerator_config={"split_batches": True},
+        multi_dataset_batch_sampler="proportional",
+        eval_strategy="steps",
+        eval_steps=EVAL_STEPS,
+        save_strategy="steps",
+        save_steps=50,
+        save_total_limit=2,
+        logging_steps=1,
+        seed=SEED,
+        dataloader_num_workers=8,
+        ddp_timeout=DDP_TIMEOUT,
+        report_to=["wandb"],
+    )
+
+    # ── 6. Evaluator (ViDoRe v2) ─────────────────────────────────────────────
+    log.info("Building ViDoRe evaluator...")
+    evaluator = evaluation.ViDoREvaluator(
+        dataset_names=["esgreports"],
+        # Must match training: with the native template nothing adds a prompt
+        # to image-only documents, so it has to be passed here too (see the
+        # DOCUMENT_PROMPT comment at the top).
+        document_prompt=DOCUMENT_PROMPT,
+        corpus_chunk_size=EVAL_CORPUS_CHUNK_SIZE,
+        batch_size=EVAL_BATCH_SIZE,
+    )
+
+    # ── 7. Train ─────────────────────────────────────────────────────────────
+    trainer = SentenceTransformerTrainer(
+        model=model,
+        args=training_args,
+        train_dataset=train_datasets,
+        loss=loss,
+        data_collator=data_collator,
+        evaluator=evaluator,
+    )
+    log.info("Starting training...")
+    trainer.train()
+
+    # ── 8. Final eval + save ─────────────────────────────────────────────────
+    log.info("Running post-training evaluation...")
+    evaluator(model)
+    log.info("Saving model to %s...", f"{OUTPUT_DIR}/final")
+    model.save_pretrained(f"{OUTPUT_DIR}/final")
+    log.info("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/train/multimodal_colbert.py
+++ b/examples/train/multimodal_colbert.py
@@ -28,16 +28,17 @@ import os
 import random
 
 from accelerate import PartialState
-from PIL import Image as PIL_Image
 from datasets import (
     Dataset,
     DatasetDict,
-    Image as DatasetImage,
     load_dataset,
     load_from_disk,
 )
+from datasets import (
+    Image as DatasetImage,
+)
 from peft import LoraConfig, TaskType
-from pylate import evaluation, losses, models, utils
+from PIL import Image as PIL_Image
 from sentence_transformers import (
     SentenceTransformerTrainer,
     SentenceTransformerTrainingArguments,
@@ -45,7 +46,11 @@ from sentence_transformers import (
 from sentence_transformers.sampler import NoDuplicatesBatchSampler
 from transformers import AutoModelForImageTextToText
 
-logging.basicConfig(level=logging.WARNING, format="%(asctime)s %(levelname)s %(message)s")
+from pylate import evaluation, losses, models, utils
+
+logging.basicConfig(
+    level=logging.WARNING, format="%(asctime)s %(levelname)s %(message)s"
+)
 log = logging.getLogger(__name__)
 
 # ── Run config ───────────────────────────────────────────────────────────────
@@ -53,7 +58,9 @@ log = logging.getLogger(__name__)
 # "colpali": use the minimal ColPali-style template defined below.
 CHAT_TEMPLATE_VARIANT = "native"
 
-RUN_NAME = f"qwen3_5_4b_colpali_contrastive_vidore_v1v2_vdr_v2_{CHAT_TEMPLATE_VARIANT}_3e-5"
+RUN_NAME = (
+    f"qwen3_5_4b_colpali_contrastive_vidore_v1v2_vdr_v2_{CHAT_TEMPLATE_VARIANT}_3e-5"
+)
 OUTPUT_DIR = f"models/{RUN_NAME}"
 WANDB_PROJECT = "multimodal_pylate"
 
@@ -61,11 +68,11 @@ WANDB_PROJECT = "multimodal_pylate"
 MODEL_NAME = "Qwen/Qwen3.5-4B"
 TORCH_DTYPE = "bfloat16"
 ATTN_IMPLEMENTATION = "flash_attention_3"
-EMBEDDING_SIZE = 128       # ColBERT projection dim
+EMBEDDING_SIZE = 128  # ColBERT projection dim
 QUERY_LENGTH = 48
 DOCUMENT_LENGTH = 1024
-MIN_PIXELS = 3136          # 4 x 28x28 patches minimum
-MAX_PIXELS = 1_003_520     # match ColNomic
+MIN_PIXELS = 3136  # 4 x 28x28 patches minimum
+MAX_PIXELS = 1_003_520  # match ColNomic
 MAX_SEQ_LENGTH = 4096
 
 # ── Chat template ────────────────────────────────────────────────────────────
@@ -105,7 +112,9 @@ QWEN_VL_COLPALI_CHAT_TEMPLATE = (
     "{%- endif -%}"
 )
 
-CHAT_TEMPLATE = QWEN_VL_COLPALI_CHAT_TEMPLATE if CHAT_TEMPLATE_VARIANT == "colpali" else None
+CHAT_TEMPLATE = (
+    QWEN_VL_COLPALI_CHAT_TEMPLATE if CHAT_TEMPLATE_VARIANT == "colpali" else None
+)
 
 # ── LoRA config ──────────────────────────────────────────────────────────────
 # Qwen3.5 mixes full self-attention layers (q/k/v/o_proj) with linear-attention
@@ -138,13 +147,13 @@ LORA_EXCLUDE_MODULES = "visual.blocks.*"  # freeze vision encoder; merger stays 
 # ── Trainer / loss config ────────────────────────────────────────────────────
 TEMPERATURE = 0.02
 BATCH_SIZE = 32
-MINI_BATCH_SIZE = 4        # CachedContrastive gradient-cache chunk size
+MINI_BATCH_SIZE = 4  # CachedContrastive gradient-cache chunk size
 LEARNING_RATE = 3e-5
 WARMUP_RATIO = 0.005
 MAX_STEPS = 3125
 SEED = 42
 EVAL_STEPS = 250
-DDP_TIMEOUT = 14400        # 4h — rank-0 ViDoRe eval on the 4B backbone blocks other ranks
+DDP_TIMEOUT = 14400  # 4h — rank-0 ViDoRe eval on the 4B backbone blocks other ranks
 
 # ── Data: ColPali (ViDoRe) ───────────────────────────────────────────────────
 KD_HUB_DATASET = "lightonai/colpali-train-fine-tuning"
@@ -157,10 +166,10 @@ VDR_IMAGE_HUB_DATASET = "lightonai/llamaindex-vdr-images"
 VDR_LANGUAGES = ["de", "en", "es", "fr", "it"]
 
 # ── Negative filtering / sampling ────────────────────────────────────────────
-NV_THRESHOLD = 0.95    # keep negatives with score < threshold * positive_score
-MAX_NEGATIVES = 20     # max negatives stored per query
-MIN_NEGATIVES = 1      # queries with fewer valid negatives are dropped
-SAMPLE_NEGATIVES = 3   # negatives sampled per query at transform time
+NV_THRESHOLD = 0.95  # keep negatives with score < threshold * positive_score
+MAX_NEGATIVES = 20  # max negatives stored per query
+MIN_NEGATIVES = 1  # queries with fewer valid negatives are dropped
+SAMPLE_NEGATIVES = 3  # negatives sampled per query at transform time
 
 # ── Eval config ──────────────────────────────────────────────────────────────
 EVAL_BATCH_SIZE = 16
@@ -179,7 +188,9 @@ def fix_qwen35_backbone_weights(model: models.ColBERT) -> None:
     transformer = model[0]
     probe = transformer.model.language_model.layers[0].input_layernorm.weight
     if float(probe.abs().sum().item()) != 0.0:
-        log.warning("Qwen3.5 LM tower loaded correctly (layernorm sum != 0) — no fix needed.")
+        log.warning(
+            "Qwen3.5 LM tower loaded correctly (layernorm sum != 0) — no fix needed."
+        )
         return
 
     log.warning(
@@ -226,7 +237,9 @@ def verify_chat_template(model: models.ColBERT) -> None:
     ]
 
     doc_render = processor.apply_chat_template(doc_messages, tokenize=False, **kwargs)
-    query_render = processor.apply_chat_template(query_messages, tokenize=False, **kwargs)
+    query_render = processor.apply_chat_template(
+        query_messages, tokenize=False, **kwargs
+    )
     log.info(
         "Chat-template render check (variant=%r):\n  DOCUMENT:\n%s\n  QUERY:\n%s",
         CHAT_TEMPLATE_VARIANT,
@@ -234,7 +247,9 @@ def verify_chat_template(model: models.ColBERT) -> None:
         query_render,
     )
 
+
 # ── Data loading ─────────────────────────────────────────────────────────────
+
 
 def build_image_index(images_ds: Dataset) -> dict[str, int]:
     """Map image_filename -> row index for fast lookup."""
@@ -317,7 +332,11 @@ def load_kd_split(hub_dataset: str, split: str, image_index: dict[str, int]) -> 
             continue
 
         valid_negs = _filter_negatives(
-            doc_ids, score_values, doc_index, all_doc_filenames, image_index,
+            doc_ids,
+            score_values,
+            doc_index,
+            all_doc_filenames,
+            image_index,
         )
         if len(valid_negs) < MIN_NEGATIVES:
             skipped += 1
@@ -329,7 +348,10 @@ def load_kd_split(hub_dataset: str, split: str, image_index: dict[str, int]) -> 
 
     log.info(
         "Split %s: %d rows kept, %d skipped (nv_threshold=%.2f).",
-        split, len(rows["query"]), skipped, NV_THRESHOLD,
+        split,
+        len(rows["query"]),
+        skipped,
+        NV_THRESHOLD,
     )
     return Dataset.from_dict(rows)
 
@@ -425,7 +447,9 @@ def main() -> None:
     if CHAT_TEMPLATE is not None:
         processor_kwargs["chat_template"] = {"chat_template": CHAT_TEMPLATE}
 
-    log.info("Loading model %s (chat template: %s)...", MODEL_NAME, CHAT_TEMPLATE_VARIANT)
+    log.info(
+        "Loading model %s (chat template: %s)...", MODEL_NAME, CHAT_TEMPLATE_VARIANT
+    )
     model = models.ColBERT(
         model_name_or_path=MODEL_NAME,
         model_kwargs={
@@ -460,7 +484,6 @@ def main() -> None:
         exclude_modules=LORA_EXCLUDE_MODULES,
     )
     model.add_adapter(lora_config)
-    log_lora_stats(model)
 
     # ── 3. Data ──────────────────────────────────────────────────────────────
     state = PartialState()

--- a/examples/train/reason_moderncolbert.py
+++ b/examples/train/reason_moderncolbert.py
@@ -91,7 +91,7 @@ def main():
         args=args,
         train_dataset=train_dataset,
         loss=train_loss,
-        data_collator=utils.ColBERTCollator(model.tokenize),
+        data_collator=utils.ColBERTCollator(model.preprocess),
     )
 
     trainer.train()

--- a/pylate/evaluation/__init__.py
+++ b/pylate/evaluation/__init__.py
@@ -6,7 +6,11 @@ from .colbert_triplet import ColBERTTripletEvaluator
 from .custom_dataset import load_custom_dataset
 from .nano_beir_evaluator import NanoBEIREvaluator
 from .pylate_information_retrieval_evaluator import PyLateInformationRetrievalEvaluator
-from .vidore_evaluator import ViDoREvaluator
+
+try:
+    from .vidore_evaluator import ViDoREvaluator
+except ImportError:
+    pass
 
 __all__ = [
     "ColBERTTripletEvaluator",

--- a/pylate/evaluation/__init__.py
+++ b/pylate/evaluation/__init__.py
@@ -6,11 +6,13 @@ from .colbert_triplet import ColBERTTripletEvaluator
 from .custom_dataset import load_custom_dataset
 from .nano_beir_evaluator import NanoBEIREvaluator
 from .pylate_information_retrieval_evaluator import PyLateInformationRetrievalEvaluator
+from .vidore_evaluator import ViDoREvaluator
 
 __all__ = [
     "ColBERTTripletEvaluator",
     "ColBERTDistillationEvaluator",
     "NanoBEIREvaluator",
+    "ViDoREvaluator",
     "get_beir_triples",
     "load_beir",
     "load_custom_dataset",

--- a/pylate/evaluation/colbert_distillation.py
+++ b/pylate/evaluation/colbert_distillation.py
@@ -139,7 +139,7 @@ class ColBERTDistillationEvaluator(SentenceEvaluator):
         with (
             nullcontext()
             if self.truncate_dim is None
-            else model.truncate_sentence_embeddings(self.truncate_dim)
+            else model.truncate_embeddings(self.truncate_dim)
         ):
             queries_embeddings = torch.nn.utils.rnn.pad_sequence(
                 model.encode(

--- a/pylate/evaluation/colbert_distillation.py
+++ b/pylate/evaluation/colbert_distillation.py
@@ -6,8 +6,8 @@ import os
 from contextlib import nullcontext
 
 import torch
-from sentence_transformers.evaluation.SentenceEvaluator import SentenceEvaluator
-from sentence_transformers.SentenceTransformer import SentenceTransformer
+from sentence_transformers.base.evaluation import SentenceEvaluator
+from sentence_transformers.sentence_transformer.model import SentenceTransformer
 
 from ..scores import colbert_kd_scores
 from .colbert_triplet import csv_writer, evaluation_message

--- a/pylate/evaluation/colbert_triplet.py
+++ b/pylate/evaluation/colbert_triplet.py
@@ -5,7 +5,7 @@ import logging
 import os
 from contextlib import nullcontext
 
-from sentence_transformers.evaluation import TripletEvaluator
+from sentence_transformers.sentence_transformer.evaluation import TripletEvaluator
 
 from ..models import ColBERT
 from ..scores import colbert_scores_pairwise

--- a/pylate/evaluation/colbert_triplet.py
+++ b/pylate/evaluation/colbert_triplet.py
@@ -201,7 +201,7 @@ class ColBERTTripletEvaluator(TripletEvaluator):
         with (
             nullcontext()
             if self.truncate_dim is None
-            else model.truncate_sentence_embeddings(truncate_dim=self.truncate_dim)
+            else model.truncate_embeddings(truncate_dim=self.truncate_dim)
         ):
             embeddings_anchors = model.encode(
                 sentences=self.anchors,

--- a/pylate/evaluation/nano_beir_evaluator.py
+++ b/pylate/evaluation/nano_beir_evaluator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Literal
 
-from sentence_transformers.evaluation.NanoBEIREvaluator import (
+from sentence_transformers.sentence_transformer.evaluation.nano_beir import (
     NanoBEIREvaluator as NanoBEIREvaluatorST,
 )
 from sentence_transformers.util import is_datasets_available

--- a/pylate/evaluation/pylate_information_retrieval_evaluator.py
+++ b/pylate/evaluation/pylate_information_retrieval_evaluator.py
@@ -44,7 +44,7 @@ class PyLateInformationRetrievalEvaluator(InformationRetrievalEvaluator):
         with (
             nullcontext()
             if self.truncate_dim is None
-            else model.truncate_sentence_embeddings(self.truncate_dim)
+            else model.truncate_embeddings(self.truncate_dim)
         ):
             query_embeddings = torch.nn.utils.rnn.pad_sequence(
                 model.encode(
@@ -81,7 +81,7 @@ class PyLateInformationRetrievalEvaluator(InformationRetrievalEvaluator):
                 with (
                     nullcontext()
                     if self.truncate_dim is None
-                    else corpus_model.truncate_sentence_embeddings(self.truncate_dim)
+                    else corpus_model.truncate_embeddings(self.truncate_dim)
                 ):
                     sub_corpus_embeddings = torch.nn.utils.rnn.pad_sequence(
                         corpus_model.encode(

--- a/pylate/evaluation/pylate_information_retrieval_evaluator.py
+++ b/pylate/evaluation/pylate_information_retrieval_evaluator.py
@@ -8,7 +8,9 @@ from contextlib import nullcontext
 from typing import TYPE_CHECKING
 
 import torch
-from sentence_transformers.sentence_transformer.evaluation import InformationRetrievalEvaluator
+from sentence_transformers.sentence_transformer.evaluation import (
+    InformationRetrievalEvaluator,
+)
 from torch import Tensor
 from tqdm import trange
 

--- a/pylate/evaluation/pylate_information_retrieval_evaluator.py
+++ b/pylate/evaluation/pylate_information_retrieval_evaluator.py
@@ -8,7 +8,7 @@ from contextlib import nullcontext
 from typing import TYPE_CHECKING
 
 import torch
-from sentence_transformers.evaluation import InformationRetrievalEvaluator
+from sentence_transformers.sentence_transformer.evaluation import InformationRetrievalEvaluator
 from torch import Tensor
 from tqdm import trange
 

--- a/pylate/evaluation/pylate_information_retrieval_evaluator.py
+++ b/pylate/evaluation/pylate_information_retrieval_evaluator.py
@@ -22,10 +22,10 @@ logger = logging.getLogger(__name__)
 
 class PyLateInformationRetrievalEvaluator(InformationRetrievalEvaluator):
     """
-    This class evaluates an Information Retrieval (IR) setting. This is a direct extension of the InformationRetrievalEvaluator from the sentence-transformers library, only override the compute_metrices method to be compilatible with PyLate models (define asymmetric encoding using is_query params and add padding).
+    This class evaluates an Information Retrieval (IR) setting. This is a direct extension of the InformationRetrievalEvaluator from the sentence-transformers library, only override the compute_all_metrics method to be compilatible with PyLate models (define asymmetric encoding using is_query params and add padding).
     """
 
-    def compute_metrices(
+    def compute_all_metrics(
         self,
         model: ColBERT,
         corpus_model=None,

--- a/pylate/evaluation/pylate_information_retrieval_evaluator.py
+++ b/pylate/evaluation/pylate_information_retrieval_evaluator.py
@@ -25,6 +25,14 @@ class PyLateInformationRetrievalEvaluator(InformationRetrievalEvaluator):
     This class evaluates an Information Retrieval (IR) setting. This is a direct extension of the InformationRetrievalEvaluator from the sentence-transformers library, only override the compute_all_metrics method to be compilatible with PyLate models (define asymmetric encoding using is_query params and add padding).
     """
 
+    def _get_corpus_chunk(self, start: int, end: int) -> list:
+        """Return corpus entries for the given slice.
+
+        Subclasses can override this to decode or transform entries lazily
+        (e.g. decode images from bytes only when the chunk is about to be encoded).
+        """
+        return self.corpus[start:end]
+
     def compute_all_metrics(
         self,
         model: ColBERT,
@@ -85,9 +93,12 @@ class PyLateInformationRetrievalEvaluator(InformationRetrievalEvaluator):
                     if self.truncate_dim is None
                     else corpus_model.truncate_embeddings(self.truncate_dim)
                 ):
+                    corpus_chunk = self._get_corpus_chunk(
+                        corpus_start_idx, corpus_end_idx
+                    )
                     sub_corpus_embeddings = torch.nn.utils.rnn.pad_sequence(
                         corpus_model.encode(
-                            self.corpus[corpus_start_idx:corpus_end_idx],
+                            corpus_chunk,
                             prompt_name=self.corpus_prompt_name,
                             prompt=self.corpus_prompt,
                             is_query=False,

--- a/pylate/evaluation/vidore_evaluator.py
+++ b/pylate/evaluation/vidore_evaluator.py
@@ -224,13 +224,13 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
         ``None`` (default) evaluates every language separately (one
         sub-evaluator per dataset-language pair, matching MTEB).
         V1 datasets are monolingual and always included as-is.
-    document_prompt : str | None
-        Text appended alongside each corpus image
-        (e.g. ``"Describe the image."``).  Defaults to ``None`` (raw images,
-        matching MTEB's processing).  For per-dataset texts, use
-        ``corpus_prompts`` instead (mutually exclusive): it fills the same
-        image-side ``"text"`` slot, keyed by the expanded
-        ``"dataset:language"`` names.
+    corpus_prompts : str | dict[str, str], optional
+        Text rendered alongside each corpus image
+        (e.g. ``"Describe the image."``) — injected as the image-side
+        ``"text"``, not a string prefix.  Defaults to ``None`` (raw images,
+        matching MTEB's processing).  A string applies to all datasets; a
+        dict must be keyed by the expanded ``"dataset:language"`` names.
+        Make sure this matches how the model was trained.
     query_prompts : str | dict[str, str], optional
         Prompt(s) prepended to queries at encode time (e.g. MTEB v3 uses
         ``"Find a screenshot that is relevant to the user's question."``).
@@ -284,23 +284,12 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
         dataset_names: list[DatasetNameType | str] | None = None,
         versions: list[VersionType] | None = None,
         language: str | None = None,
-        document_prompt: str | None = None,
         corpus_chunk_size: int = 32,
         ndcg_at_k: list[int] | None = None,
         batch_size: int = 16,
         **kwargs,
     ) -> None:
-        # corpus_prompts and document_prompt fill the same slot: the text
-        # rendered alongside each corpus image. corpus_prompts (ST-inherited)
-        # additionally supports per-dataset values.
-        if document_prompt is not None and kwargs.get("corpus_prompts") is not None:
-            raise ValueError(
-                "Specify either `document_prompt` (one text for every corpus "
-                "image) or `corpus_prompts` (per-dataset texts), not both."
-            )
-
         # Must be set before super().__init__ calls _load_dataset
-        self.document_prompt = document_prompt
         self._corpus_chunk_size = corpus_chunk_size
 
         if dataset_names is None:
@@ -463,12 +452,11 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
 
         queries = {str(r[qid_col]): r["query"] for r in queries_ds}
 
-        # document_prompt and corpus_prompts fill the same slot: the text
-        # rendered alongside each corpus image (VLM processors render
-        # "<vision tokens> + text", matching colpali_engine's
-        # visual_prompt_prefix). corpus_prompts supports per-dataset values,
-        # keyed by the expanded "dataset:language" names.
-        document_text = self.document_prompt
+        # The corpus prompt is the text rendered alongside each corpus image
+        # (VLM processors render "<vision tokens> + text", matching
+        # colpali_engine's visual_prompt_prefix). Keyed by the expanded
+        # "dataset:language" names.
+        document_text = None
         if self.corpus_prompts is not None:
             document_text = self.corpus_prompts.get(dataset_name)
 

--- a/pylate/evaluation/vidore_evaluator.py
+++ b/pylate/evaluation/vidore_evaluator.py
@@ -167,8 +167,10 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
         Filter queries to a single language (v2/v3 contain multilingual
         queries).  E.g. ``"english"``, ``"french"``, ``"german"``,
         ``"spanish"``, ``"italian"``, ``"portuguese"``.
-        ``None`` (default) keeps all languages.  V1 datasets have no language
-        column and are always included in full.
+        Defaults to ``"english"`` when v2/v3 datasets are included (mixed-
+        language evaluation is not meaningful).  ``None`` is only valid
+        for v1-only evaluation.  V1 datasets have no language column and
+        are always included in full.
     document_prompt : str | None
         Text appended alongside each corpus image
         (e.g. ``"Describe the image."``).  Defaults to ``None`` (raw images,
@@ -210,7 +212,6 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
     ) -> None:
         # Must be set before super().__init__ calls _load_dataset
         self.document_prompt = document_prompt
-        self.language = language.lower() if language else None
         self._corpus_chunk_size = corpus_chunk_size
 
         if dataset_names is None:
@@ -224,6 +225,19 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
                         f"Valid versions: {list(VIDORE_VERSION_DATASETS)}"
                     )
                 dataset_names.extend(VIDORE_VERSION_DATASETS[v].keys())
+
+        has_multilingual = any(
+            dn.lower() in {**VIDORE_V2_DATASETS, **VIDORE_V3_DATASETS}
+            for dn in dataset_names
+        )
+        if language is None and has_multilingual:
+            language = "english"
+            logger.warning(
+                "v2/v3 datasets contain multilingual queries — "
+                "defaulting to language='english'. "
+                "Pass language explicitly to evaluate a different language."
+            )
+        self.language = language.lower() if language else None
 
         has_v3 = any(
             dn.lower() in VIDORE_V3_DATASETS for dn in dataset_names

--- a/pylate/evaluation/vidore_evaluator.py
+++ b/pylate/evaluation/vidore_evaluator.py
@@ -171,12 +171,14 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
         column and are always included in full.
     document_prompt : str | None
         Text appended alongside each corpus image
-        (e.g. ``"Describe the image."``).  Set to ``None`` to pass raw images.
+        (e.g. ``"Describe the image."``).  Defaults to ``None`` (raw images,
+        matching MTEB's processing).
     corpus_chunk_size : int
         Number of corpus documents encoded per forward-pass chunk.
         Keep small (32-64) for image corpora to avoid OOM.
     ndcg_at_k : list[int] | None
-        NDCG cut-offs.  Defaults to ``[5]`` (the ViDoRe canonical metric).
+        NDCG cut-offs.  Defaults to ``[5]`` for v1/v2, ``[5, 10]`` when v3
+        datasets are included (MTEB uses NDCG@10 as main score for v3).
     batch_size : int
         Encoding batch size.
     **kwargs
@@ -200,7 +202,7 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
         dataset_names: list[DatasetNameType | str] | None = None,
         versions: list[VersionType] | None = None,
         language: str | None = None,
-        document_prompt: str | None = "Describe the image.",
+        document_prompt: str | None = None,
         corpus_chunk_size: int = 32,
         ndcg_at_k: list[int] | None = None,
         batch_size: int = 16,
@@ -223,8 +225,13 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
                     )
                 dataset_names.extend(VIDORE_VERSION_DATASETS[v].keys())
 
+        has_v3 = any(
+            dn.lower() in VIDORE_V3_DATASETS for dn in dataset_names
+        )
         if ndcg_at_k is None:
-            ndcg_at_k = [5]
+            ndcg_at_k = [5, 10] if has_v3 else [5]
+        elif has_v3 and 10 not in ndcg_at_k:
+            ndcg_at_k = list(ndcg_at_k) + [10]
 
         super().__init__(
             dataset_names=dataset_names,
@@ -358,11 +365,11 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
             for metric, values in per_metric.items():
                 results[f"ViDoRE_{version}_{metric}"] = sum(values) / len(values)
 
-            ndcg_k = max(self.ndcg_at_k)
+            ndcg_k = 10 if version == "v3" else 5
             for score_name in self.score_function_names:
                 ver_key = f"ViDoRE_{version}_{score_name}_ndcg@{ndcg_k}"
                 if ver_key in results:
-                    logger.info(
+                    logger.warning(
                         f"ViDoRE {version} macro NDCG@{ndcg_k}: {results[ver_key]:.4f}"
                     )
 

--- a/pylate/evaluation/vidore_evaluator.py
+++ b/pylate/evaluation/vidore_evaluator.py
@@ -571,30 +571,28 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
         if output_path is not None and self.write_csv:
             os.makedirs(output_path, exist_ok=True)
             csv_path = os.path.join(output_path, self.csv_file)
-            if not os.path.isfile(csv_path):
-                fOut = open(csv_path, mode="w", encoding="utf-8")
-                fOut.write(",".join(self.csv_headers))
+            mode = "w" if not os.path.isfile(csv_path) else "a"
+            with open(csv_path, mode=mode, encoding="utf-8") as fOut:
+                if mode == "w":
+                    fOut.write(",".join(self.csv_headers))
+                    fOut.write("\n")
+
+                output_data = [epoch, steps]
+                for name in self.score_function_names:
+                    for k in self.accuracy_at_k:
+                        output_data.append(agg_results[f"{name}_accuracy@{k}"])
+                    for k in self.precision_recall_at_k:
+                        output_data.append(agg_results[f"{name}_precision@{k}"])
+                        output_data.append(agg_results[f"{name}_recall@{k}"])
+                    for k in self.mrr_at_k:
+                        output_data.append(agg_results[f"{name}_mrr@{k}"])
+                    for k in self.ndcg_at_k:
+                        output_data.append(agg_results[f"{name}_ndcg@{k}"])
+                    for k in self.map_at_k:
+                        output_data.append(agg_results[f"{name}_map@{k}"])
+
+                fOut.write(",".join(map(str, output_data)))
                 fOut.write("\n")
-            else:
-                fOut = open(csv_path, mode="a", encoding="utf-8")
-
-            output_data = [epoch, steps]
-            for name in self.score_function_names:
-                for k in self.accuracy_at_k:
-                    output_data.append(agg_results[f"{name}_accuracy@{k}"])
-                for k in self.precision_recall_at_k:
-                    output_data.append(agg_results[f"{name}_precision@{k}"])
-                    output_data.append(agg_results[f"{name}_recall@{k}"])
-                for k in self.mrr_at_k:
-                    output_data.append(agg_results[f"{name}_mrr@{k}"])
-                for k in self.ndcg_at_k:
-                    output_data.append(agg_results[f"{name}_ndcg@{k}"])
-                for k in self.map_at_k:
-                    output_data.append(agg_results[f"{name}_map@{k}"])
-
-            fOut.write(",".join(map(str, output_data)))
-            fOut.write("\n")
-            fOut.close()
 
         if not self.primary_metric:
             if self.main_score_function is None:
@@ -688,8 +686,8 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
             for score_name in self.score_function_names:
                 avg_key = f"{base_hr}_{score_name}_ndcg@{ndcg_k}"
                 if avg_key in results:
-                    logger.warning(
-                        f"{base_hr} macro NDCG@{ndcg_k}: {results[avg_key]:.4f}"
+                    logger.info(
+                        "%s macro NDCG@%d: %.4f", base_hr, ndcg_k, results[avg_key]
                     )
 
         # Per-version macro averages
@@ -719,8 +717,11 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
             for score_name in self.score_function_names:
                 ver_key = f"ViDoRE_{version}_{score_name}_ndcg@{ndcg_k}"
                 if ver_key in results:
-                    logger.warning(
-                        f"ViDoRE {version} macro NDCG@{ndcg_k}: {results[ver_key]:.4f}"
+                    logger.info(
+                        "ViDoRE %s macro NDCG@%d: %.4f",
+                        version,
+                        ndcg_k,
+                        results[ver_key],
                     )
 
         return results

--- a/pylate/evaluation/vidore_evaluator.py
+++ b/pylate/evaluation/vidore_evaluator.py
@@ -227,7 +227,16 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
     document_prompt : str | None
         Text appended alongside each corpus image
         (e.g. ``"Describe the image."``).  Defaults to ``None`` (raw images,
-        matching MTEB's processing).
+        matching MTEB's processing).  For per-dataset texts, use
+        ``corpus_prompts`` instead (mutually exclusive): it fills the same
+        image-side ``"text"`` slot, keyed by the expanded
+        ``"dataset:language"`` names.
+    query_prompts : str | dict[str, str], optional
+        Prompt(s) prepended to queries at encode time (e.g. MTEB v3 uses
+        ``"Find a screenshot that is relevant to the user's question."``).
+        A string applies to all datasets; a dict must be keyed by the
+        expanded ``"dataset:language"`` names.  Make sure this matches how
+        the model was trained.
     corpus_chunk_size : int
         Number of corpus documents encoded per forward-pass chunk.
         Keep small (32-64) for image corpora to avoid OOM.
@@ -281,6 +290,15 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
         batch_size: int = 16,
         **kwargs,
     ) -> None:
+        # corpus_prompts and document_prompt fill the same slot: the text
+        # rendered alongside each corpus image. corpus_prompts (ST-inherited)
+        # additionally supports per-dataset values.
+        if document_prompt is not None and kwargs.get("corpus_prompts") is not None:
+            raise ValueError(
+                "Specify either `document_prompt` (one text for every corpus "
+                "image) or `corpus_prompts` (per-dataset texts), not both."
+            )
+
         # Must be set before super().__init__ calls _load_dataset
         self.document_prompt = document_prompt
         self._corpus_chunk_size = corpus_chunk_size
@@ -445,9 +463,18 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
 
         queries = {str(r[qid_col]): r["query"] for r in queries_ds}
 
-        if self.document_prompt:
+        # document_prompt and corpus_prompts fill the same slot: the text
+        # rendered alongside each corpus image (VLM processors render
+        # "<vision tokens> + text", matching colpali_engine's
+        # visual_prompt_prefix). corpus_prompts supports per-dataset values,
+        # keyed by the expanded "dataset:language" names.
+        document_text = self.document_prompt
+        if self.corpus_prompts is not None:
+            document_text = self.corpus_prompts.get(dataset_name)
+
+        if document_text:
             corpus = {
-                str(r[cid_col]): {"image": r["image"], "text": self.document_prompt}
+                str(r[cid_col]): {"image": r["image"], "text": document_text}
                 for r in corpus_ds
             }
         else:
@@ -467,6 +494,15 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
         human_readable_name = self._get_human_readable_name(dataset_name)
 
         ir_evaluator_kwargs["corpus_chunk_size"] = self._corpus_chunk_size
+
+        # Forward the per-dataset query prompt (e.g. MTEB v3's "Find a
+        # screenshot that is relevant to the user's question.") so it is
+        # prepended to queries at encode time, mirroring ST's NanoBEIR.
+        # The corpus prompt is deliberately NOT forwarded: it is injected as
+        # the image-side "text" above, string-prefixing is meaningless for
+        # image corpora.
+        if self.query_prompts is not None:
+            ir_evaluator_kwargs["query_prompt"] = self.query_prompts.get(dataset_name)
 
         evaluator = self.information_retrieval_class(
             queries=queries,

--- a/pylate/evaluation/vidore_evaluator.py
+++ b/pylate/evaluation/vidore_evaluator.py
@@ -125,7 +125,14 @@ DATASET_NAME_TO_HUMAN_READABLE = {
 }
 
 VIDORE_V2_LANGUAGES = ["english", "french", "spanish", "german"]
-VIDORE_V3_LANGUAGES = ["english", "french", "spanish", "german", "italian", "portuguese"]
+VIDORE_V3_LANGUAGES = [
+    "english",
+    "french",
+    "spanish",
+    "german",
+    "italian",
+    "portuguese",
+]
 
 LANGUAGE_SHORT = {
     "english": "En",
@@ -266,9 +273,7 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
                 expanded_names.append(dn_lower)
         dataset_names = expanded_names
 
-        has_v3 = any(
-            dn.split(":")[0] in VIDORE_V3_DATASETS for dn in dataset_names
-        )
+        has_v3 = any(dn.split(":")[0] in VIDORE_V3_DATASETS for dn in dataset_names)
         if ndcg_at_k is None:
             ndcg_at_k = [5, 10] if has_v3 else [5]
         elif has_v3 and 10 not in ndcg_at_k:
@@ -323,8 +328,7 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
     ) -> PyLateInformationRetrievalEvaluator:
         if not is_datasets_available():
             raise ValueError(
-                "datasets is not available. "
-                "Install it with: pip install datasets"
+                "datasets is not available. Install it with: pip install datasets"
             )
         from datasets import load_dataset
 
@@ -346,9 +350,7 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
         qrel_cid = "corpus-id" if "corpus-id" in qrels_ds.column_names else "corpus_id"
 
         if lang and "language" in queries_ds.column_names:
-            queries_ds = queries_ds.filter(
-                lambda r: r["language"] == lang
-            )
+            queries_ds = queries_ds.filter(lambda r: r["language"] == lang)
 
         queries = {str(r[qid_col]): r["query"] for r in queries_ds}
 

--- a/pylate/evaluation/vidore_evaluator.py
+++ b/pylate/evaluation/vidore_evaluator.py
@@ -448,9 +448,7 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
                 evaluator.corpus_chunk_size,
                 desc="Encoding shared corpus",
             ):
-                end = min(
-                    start + evaluator.corpus_chunk_size, len(evaluator.corpus)
-                )
+                end = min(start + evaluator.corpus_chunk_size, len(evaluator.corpus))
                 corpus_chunk = evaluator._get_corpus_chunk(start, end)
                 chunk_embs = torch.nn.utils.rnn.pad_sequence(
                     model.encode(
@@ -546,8 +544,7 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
                     # New corpus group — free previous, encode this one once
                     del corpus_embeddings
                     logger.info(
-                        "Encoding corpus for %s "
-                        "(%d language variants will reuse it)",
+                        "Encoding corpus for %s (%d language variants will reuse it)",
                         path,
                         corpus_counts[path],
                     )
@@ -555,14 +552,10 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
                     current_corpus_path = path
                 extra_kwargs["corpus_embeddings"] = corpus_embeddings
 
-            evaluation = evaluator(
-                model, output_path, epoch, steps, **extra_kwargs
-            )
+            evaluation = evaluator(model, output_path, epoch, steps, **extra_kwargs)
 
             for full_key, metric_value in evaluation.items():
-                metric = full_key.split(
-                    "_", maxsplit=num_underscores_in_name
-                )[-1]
+                metric = full_key.split("_", maxsplit=num_underscores_in_name)[-1]
                 per_metric_results.setdefault(metric, []).append(metric_value)
                 per_dataset_results[full_key] = metric_value
 
@@ -615,18 +608,14 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
                     ],
                     key=lambda x: x[1],
                 )[0]
-                self.primary_metric = (
-                    f"{score_function}_ndcg@{max(self.ndcg_at_k)}"
-                )
+                self.primary_metric = f"{score_function}_ndcg@{max(self.ndcg_at_k)}"
             else:
-                self.primary_metric = f"{self.main_score_function.value}_ndcg@{max(self.ndcg_at_k)}"
+                self.primary_metric = (
+                    f"{self.main_score_function.value}_ndcg@{max(self.ndcg_at_k)}"
+                )
 
-        avg_queries = np.mean(
-            [len(e.queries) for e in self.evaluators]
-        )
-        avg_corpus = np.mean(
-            [len(e.corpus) for e in self.evaluators]
-        )
+        avg_queries = np.mean([len(e.queries) for e in self.evaluators])
+        avg_corpus = np.mean([len(e.corpus) for e in self.evaluators])
         logger.info("Average Queries: %s", avg_queries)
         logger.info("Average Corpus: %s\n", avg_corpus)
 
@@ -650,17 +639,11 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
                     agg_results[f"{name}_recall@{k}"] * 100,
                 )
             for k in self.mrr_at_k:
-                logger.info(
-                    "MRR@%d: %.4f", k, agg_results[f"{name}_mrr@{k}"]
-                )
+                logger.info("MRR@%d: %.4f", k, agg_results[f"{name}_mrr@{k}"])
             for k in self.ndcg_at_k:
-                logger.info(
-                    "NDCG@%d: %.4f", k, agg_results[f"{name}_ndcg@{k}"]
-                )
+                logger.info("NDCG@%d: %.4f", k, agg_results[f"{name}_ndcg@{k}"])
             for k in self.map_at_k:
-                logger.info(
-                    "MAP@%d: %.4f", k, agg_results[f"{name}_map@{k}"]
-                )
+                logger.info("MAP@%d: %.4f", k, agg_results[f"{name}_map@{k}"])
 
         agg_results = self.prefix_name_to_metrics(agg_results, self.name)
         self.store_metrics_in_model_card_data(model, agg_results, epoch, steps)

--- a/pylate/evaluation/vidore_evaluator.py
+++ b/pylate/evaluation/vidore_evaluator.py
@@ -13,9 +13,12 @@ from __future__ import annotations
 
 import gc
 import logging
+import os
+from contextlib import nullcontext
 from io import BytesIO
 from typing import TYPE_CHECKING, Literal
 
+import numpy as np
 import torch
 from datasets import Image as DatasetImage
 from PIL import Image
@@ -23,6 +26,7 @@ from sentence_transformers.sentence_transformer.evaluation.nano_beir import (
     NanoBEIREvaluator as NanoBEIREvaluatorST,
 )
 from sentence_transformers.util import is_datasets_available
+from tqdm import tqdm, trange
 
 from .pylate_information_retrieval_evaluator import PyLateInformationRetrievalEvaluator
 
@@ -414,13 +418,72 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
 
         ir_evaluator_kwargs["corpus_chunk_size"] = self._corpus_chunk_size
 
-        return self.information_retrieval_class(
+        evaluator = self.information_retrieval_class(
             queries=queries,
             corpus=corpus,
             relevant_docs=relevant_docs,
             name=human_readable_name,
             **ir_evaluator_kwargs,
         )
+        evaluator._corpus_dataset_path = dataset_path
+        return evaluator
+
+    # ── Corpus encoding ──────────────────────────────────────────────────
+
+    @staticmethod
+    def _encode_corpus(
+        model: ColBERT,
+        evaluator: ViDoREInformationRetrievalEvaluator,
+    ) -> torch.Tensor:
+        """Encode an evaluator's full corpus into a padded 3D tensor."""
+        chunks: list[torch.Tensor] = []
+        with (
+            nullcontext()
+            if evaluator.truncate_dim is None
+            else model.truncate_embeddings(evaluator.truncate_dim)
+        ):
+            for start in trange(
+                0,
+                len(evaluator.corpus),
+                evaluator.corpus_chunk_size,
+                desc="Encoding shared corpus",
+            ):
+                end = min(
+                    start + evaluator.corpus_chunk_size, len(evaluator.corpus)
+                )
+                corpus_chunk = evaluator._get_corpus_chunk(start, end)
+                chunk_embs = torch.nn.utils.rnn.pad_sequence(
+                    model.encode(
+                        corpus_chunk,
+                        prompt_name=evaluator.corpus_prompt_name,
+                        prompt=evaluator.corpus_prompt,
+                        is_query=False,
+                        batch_size=evaluator.batch_size,
+                        show_progress_bar=False,
+                        convert_to_numpy=False,
+                    ),
+                    batch_first=True,
+                    padding_value=0,
+                )
+                chunks.append(chunk_embs)
+
+        max_tokens = max(c.shape[1] for c in chunks)
+        padded = []
+        for c in chunks:
+            if c.shape[1] < max_tokens:
+                p = torch.zeros(
+                    c.shape[0],
+                    max_tokens - c.shape[1],
+                    c.shape[2],
+                    dtype=c.dtype,
+                    device=c.device,
+                )
+                c = torch.cat([c, p], dim=1)
+            padded.append(c)
+
+        return torch.cat(padded, dim=0)
+
+    # ── Main entry point ───────────────────────────────────────────────
 
     def __call__(
         self,
@@ -431,18 +494,189 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
         *args,
         **kwargs,
     ) -> dict[str, float]:
-        results = super().__call__(model, output_path, epoch, steps, *args, **kwargs)
+        per_metric_results: dict[str, list[float]] = {}
+        per_dataset_results: dict[str, float] = {}
 
-        # Free GPU memory accumulated during evaluation (many sub-evaluators
-        # each encode corpus images, fragmenting the CUDA allocator).  Without
-        # this, training can hang on the first all_gather after eval in DDP.
+        if epoch != -1:
+            out_txt = (
+                f" in epoch {epoch} after {steps} steps"
+                if steps != -1
+                else f" after epoch {epoch}"
+            )
+        else:
+            out_txt = ""
+        if self.truncate_dim is not None:
+            out_txt += f" (truncated to {self.truncate_dim})"
+        logger.info(
+            "ViDoRe Evaluation of the model on %s dataset%s:",
+            self.dataset_names,
+            out_txt,
+        )
+
+        if self.score_functions is None:
+            self.score_functions = {model.similarity_fn_name: model.similarity}
+            self.score_function_names = [model.similarity_fn_name]
+            self._append_csv_headers(self.score_function_names)
+
+        # Identify which corpus paths are shared across language variants
+        corpus_counts: dict[str, int] = {}
+        for evaluator in self.evaluators:
+            path = getattr(evaluator, "_corpus_dataset_path", None)
+            if path:
+                corpus_counts[path] = corpus_counts.get(path, 0) + 1
+        shared_paths = {p for p, c in corpus_counts.items() if c > 1}
+
+        # Iterate evaluators, encoding each shared corpus once and passing
+        # the embeddings to every language variant before freeing it.
+        num_underscores_in_name = self.name.count("_")
+        current_corpus_path: str | None = None
+        corpus_embeddings: torch.Tensor | None = None
+
+        for evaluator in tqdm(
+            self.evaluators,
+            desc="Evaluating datasets",
+            disable=not self.show_progress_bar,
+        ):
+            logger.info("Evaluating %s", evaluator.name)
+            path = getattr(evaluator, "_corpus_dataset_path", None)
+
+            extra_kwargs: dict = {}
+            if path in shared_paths:
+                if path != current_corpus_path:
+                    # New corpus group — free previous, encode this one once
+                    del corpus_embeddings
+                    logger.info(
+                        "Encoding corpus for %s "
+                        "(%d language variants will reuse it)",
+                        path,
+                        corpus_counts[path],
+                    )
+                    corpus_embeddings = self._encode_corpus(model, evaluator)
+                    current_corpus_path = path
+                extra_kwargs["corpus_embeddings"] = corpus_embeddings
+
+            evaluation = evaluator(
+                model, output_path, epoch, steps, **extra_kwargs
+            )
+
+            for full_key, metric_value in evaluation.items():
+                metric = full_key.split(
+                    "_", maxsplit=num_underscores_in_name
+                )[-1]
+                per_metric_results.setdefault(metric, []).append(metric_value)
+                per_dataset_results[full_key] = metric_value
+
+        del corpus_embeddings
+
+        # ── Aggregation (mirrors NanoBEIREvaluatorST) ──────────────────
+
+        agg_results = {
+            metric: self.aggregate_fn(values)
+            for metric, values in per_metric_results.items()
+        }
+
+        if output_path is not None and self.write_csv:
+            os.makedirs(output_path, exist_ok=True)
+            csv_path = os.path.join(output_path, self.csv_file)
+            if not os.path.isfile(csv_path):
+                fOut = open(csv_path, mode="w", encoding="utf-8")
+                fOut.write(",".join(self.csv_headers))
+                fOut.write("\n")
+            else:
+                fOut = open(csv_path, mode="a", encoding="utf-8")
+
+            output_data = [epoch, steps]
+            for name in self.score_function_names:
+                for k in self.accuracy_at_k:
+                    output_data.append(agg_results[f"{name}_accuracy@{k}"])
+                for k in self.precision_recall_at_k:
+                    output_data.append(agg_results[f"{name}_precision@{k}"])
+                    output_data.append(agg_results[f"{name}_recall@{k}"])
+                for k in self.mrr_at_k:
+                    output_data.append(agg_results[f"{name}_mrr@{k}"])
+                for k in self.ndcg_at_k:
+                    output_data.append(agg_results[f"{name}_ndcg@{k}"])
+                for k in self.map_at_k:
+                    output_data.append(agg_results[f"{name}_map@{k}"])
+
+            fOut.write(",".join(map(str, output_data)))
+            fOut.write("\n")
+            fOut.close()
+
+        if not self.primary_metric:
+            if self.main_score_function is None:
+                score_function = max(
+                    [
+                        (
+                            name,
+                            agg_results[f"{name}_ndcg@{max(self.ndcg_at_k)}"],
+                        )
+                        for name in self.score_function_names
+                    ],
+                    key=lambda x: x[1],
+                )[0]
+                self.primary_metric = (
+                    f"{score_function}_ndcg@{max(self.ndcg_at_k)}"
+                )
+            else:
+                self.primary_metric = f"{self.main_score_function.value}_ndcg@{max(self.ndcg_at_k)}"
+
+        avg_queries = np.mean(
+            [len(e.queries) for e in self.evaluators]
+        )
+        avg_corpus = np.mean(
+            [len(e.corpus) for e in self.evaluators]
+        )
+        logger.info("Average Queries: %s", avg_queries)
+        logger.info("Average Corpus: %s\n", avg_corpus)
+
+        for name in self.score_function_names:
+            logger.info("Aggregated for Score Function: %s", name)
+            for k in self.accuracy_at_k:
+                logger.info(
+                    "Accuracy@%d: %.2f%%",
+                    k,
+                    agg_results[f"{name}_accuracy@{k}"] * 100,
+                )
+            for k in self.precision_recall_at_k:
+                logger.info(
+                    "Precision@%d: %.2f%%",
+                    k,
+                    agg_results[f"{name}_precision@{k}"] * 100,
+                )
+                logger.info(
+                    "Recall@%d: %.2f%%",
+                    k,
+                    agg_results[f"{name}_recall@{k}"] * 100,
+                )
+            for k in self.mrr_at_k:
+                logger.info(
+                    "MRR@%d: %.4f", k, agg_results[f"{name}_mrr@{k}"]
+                )
+            for k in self.ndcg_at_k:
+                logger.info(
+                    "NDCG@%d: %.4f", k, agg_results[f"{name}_ndcg@{k}"]
+                )
+            for k in self.map_at_k:
+                logger.info(
+                    "MAP@%d: %.4f", k, agg_results[f"{name}_map@{k}"]
+                )
+
+        agg_results = self.prefix_name_to_metrics(agg_results, self.name)
+        self.store_metrics_in_model_card_data(model, agg_results, epoch, steps)
+
+        results: dict[str, float] = per_dataset_results
+        results.update(agg_results)
+
+        # ── ViDoRe-specific aggregation ────────────────────────────────
+
         gc.collect()
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
 
         num_underscores = self.name.count("_")
 
-        # Compute per-dataset macro averages over languages (v2/v3 only)
+        # Per-dataset macro averages over languages (v2/v3 only)
         dataset_lang_groups: dict[str, list[str]] = {}
         for dataset_name in self.dataset_names:
             if ":" in dataset_name:
@@ -475,7 +709,7 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
                         f"{base_hr} macro NDCG@{ndcg_k}: {results[avg_key]:.4f}"
                     )
 
-        # Group evaluated datasets by version
+        # Per-version macro averages
         version_groups: dict[str, list[str]] = {}
         for dataset_name in self.dataset_names:
             base = dataset_name.split(":")[0].lower()
@@ -486,7 +720,6 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
                     )
                     break
 
-        # Compute per-version macro averages
         for version, hr_names in version_groups.items():
             per_metric: dict[str, list[float]] = {}
             for hr_name in hr_names:

--- a/pylate/evaluation/vidore_evaluator.py
+++ b/pylate/evaluation/vidore_evaluator.py
@@ -34,7 +34,7 @@ Use in a training loop:
 from __future__ import annotations
 
 import logging
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from sentence_transformers.sentence_transformer.evaluation.nano_beir import (
     NanoBEIREvaluator as NanoBEIREvaluatorST,
@@ -42,6 +42,9 @@ from sentence_transformers.sentence_transformer.evaluation.nano_beir import (
 from sentence_transformers.util import is_datasets_available
 
 from .pylate_information_retrieval_evaluator import PyLateInformationRetrievalEvaluator
+
+if TYPE_CHECKING:
+    from ..models import ColBERT
 
 logger = logging.getLogger(__name__)
 
@@ -297,3 +300,52 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
             name=human_readable_name,
             **ir_evaluator_kwargs,
         )
+
+    def __call__(
+        self,
+        model: ColBERT,
+        output_path: str | None = None,
+        epoch: int = -1,
+        steps: int = -1,
+        *args,
+        **kwargs,
+    ) -> dict[str, float]:
+        results = super().__call__(model, output_path, epoch, steps, *args, **kwargs)
+
+        # Group evaluated datasets by version
+        version_groups: dict[str, list[str]] = {}
+        for dataset_name in self.dataset_names:
+            for version, datasets in VIDORE_VERSION_DATASETS.items():
+                if dataset_name.lower() in datasets:
+                    version_groups.setdefault(version, []).append(
+                        self._get_human_readable_name(dataset_name)
+                    )
+                    break
+
+        active_versions = [v for v, names in version_groups.items() if names]
+        if len(active_versions) <= 1:
+            return results
+
+        # Compute per-version macro averages
+        num_underscores = self.name.count("_")
+        for version, hr_names in version_groups.items():
+            per_metric: dict[str, list[float]] = {}
+            for hr_name in hr_names:
+                prefix = hr_name + "_"
+                for key, value in results.items():
+                    if key.startswith(prefix):
+                        metric = key.split("_", maxsplit=num_underscores)[-1]
+                        per_metric.setdefault(metric, []).append(value)
+
+            for metric, values in per_metric.items():
+                results[f"ViDoRE_{version}_{metric}"] = sum(values) / len(values)
+
+            ndcg_k = max(self.ndcg_at_k)
+            for score_name in self.score_function_names:
+                ver_key = f"ViDoRE_{version}_{score_name}_ndcg@{ndcg_k}"
+                if ver_key in results:
+                    logger.info(
+                        f"ViDoRE {version} macro NDCG@{ndcg_k}: {results[ver_key]:.4f}"
+                    )
+
+        return results

--- a/pylate/evaluation/vidore_evaluator.py
+++ b/pylate/evaluation/vidore_evaluator.py
@@ -7,14 +7,18 @@ and aggregates NDCG/MRR/Recall across datasets.
 Supports three benchmark versions (v1, v2, v3) with per-dataset and per-version
 selection.  V2/V3 datasets contain multilingual queries — each language is
 evaluated as a separate sub-evaluator (matching MTEB's per-language scoring).
-
 """
 
 from __future__ import annotations
 
+import gc
 import logging
+from io import BytesIO
 from typing import TYPE_CHECKING, Literal
 
+import torch
+from datasets import Image as DatasetImage
+from PIL import Image
 from sentence_transformers.sentence_transformer.evaluation.nano_beir import (
     NanoBEIREvaluator as NanoBEIREvaluatorST,
 )
@@ -26,6 +30,16 @@ if TYPE_CHECKING:
     from ..models import ColBERT
 
 logger = logging.getLogger(__name__)
+
+
+def _decode_lazy_image(value):
+    """Decode a datasets lazy-encoded image dict to a PIL Image."""
+    if isinstance(value, dict) and "bytes" in value and value["bytes"] is not None:
+        return Image.open(BytesIO(value["bytes"]))
+    if isinstance(value, dict) and "path" in value and value["path"] is not None:
+        return Image.open(value["path"])
+    return value
+
 
 # ── Dataset registry ────────────────────────────────────────────────────────
 
@@ -144,6 +158,31 @@ DatasetNameType = Literal[
 VersionType = Literal["v1", "v2", "v3"]
 
 
+# ── Multimodal IR evaluator ────────────────────────────────────────────────
+
+
+class ViDoREInformationRetrievalEvaluator(PyLateInformationRetrievalEvaluator):
+    """IR evaluator that decodes lazy-encoded corpus images before encoding.
+
+    ViDoRe corpora store images with ``datasets.Image(decode=False)`` to avoid
+    materializing every PIL image at init time.  This subclass decodes the
+    ``{"bytes": ..., "path": ...}`` dicts to PIL Images per-chunk right before
+    the model encodes them.
+    """
+
+    @staticmethod
+    def _decode_corpus_chunk(entries: list) -> list:
+        return [
+            {**entry, "image": _decode_lazy_image(entry["image"])}
+            if isinstance(entry, dict) and "image" in entry
+            else entry
+            for entry in entries
+        ]
+
+    def _get_corpus_chunk(self, start: int, end: int) -> list:
+        return self._decode_corpus_chunk(self.corpus[start:end])
+
+
 # ── Evaluator ───────────────────────────────────────────────────────────────
 
 
@@ -217,7 +256,7 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
     trainer = SentenceTransformerTrainer(..., evaluator=evaluator)
     """
 
-    information_retrieval_class = PyLateInformationRetrievalEvaluator
+    information_retrieval_class = ViDoREInformationRetrievalEvaluator
 
     def __init__(
         self,
@@ -344,6 +383,16 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
         if lang and "language" in queries_ds.column_names:
             queries_ds = queries_ds.filter(lambda r: r["language"] == lang)
 
+        # Keep corpus images as encoded bytes (decode=False) to avoid
+        # materializing every PIL image at init time.  Images are decoded
+        # lazily in PyLateInformationRetrievalEvaluator.compute_all_metrics
+        # right before each chunk is encoded.
+        image_col = "image"
+        if image_col in corpus_ds.column_names:
+            feat = corpus_ds.features.get(image_col)
+            if isinstance(feat, DatasetImage) and feat.decode:
+                corpus_ds = corpus_ds.cast_column(image_col, DatasetImage(decode=False))
+
         queries = {str(r[qid_col]): r["query"] for r in queries_ds}
 
         if self.document_prompt:
@@ -384,6 +433,48 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
     ) -> dict[str, float]:
         results = super().__call__(model, output_path, epoch, steps, *args, **kwargs)
 
+        # Free GPU memory accumulated during evaluation (many sub-evaluators
+        # each encode corpus images, fragmenting the CUDA allocator).  Without
+        # this, training can hang on the first all_gather after eval in DDP.
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+        num_underscores = self.name.count("_")
+
+        # Compute per-dataset macro averages over languages (v2/v3 only)
+        dataset_lang_groups: dict[str, list[str]] = {}
+        for dataset_name in self.dataset_names:
+            if ":" in dataset_name:
+                base = dataset_name.rsplit(":", 1)[0].lower()
+                dataset_lang_groups.setdefault(base, []).append(
+                    self._get_human_readable_name(dataset_name)
+                )
+
+        for base, hr_names in dataset_lang_groups.items():
+            base_hr = DATASET_NAME_TO_HUMAN_READABLE[base]
+            if self.truncate_dim is not None:
+                base_hr += f"_{self.truncate_dim}"
+
+            per_metric: dict[str, list[float]] = {}
+            for hr_name in hr_names:
+                prefix = hr_name + "_"
+                for key, value in results.items():
+                    if key.startswith(prefix):
+                        metric = key.split("_", maxsplit=num_underscores)[-1]
+                        per_metric.setdefault(metric, []).append(value)
+
+            for metric, values in per_metric.items():
+                results[f"{base_hr}_{metric}"] = sum(values) / len(values)
+
+            ndcg_k = 10 if base in VIDORE_V3_DATASETS else 5
+            for score_name in self.score_function_names:
+                avg_key = f"{base_hr}_{score_name}_ndcg@{ndcg_k}"
+                if avg_key in results:
+                    logger.warning(
+                        f"{base_hr} macro NDCG@{ndcg_k}: {results[avg_key]:.4f}"
+                    )
+
         # Group evaluated datasets by version
         version_groups: dict[str, list[str]] = {}
         for dataset_name in self.dataset_names:
@@ -400,7 +491,6 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
             return results
 
         # Compute per-version macro averages
-        num_underscores = self.name.count("_")
         for version, hr_names in version_groups.items():
             per_metric: dict[str, list[float]] = {}
             for hr_name in hr_names:

--- a/pylate/evaluation/vidore_evaluator.py
+++ b/pylate/evaluation/vidore_evaluator.py
@@ -214,15 +214,6 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
     **kwargs
         Forwarded to the parent (``mrr_at_k``, ``accuracy_at_k``, ``map_at_k``,
         ``show_progress_bar``, ``write_csv``, ``aggregate_fn``, etc.).
-
-    Examples
-    --------
-    >>> evaluator = ViDoREvaluator()                               # all v1
-    >>> evaluator = ViDoREvaluator(versions=["v2", "v3"])          # v2+v3, all langs
-    >>> evaluator = ViDoREvaluator(versions=["v3"], language="french")  # v3 French only
-    >>> evaluator = ViDoREvaluator(dataset_names=["arxivqa"])      # single v1 dataset
-    >>> results = evaluator(model)
-    >>> print(results[evaluator.primary_metric])
     """
 
     information_retrieval_class = PyLateInformationRetrievalEvaluator

--- a/pylate/evaluation/vidore_evaluator.py
+++ b/pylate/evaluation/vidore_evaluator.py
@@ -71,6 +71,7 @@ VIDORE_V2_DATASETS = {
 
 VIDORE_V3_DATASETS = {
     "finance": "vidore/vidore_v3_finance_en",
+    "financefr": "vidore/vidore_v3_finance_fr",
     "hr": "vidore/vidore_v3_hr",
     "industrial": "vidore/vidore_v3_industrial",
     "pharmaceuticals": "vidore/vidore_v3_pharmaceuticals",
@@ -109,6 +110,7 @@ DATASET_NAME_TO_HUMAN_READABLE = {
     "biomedical": "BiomedicalV2",
     "economics": "EconomicsV2",
     "finance": "FinanceV3",
+    "financefr": "FinanceFrV3",
     "hr": "HRV3",
     "industrial": "IndustrialV3",
     "pharmaceuticals": "PharmaceuticalsV3",
@@ -132,6 +134,7 @@ DatasetNameType = Literal[
     "biomedical",
     "economics",
     "finance",
+    "financefr",
     "hr",
     "industrial",
     "pharmaceuticals",
@@ -160,6 +163,12 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
     versions : list[str] | None
         Benchmark versions to include — any combination of ``"v1"``,
         ``"v2"``, ``"v3"``.  Defaults to ``["v1"]``.
+    language : str | None
+        Filter queries to a single language (v2/v3 contain multilingual
+        queries).  E.g. ``"english"``, ``"french"``, ``"german"``,
+        ``"spanish"``, ``"italian"``, ``"portuguese"``.
+        ``None`` (default) keeps all languages.  V1 datasets have no language
+        column and are always included in full.
     document_prompt : str | None
         Text appended alongside each corpus image
         (e.g. ``"Describe the image."``).  Set to ``None`` to pass raw images.
@@ -179,6 +188,7 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
     >>> evaluator = ViDoREvaluator()                               # all v1
     >>> evaluator = ViDoREvaluator(versions=["v2", "v3"])          # v2 + v3
     >>> evaluator = ViDoREvaluator(dataset_names=["arxivqa"])      # single dataset
+    >>> evaluator = ViDoREvaluator(versions=["v3"], language="french")
     >>> results = evaluator(model)
     >>> print(results[evaluator.primary_metric])
     """
@@ -189,6 +199,7 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
         self,
         dataset_names: list[DatasetNameType | str] | None = None,
         versions: list[VersionType] | None = None,
+        language: str | None = None,
         document_prompt: str | None = "Describe the image.",
         corpus_chunk_size: int = 32,
         ndcg_at_k: list[int] | None = None,
@@ -197,6 +208,7 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
     ) -> None:
         # Must be set before super().__init__ calls _load_dataset
         self.document_prompt = document_prompt
+        self.language = language.lower() if language else None
         self._corpus_chunk_size = corpus_chunk_size
 
         if dataset_names is None:
@@ -271,6 +283,12 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
         cid_col = "corpus-id" if "corpus-id" in corpus_ds.column_names else "corpus_id"
         qrel_qid = "query-id" if "query-id" in qrels_ds.column_names else "query_id"
         qrel_cid = "corpus-id" if "corpus-id" in qrels_ds.column_names else "corpus_id"
+
+        # Filter by language when the column exists and a language was requested
+        if self.language and "language" in queries_ds.column_names:
+            queries_ds = queries_ds.filter(
+                lambda r: r["language"] == self.language
+            )
 
         queries = {str(r[qid_col]): r["query"] for r in queries_ds}
 

--- a/pylate/evaluation/vidore_evaluator.py
+++ b/pylate/evaluation/vidore_evaluator.py
@@ -1,0 +1,299 @@
+"""ViDoRe evaluator for PyLate multi-vector models on visual document retrieval.
+
+Follows the same pattern as NanoBEIREvaluator: loads BEIR-formatted datasets from
+the HuggingFace Hub, wraps them in PyLateInformationRetrievalEvaluator instances,
+and aggregates NDCG/MRR/Recall across datasets.
+
+Supports three benchmark versions (v1, v2, v3) with per-dataset and per-version
+selection.
+
+Examples
+--------
+>>> from pylate import models, evaluation
+
+>>> model = models.ColBERT(model_name_or_path="my-vidore-model", device="cuda")
+
+All v1 datasets (default):
+
+>>> evaluator = evaluation.ViDoREvaluator()
+
+Specific versions:
+
+>>> evaluator = evaluation.ViDoREvaluator(versions=["v1", "v2"])
+
+Cherry-pick datasets across versions:
+
+>>> evaluator = evaluation.ViDoREvaluator(dataset_names=["arxivqa", "infovqa", "finance"])
+
+Use in a training loop:
+
+>>> from sentence_transformers import SentenceTransformerTrainer
+>>> trainer = SentenceTransformerTrainer(..., evaluator=evaluator)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+from sentence_transformers.sentence_transformer.evaluation.nano_beir import (
+    NanoBEIREvaluator as NanoBEIREvaluatorST,
+)
+from sentence_transformers.util import is_datasets_available
+
+from .pylate_information_retrieval_evaluator import PyLateInformationRetrievalEvaluator
+
+logger = logging.getLogger(__name__)
+
+# ── Dataset registry ────────────────────────────────────────────────────────
+
+VIDORE_V1_DATASETS = {
+    "arxivqa": "vidore/arxivqa_test_subsampled_beir",
+    "docvqa": "vidore/docvqa_test_subsampled_beir",
+    "infovqa": "vidore/infovqa_test_subsampled_beir",
+    "tabfquad": "vidore/tabfquad_test_subsampled_beir",
+    "tatdqa": "vidore/tatdqa_test_beir",
+    "shiftproject": "vidore/shiftproject_test_beir",
+    "syntheticai": "vidore/syntheticDocQA_artificial_intelligence_test_beir",
+    "syntheticenergy": "vidore/syntheticDocQA_energy_test_beir",
+    "syntheticgov": "vidore/syntheticDocQA_government_reports_test_beir",
+    "synthetichealthcare": "vidore/syntheticDocQA_healthcare_industry_test_beir",
+}
+
+VIDORE_V2_DATASETS = {
+    "esgreports": "vidore/esg_reports_v2",
+    "biomedical": "vidore/biomedical_lectures_v2",
+    "economics": "vidore/economics_reports_v2",
+}
+
+VIDORE_V3_DATASETS = {
+    "finance": "vidore/vidore_v3_finance_en",
+    "hr": "vidore/vidore_v3_hr",
+    "industrial": "vidore/vidore_v3_industrial",
+    "pharmaceuticals": "vidore/vidore_v3_pharmaceuticals",
+    "computerscience": "vidore/vidore_v3_computer_science",
+    "energy": "vidore/vidore_v3_energy",
+    "physics": "vidore/vidore_v3_physics",
+}
+
+VIDORE_VERSION_DATASETS = {
+    "v1": VIDORE_V1_DATASETS,
+    "v2": VIDORE_V2_DATASETS,
+    "v3": VIDORE_V3_DATASETS,
+}
+
+ALL_VIDORE_DATASETS = {
+    **VIDORE_V1_DATASETS,
+    **VIDORE_V2_DATASETS,
+    **VIDORE_V3_DATASETS,
+}
+
+# CamelCase names — no underscores, required by the parent's metric-key parsing
+# (it splits on "_" up to self.name.count("_") to separate dataset prefix from
+# the metric suffix like "MaxSim_ndcg@5").
+DATASET_NAME_TO_HUMAN_READABLE = {
+    "arxivqa": "ArxivQA",
+    "docvqa": "DocVQA",
+    "infovqa": "InfoVQA",
+    "tabfquad": "TabFQuAD",
+    "tatdqa": "TATDQA",
+    "shiftproject": "ShiftProject",
+    "syntheticai": "SyntheticAI",
+    "syntheticenergy": "SyntheticEnergy",
+    "syntheticgov": "SyntheticGov",
+    "synthetichealthcare": "SyntheticHealthcare",
+    "esgreports": "ESGReportsV2",
+    "biomedical": "BiomedicalV2",
+    "economics": "EconomicsV2",
+    "finance": "FinanceV3",
+    "hr": "HRV3",
+    "industrial": "IndustrialV3",
+    "pharmaceuticals": "PharmaceuticalsV3",
+    "computerscience": "ComputerScienceV3",
+    "energy": "EnergyV3",
+    "physics": "PhysicsV3",
+}
+
+DatasetNameType = Literal[
+    "arxivqa",
+    "docvqa",
+    "infovqa",
+    "tabfquad",
+    "tatdqa",
+    "shiftproject",
+    "syntheticai",
+    "syntheticenergy",
+    "syntheticgov",
+    "synthetichealthcare",
+    "esgreports",
+    "biomedical",
+    "economics",
+    "finance",
+    "hr",
+    "industrial",
+    "pharmaceuticals",
+    "computerscience",
+    "energy",
+    "physics",
+]
+
+VersionType = Literal["v1", "v2", "v3"]
+
+
+# ── Evaluator ───────────────────────────────────────────────────────────────
+
+
+class ViDoREvaluator(NanoBEIREvaluatorST):
+    """Evaluate a PyLate ColBERT model on ViDoRe visual document retrieval.
+
+    Mirrors :class:`~pylate.evaluation.NanoBEIREvaluator` but loads multimodal
+    (image) corpora from the ``vidore/*`` datasets on the HuggingFace Hub.
+
+    Parameters
+    ----------
+    dataset_names : list[str] | None
+        Specific dataset short names to evaluate.  Overrides *versions* when
+        provided.  Valid names are listed in :data:`ALL_VIDORE_DATASETS`.
+    versions : list[str] | None
+        Benchmark versions to include — any combination of ``"v1"``,
+        ``"v2"``, ``"v3"``.  Defaults to ``["v1"]``.
+    document_prompt : str | None
+        Text appended alongside each corpus image
+        (e.g. ``"Describe the image."``).  Set to ``None`` to pass raw images.
+    corpus_chunk_size : int
+        Number of corpus documents encoded per forward-pass chunk.
+        Keep small (32-64) for image corpora to avoid OOM.
+    ndcg_at_k : list[int] | None
+        NDCG cut-offs.  Defaults to ``[5]`` (the ViDoRe canonical metric).
+    batch_size : int
+        Encoding batch size.
+    **kwargs
+        Forwarded to the parent (``mrr_at_k``, ``accuracy_at_k``, ``map_at_k``,
+        ``show_progress_bar``, ``write_csv``, ``aggregate_fn``, etc.).
+
+    Examples
+    --------
+    >>> evaluator = ViDoREvaluator()                               # all v1
+    >>> evaluator = ViDoREvaluator(versions=["v2", "v3"])          # v2 + v3
+    >>> evaluator = ViDoREvaluator(dataset_names=["arxivqa"])      # single dataset
+    >>> results = evaluator(model)
+    >>> print(results[evaluator.primary_metric])
+    """
+
+    information_retrieval_class = PyLateInformationRetrievalEvaluator
+
+    def __init__(
+        self,
+        dataset_names: list[DatasetNameType | str] | None = None,
+        versions: list[VersionType] | None = None,
+        document_prompt: str | None = "Describe the image.",
+        corpus_chunk_size: int = 32,
+        ndcg_at_k: list[int] | None = None,
+        batch_size: int = 16,
+        **kwargs,
+    ) -> None:
+        # Must be set before super().__init__ calls _load_dataset
+        self.document_prompt = document_prompt
+        self._corpus_chunk_size = corpus_chunk_size
+
+        if dataset_names is None:
+            if versions is None:
+                versions = ["v1"]
+            dataset_names = []
+            for v in versions:
+                if v not in VIDORE_VERSION_DATASETS:
+                    raise ValueError(
+                        f"Unknown version {v!r}. "
+                        f"Valid versions: {list(VIDORE_VERSION_DATASETS)}"
+                    )
+                dataset_names.extend(VIDORE_VERSION_DATASETS[v].keys())
+
+        if ndcg_at_k is None:
+            ndcg_at_k = [5]
+
+        super().__init__(
+            dataset_names=dataset_names,
+            ndcg_at_k=ndcg_at_k,
+            batch_size=batch_size,
+            **kwargs,
+        )
+
+        aggregate_key = kwargs.get("aggregate_key", "mean")
+        self.name = f"ViDoRE_{aggregate_key}"
+        if self.truncate_dim:
+            self.name += f"_{self.truncate_dim}"
+        self.csv_file = f"ViDoRE_evaluation_{aggregate_key}_results.csv"
+
+    # ── Overrides ───────────────────────────────────────────────────────────
+
+    def _validate_dataset_names(self) -> None:
+        if not self.dataset_names:
+            raise ValueError(
+                "dataset_names cannot be empty. "
+                "Pass None to evaluate on the default version (v1)."
+            )
+        missing = [
+            n for n in self.dataset_names if n.lower() not in ALL_VIDORE_DATASETS
+        ]
+        if missing:
+            raise ValueError(
+                f"Unknown ViDoRe dataset(s): {missing}. "
+                f"Valid names: {sorted(ALL_VIDORE_DATASETS)}"
+            )
+
+    def _get_human_readable_name(self, dataset_name: str) -> str:
+        name = DATASET_NAME_TO_HUMAN_READABLE[dataset_name.lower()]
+        if self.truncate_dim is not None:
+            name += f"_{self.truncate_dim}"
+        return name
+
+    def _load_dataset(
+        self, dataset_name: str, **ir_evaluator_kwargs
+    ) -> PyLateInformationRetrievalEvaluator:
+        if not is_datasets_available():
+            raise ValueError(
+                "datasets is not available. "
+                "Install it with: pip install datasets"
+            )
+        from datasets import load_dataset
+
+        dataset_path = ALL_VIDORE_DATASETS[dataset_name.lower()]
+
+        queries_ds = load_dataset(dataset_path, "queries", split="test")
+        corpus_ds = load_dataset(dataset_path, "corpus", split="test")
+        qrels_ds = load_dataset(dataset_path, "qrels", split="test")
+
+        # v1/v2 use hyphenated keys, v3 uses underscores
+        qid_col = "query-id" if "query-id" in queries_ds.column_names else "query_id"
+        cid_col = "corpus-id" if "corpus-id" in corpus_ds.column_names else "corpus_id"
+        qrel_qid = "query-id" if "query-id" in qrels_ds.column_names else "query_id"
+        qrel_cid = "corpus-id" if "corpus-id" in qrels_ds.column_names else "corpus_id"
+
+        queries = {str(r[qid_col]): r["query"] for r in queries_ds}
+
+        if self.document_prompt:
+            corpus = {
+                str(r[cid_col]): {"image": r["image"], "text": self.document_prompt}
+                for r in corpus_ds
+            }
+        else:
+            corpus = {str(r[cid_col]): {"image": r["image"]} for r in corpus_ds}
+
+        relevant_docs: dict[str, set[str]] = {}
+        for r in qrels_ds:
+            if int(r["score"]) > 0:
+                qid = str(r[qrel_qid])
+                if qid in queries:
+                    relevant_docs.setdefault(qid, set()).add(str(r[qrel_cid]))
+
+        human_readable_name = self._get_human_readable_name(dataset_name)
+
+        ir_evaluator_kwargs["corpus_chunk_size"] = self._corpus_chunk_size
+
+        return self.information_retrieval_class(
+            queries=queries,
+            corpus=corpus,
+            relevant_docs=relevant_docs,
+            name=human_readable_name,
+            **ir_evaluator_kwargs,
+        )

--- a/pylate/evaluation/vidore_evaluator.py
+++ b/pylate/evaluation/vidore_evaluator.py
@@ -298,22 +298,44 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
                 dataset_names.extend(VIDORE_VERSION_DATASETS[v].keys())
 
         resolved_lang = language.lower() if language else None
+        if resolved_lang is not None and resolved_lang not in LANGUAGE_SHORT:
+            raise ValueError(
+                f"Unknown language {language!r}. "
+                f"Supported languages: {list(LANGUAGE_SHORT)}"
+            )
 
         # Expand multilingual datasets (v2/v3) into per-language entries.
         # Format: "datasetname:language" for multilingual, plain name for v1.
+        # When a language is requested, datasets that do not cover it are
+        # skipped with a warning (e.g. italian only exists in v3), so that
+        # mixed-version selections still evaluate the language where available.
         expanded_names: list[str] = []
         for dn in dataset_names:
             dn_lower = dn.lower()
             if dn_lower in VIDORE_V2_DATASETS:
-                langs = [resolved_lang] if resolved_lang else VIDORE_V2_LANGUAGES
-                for lang in langs:
-                    expanded_names.append(f"{dn_lower}:{lang}")
+                available_langs = VIDORE_V2_LANGUAGES
             elif dn_lower in VIDORE_V3_DATASETS:
-                langs = [resolved_lang] if resolved_lang else VIDORE_V3_LANGUAGES
-                for lang in langs:
-                    expanded_names.append(f"{dn_lower}:{lang}")
+                available_langs = VIDORE_V3_LANGUAGES
             else:
                 expanded_names.append(dn_lower)
+                continue
+            if resolved_lang is not None:
+                if resolved_lang not in available_langs:
+                    logger.warning(
+                        f"Skipping {dn_lower}: language {resolved_lang!r} is not "
+                        f"available for this dataset (available: {available_langs})."
+                    )
+                    continue
+                langs = [resolved_lang]
+            else:
+                langs = available_langs
+            for lang in langs:
+                expanded_names.append(f"{dn_lower}:{lang}")
+        if not expanded_names:
+            raise ValueError(
+                f"No datasets left to evaluate for language {language!r}. "
+                f"Requested datasets: {dataset_names}."
+            )
         dataset_names = expanded_names
 
         has_v3 = any(dn.split(":")[0] in VIDORE_V3_DATASETS for dn in dataset_names)
@@ -392,8 +414,24 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
         qrel_qid = "query-id" if "query-id" in qrels_ds.column_names else "query_id"
         qrel_cid = "corpus-id" if "corpus-id" in qrels_ds.column_names else "corpus_id"
 
-        if lang and "language" in queries_ds.column_names:
+        if lang:
+            # Raising here happens at evaluator construction time, before any
+            # (expensive) corpus encoding in __call__.
+            if "language" not in queries_ds.column_names:
+                raise ValueError(
+                    f"A per-language evaluation ({lang!r}) was requested for "
+                    f"{dataset_path}, but its queries split has no 'language' "
+                    "column. Evaluating without filtering would silently score "
+                    "all languages under a per-language name and corrupt the "
+                    "macro averages."
+                )
             queries_ds = queries_ds.filter(lambda r: r["language"] == lang)
+            if len(queries_ds) == 0:
+                raise ValueError(
+                    f"No queries with language == {lang!r} in {dataset_path}. "
+                    "Check the language spelling (full lowercase name, e.g. "
+                    "'french')."
+                )
 
         # Keep corpus images as encoded bytes (decode=False) to avoid
         # materializing every PIL image at init time.  Images are decoded

--- a/pylate/evaluation/vidore_evaluator.py
+++ b/pylate/evaluation/vidore_evaluator.py
@@ -5,7 +5,8 @@ the HuggingFace Hub, wraps them in PyLateInformationRetrievalEvaluator instances
 and aggregates NDCG/MRR/Recall across datasets.
 
 Supports three benchmark versions (v1, v2, v3) with per-dataset and per-version
-selection.
+selection.  V2/V3 datasets contain multilingual queries — each language is
+evaluated as a separate sub-evaluator (matching MTEB's per-language scoring).
 
 Examples
 --------
@@ -24,6 +25,10 @@ Specific versions:
 Cherry-pick datasets across versions:
 
 >>> evaluator = evaluation.ViDoREvaluator(dataset_names=["arxivqa", "infovqa", "finance"])
+
+Only French queries on v3:
+
+>>> evaluator = evaluation.ViDoREvaluator(versions=["v3"], language="french")
 
 Use in a training loop:
 
@@ -119,6 +124,18 @@ DATASET_NAME_TO_HUMAN_READABLE = {
     "physics": "PhysicsV3",
 }
 
+VIDORE_V2_LANGUAGES = ["english", "french", "spanish", "german"]
+VIDORE_V3_LANGUAGES = ["english", "french", "spanish", "german", "italian", "portuguese"]
+
+LANGUAGE_SHORT = {
+    "english": "En",
+    "french": "Fr",
+    "spanish": "Es",
+    "german": "De",
+    "italian": "It",
+    "portuguese": "Pt",
+}
+
 DatasetNameType = Literal[
     "arxivqa",
     "docvqa",
@@ -155,6 +172,11 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
     Mirrors :class:`~pylate.evaluation.NanoBEIREvaluator` but loads multimodal
     (image) corpora from the ``vidore/*`` datasets on the HuggingFace Hub.
 
+    V2/V3 datasets contain multilingual queries.  Each language is evaluated
+    as a separate sub-evaluator (matching MTEB).  When ``language`` is set,
+    only that language is evaluated; when ``None`` (default), every available
+    language for each dataset gets its own sub-evaluator.
+
     Parameters
     ----------
     dataset_names : list[str] | None
@@ -164,13 +186,12 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
         Benchmark versions to include — any combination of ``"v1"``,
         ``"v2"``, ``"v3"``.  Defaults to ``["v1"]``.
     language : str | None
-        Filter queries to a single language (v2/v3 contain multilingual
-        queries).  E.g. ``"english"``, ``"french"``, ``"german"``,
-        ``"spanish"``, ``"italian"``, ``"portuguese"``.
-        Defaults to ``"english"`` when v2/v3 datasets are included (mixed-
-        language evaluation is not meaningful).  ``None`` is only valid
-        for v1-only evaluation.  V1 datasets have no language column and
-        are always included in full.
+        Evaluate only this language for v2/v3 multilingual datasets.
+        E.g. ``"english"``, ``"french"``, ``"german"``, ``"spanish"``,
+        ``"italian"``, ``"portuguese"``.
+        ``None`` (default) evaluates every language separately (one
+        sub-evaluator per dataset-language pair, matching MTEB).
+        V1 datasets are monolingual and always included as-is.
     document_prompt : str | None
         Text appended alongside each corpus image
         (e.g. ``"Describe the image."``).  Defaults to ``None`` (raw images,
@@ -190,9 +211,9 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
     Examples
     --------
     >>> evaluator = ViDoREvaluator()                               # all v1
-    >>> evaluator = ViDoREvaluator(versions=["v2", "v3"])          # v2 + v3
-    >>> evaluator = ViDoREvaluator(dataset_names=["arxivqa"])      # single dataset
-    >>> evaluator = ViDoREvaluator(versions=["v3"], language="french")
+    >>> evaluator = ViDoREvaluator(versions=["v2", "v3"])          # v2+v3, all langs
+    >>> evaluator = ViDoREvaluator(versions=["v3"], language="french")  # v3 French only
+    >>> evaluator = ViDoREvaluator(dataset_names=["arxivqa"])      # single v1 dataset
     >>> results = evaluator(model)
     >>> print(results[evaluator.primary_metric])
     """
@@ -226,21 +247,27 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
                     )
                 dataset_names.extend(VIDORE_VERSION_DATASETS[v].keys())
 
-        has_multilingual = any(
-            dn.lower() in {**VIDORE_V2_DATASETS, **VIDORE_V3_DATASETS}
-            for dn in dataset_names
-        )
-        if language is None and has_multilingual:
-            language = "english"
-            logger.warning(
-                "v2/v3 datasets contain multilingual queries — "
-                "defaulting to language='english'. "
-                "Pass language explicitly to evaluate a different language."
-            )
-        self.language = language.lower() if language else None
+        resolved_lang = language.lower() if language else None
+
+        # Expand multilingual datasets (v2/v3) into per-language entries.
+        # Format: "datasetname:language" for multilingual, plain name for v1.
+        expanded_names: list[str] = []
+        for dn in dataset_names:
+            dn_lower = dn.lower()
+            if dn_lower in VIDORE_V2_DATASETS:
+                langs = [resolved_lang] if resolved_lang else VIDORE_V2_LANGUAGES
+                for lang in langs:
+                    expanded_names.append(f"{dn_lower}:{lang}")
+            elif dn_lower in VIDORE_V3_DATASETS:
+                langs = [resolved_lang] if resolved_lang else VIDORE_V3_LANGUAGES
+                for lang in langs:
+                    expanded_names.append(f"{dn_lower}:{lang}")
+            else:
+                expanded_names.append(dn_lower)
+        dataset_names = expanded_names
 
         has_v3 = any(
-            dn.lower() in VIDORE_V3_DATASETS for dn in dataset_names
+            dn.split(":")[0] in VIDORE_V3_DATASETS for dn in dataset_names
         )
         if ndcg_at_k is None:
             ndcg_at_k = [5, 10] if has_v3 else [5]
@@ -268,9 +295,11 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
                 "dataset_names cannot be empty. "
                 "Pass None to evaluate on the default version (v1)."
             )
-        missing = [
-            n for n in self.dataset_names if n.lower() not in ALL_VIDORE_DATASETS
-        ]
+        missing = []
+        for n in self.dataset_names:
+            base = n.split(":")[0].lower()
+            if base not in ALL_VIDORE_DATASETS:
+                missing.append(n)
         if missing:
             raise ValueError(
                 f"Unknown ViDoRe dataset(s): {missing}. "
@@ -278,7 +307,13 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
             )
 
     def _get_human_readable_name(self, dataset_name: str) -> str:
-        name = DATASET_NAME_TO_HUMAN_READABLE[dataset_name.lower()]
+        if ":" in dataset_name:
+            base, lang = dataset_name.rsplit(":", 1)
+            base_hr = DATASET_NAME_TO_HUMAN_READABLE[base.lower()]
+            lang_short = LANGUAGE_SHORT.get(lang, lang.capitalize())
+            name = f"{base_hr}{lang_short}"
+        else:
+            name = DATASET_NAME_TO_HUMAN_READABLE[dataset_name.lower()]
         if self.truncate_dim is not None:
             name += f"_{self.truncate_dim}"
         return name
@@ -293,7 +328,12 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
             )
         from datasets import load_dataset
 
-        dataset_path = ALL_VIDORE_DATASETS[dataset_name.lower()]
+        if ":" in dataset_name:
+            base_name, lang = dataset_name.rsplit(":", 1)
+        else:
+            base_name, lang = dataset_name, None
+
+        dataset_path = ALL_VIDORE_DATASETS[base_name.lower()]
 
         queries_ds = load_dataset(dataset_path, "queries", split="test")
         corpus_ds = load_dataset(dataset_path, "corpus", split="test")
@@ -305,10 +345,9 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
         qrel_qid = "query-id" if "query-id" in qrels_ds.column_names else "query_id"
         qrel_cid = "corpus-id" if "corpus-id" in qrels_ds.column_names else "corpus_id"
 
-        # Filter by language when the column exists and a language was requested
-        if self.language and "language" in queries_ds.column_names:
+        if lang and "language" in queries_ds.column_names:
             queries_ds = queries_ds.filter(
-                lambda r: r["language"] == self.language
+                lambda r: r["language"] == lang
             )
 
         queries = {str(r[qid_col]): r["query"] for r in queries_ds}
@@ -354,8 +393,9 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
         # Group evaluated datasets by version
         version_groups: dict[str, list[str]] = {}
         for dataset_name in self.dataset_names:
+            base = dataset_name.split(":")[0].lower()
             for version, datasets in VIDORE_VERSION_DATASETS.items():
-                if dataset_name.lower() in datasets:
+                if base in datasets:
                     version_groups.setdefault(version, []).append(
                         self._get_human_readable_name(dataset_name)
                     )

--- a/pylate/evaluation/vidore_evaluator.py
+++ b/pylate/evaluation/vidore_evaluator.py
@@ -8,32 +8,6 @@ Supports three benchmark versions (v1, v2, v3) with per-dataset and per-version
 selection.  V2/V3 datasets contain multilingual queries — each language is
 evaluated as a separate sub-evaluator (matching MTEB's per-language scoring).
 
-Examples
---------
->>> from pylate import models, evaluation
-
->>> model = models.ColBERT(model_name_or_path="my-vidore-model", device="cuda")
-
-All v1 datasets (default):
-
->>> evaluator = evaluation.ViDoREvaluator()
-
-Specific versions:
-
->>> evaluator = evaluation.ViDoREvaluator(versions=["v1", "v2"])
-
-Cherry-pick datasets across versions:
-
->>> evaluator = evaluation.ViDoREvaluator(dataset_names=["arxivqa", "infovqa", "finance"])
-
-Only French queries on v3:
-
->>> evaluator = evaluation.ViDoREvaluator(versions=["v3"], language="french")
-
-Use in a training loop:
-
->>> from sentence_transformers import SentenceTransformerTrainer
->>> trainer = SentenceTransformerTrainer(..., evaluator=evaluator)
 """
 
 from __future__ import annotations

--- a/pylate/evaluation/vidore_evaluator.py
+++ b/pylate/evaluation/vidore_evaluator.py
@@ -188,6 +188,33 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
     **kwargs
         Forwarded to the parent (``mrr_at_k``, ``accuracy_at_k``, ``map_at_k``,
         ``show_progress_bar``, ``write_csv``, ``aggregate_fn``, etc.).
+
+    Examples
+    --------
+    from pylate import models, evaluation
+
+    model = models.ColBERT(model_name_or_path="my-vidore-model", device="cuda")
+
+    All v1 datasets (default):
+
+    evaluator = evaluation.ViDoREvaluator()
+
+    Specific versions:
+
+    evaluator = evaluation.ViDoREvaluator(versions=["v1", "v2"])
+
+    Cherry-pick datasets across versions:
+
+    evaluator = evaluation.ViDoREvaluator(dataset_names=["arxivqa", "infovqa", "finance"])
+
+    Only French queries on v3:
+
+    evaluator = evaluation.ViDoREvaluator(versions=["v3"], language="french")
+
+    Use in a training loop:
+
+    from sentence_transformers import SentenceTransformerTrainer
+    trainer = SentenceTransformerTrainer(..., evaluator=evaluator)
     """
 
     information_retrieval_class = PyLateInformationRetrievalEvaluator

--- a/pylate/evaluation/vidore_evaluator.py
+++ b/pylate/evaluation/vidore_evaluator.py
@@ -486,10 +486,6 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
                     )
                     break
 
-        active_versions = [v for v, names in version_groups.items() if names]
-        if len(active_versions) <= 1:
-            return results
-
         # Compute per-version macro averages
         for version, hr_names in version_groups.items():
             per_metric: dict[str, list[float]] = {}

--- a/pylate/evaluation/vidore_evaluator.py
+++ b/pylate/evaluation/vidore_evaluator.py
@@ -201,6 +201,14 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
     only that language is evaluated; when ``None`` (default), every available
     language for each dataset gets its own sub-evaluator.
 
+    .. note::
+        Relevance judgments are binarized (score > 0), as the underlying
+        sentence-transformers evaluator only supports binary relevance.
+        V1/v2 qrels carry a single grade so this is lossless, but v3 qrels
+        are graded (1 and 2): v3 NDCG values are therefore not directly
+        comparable to the MTEB leaderboard, which computes graded-gain NDCG
+        via pytrec_eval. Rankings between models remain meaningful.
+
     Parameters
     ----------
     dataset_names : list[str] | None
@@ -407,6 +415,10 @@ class ViDoREvaluator(NanoBEIREvaluatorST):
         else:
             corpus = {str(r[cid_col]): {"image": r["image"]} for r in corpus_ds}
 
+        # Binarize qrels (score > 0): ST's InformationRetrievalEvaluator only
+        # supports binary relevance. Lossless for v1/v2 (uniform grades), but
+        # v3 qrels are graded (1/2), so v3 NDCG differs from MTEB's
+        # pytrec_eval graded-gain NDCG. See the class docstring.
         relevant_docs: dict[str, set[str]] = {}
         for r in qrels_ds:
             if int(r["score"]) > 0:

--- a/pylate/hf_hub/model_card.py
+++ b/pylate/hf_hub/model_card.py
@@ -9,7 +9,9 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import torch
 import transformers
-from sentence_transformers import SentenceTransformerModelCardData
+from sentence_transformers.sentence_transformer.model_card import (
+    SentenceTransformerModelCardData,
+)
 from sentence_transformers import __version__ as sentence_transformers_version
 from sentence_transformers.util import (
     is_accelerate_available,
@@ -23,9 +25,9 @@ from ..__version__ import __version__ as pylate_version
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from sentence_transformers.evaluation.SentenceEvaluator import SentenceEvaluator
-    from sentence_transformers.SentenceTransformer import SentenceTransformer
-    from sentence_transformers.trainer import SentenceTransformerTrainer
+    from sentence_transformers.base.evaluation import SentenceEvaluator
+    from sentence_transformers.sentence_transformer.model import SentenceTransformer
+    from sentence_transformers.sentence_transformer.trainer import SentenceTransformerTrainer
 
 
 IGNORED_FIELDS = ["model", "trainer", "eval_results_dict"]
@@ -244,7 +246,7 @@ class PylateModelCardData(SentenceTransformerModelCardData):
         super_dict["document_length"] = self.model.document_length
         super_dict["query_length"] = self.model.query_length
         super_dict["output_dimensionality"] = (
-            self.model.get_sentence_embedding_dimension()
+            self.model.get_embedding_dimension()
         )
         super_dict["model_string"] = str(self.model)
 

--- a/pylate/hf_hub/model_card.py
+++ b/pylate/hf_hub/model_card.py
@@ -9,10 +9,10 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import torch
 import transformers
+from sentence_transformers import __version__ as sentence_transformers_version
 from sentence_transformers.sentence_transformer.model_card import (
     SentenceTransformerModelCardData,
 )
-from sentence_transformers import __version__ as sentence_transformers_version
 from sentence_transformers.util import (
     is_accelerate_available,
     is_datasets_available,
@@ -27,7 +27,9 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from sentence_transformers.base.evaluation import SentenceEvaluator
     from sentence_transformers.sentence_transformer.model import SentenceTransformer
-    from sentence_transformers.sentence_transformer.trainer import SentenceTransformerTrainer
+    from sentence_transformers.sentence_transformer.trainer import (
+        SentenceTransformerTrainer,
+    )
 
 
 IGNORED_FIELDS = ["model", "trainer", "eval_results_dict"]
@@ -245,9 +247,7 @@ class PylateModelCardData(SentenceTransformerModelCardData):
         # Add some additional metadata stored in the model itself
         super_dict["document_length"] = self.model.document_length
         super_dict["query_length"] = self.model.query_length
-        super_dict["output_dimensionality"] = (
-            self.model.get_embedding_dimension()
-        )
+        super_dict["output_dimensionality"] = self.model.get_embedding_dimension()
         super_dict["model_string"] = str(self.model)
 
         if self.model.similarity_fn_name:

--- a/pylate/losses/cached_contrastive.py
+++ b/pylate/losses/cached_contrastive.py
@@ -116,15 +116,15 @@ class CachedContrastive(nn.Module):
 
     >>> loss = losses.CachedContrastive(model=model, mini_batch_size=1)
 
-    >>> anchors = model.tokenize([
+    >>> anchors = model.preprocess([
     ...     "fruits are healthy.", "chips are not healthy."
     ... ], is_query=True)
 
-    >>> positives = model.tokenize([
+    >>> positives = model.preprocess([
     ...     "fruits are good for health.", "chips are not good for health."
     ... ], is_query=False, pad=True)
 
-    >>> negatives = model.tokenize([
+    >>> negatives = model.preprocess([
     ...     "fruits are bad for health.", "chips are good for health."
     ... ], is_query=False, pad=True)
 

--- a/pylate/losses/cached_contrastive.py
+++ b/pylate/losses/cached_contrastive.py
@@ -208,8 +208,7 @@ class CachedContrastive(nn.Module):
         """Yields chunks of embeddings (and corresponding RandContext) for the given
         sentence_feature, respecting the mini_batch_size limit.
         """
-        input_ids = sentence_feature["input_ids"]
-        bsz = input_ids.size(0)
+        bsz = next(iter(sentence_feature.values())).size(0)
         for i, b in enumerate(
             tqdm.trange(
                 0,

--- a/pylate/losses/cached_contrastive.py
+++ b/pylate/losses/cached_contrastive.py
@@ -138,7 +138,17 @@ class CachedContrastive(nn.Module):
     >>> assert isinstance(loss.item(), float)
     """
 
-    # Enables per-sample media counting in Transformer.preprocess for VLM minibatching
+    # Enables per-sample media counting in Transformer.preprocess for VLM minibatching.
+    # VLM processors (e.g. Qwen2/2.5/3-VL) return `pixel_values` flat across the batch —
+    # shape `(total_visual_tokens, hidden)` — rather than `(batch, max_patches, hidden)`,
+    # so a plain `[begin:end]` slice cannot recover per-sample tensors when this loss
+    # chunks the batch into minibatches for gradcache. Setting this flag makes the
+    # ST trainer flip `track_media_counts = True` on the multimodal Transformer, which
+    # then attaches `num_images_per_sample` / `num_videos_per_sample` alongside
+    # `pixel_values` / `image_grid_thw`. `_create_minibatch` uses those counts to slice
+    # by visual-token offsets instead of by a leading batch dim. This is PyLate/ST's
+    # equivalent of colpali_engine's `torch.split` + `pad_sequence` workaround
+    # (see `ColQwen2_5_Processor.process_images`), without the padding overhead.
     requires_media_counts = True
 
     def __init__(

--- a/pylate/losses/cached_contrastive.py
+++ b/pylate/losses/cached_contrastive.py
@@ -8,6 +8,10 @@ from typing import Callable, Iterable, Optional
 import torch
 import torch.nn.functional as F
 import tqdm
+from sentence_transformers.sentence_transformer.losses.cached_multiple_negatives_ranking import (
+    _create_minibatch,
+    _get_batch_size,
+)
 from torch import Tensor, nn
 from torch.utils.checkpoint import get_device_states, set_device_states
 
@@ -134,6 +138,9 @@ class CachedContrastive(nn.Module):
     >>> assert isinstance(loss.item(), float)
     """
 
+    # Enables per-sample media counting in Transformer.preprocess for VLM minibatching
+    requires_media_counts = True
+
     def __init__(
         self,
         model: ColBERT,
@@ -181,14 +188,18 @@ class CachedContrastive(nn.Module):
         """
         grad_context = nullcontext if with_grad else torch.no_grad
         random_state_context = nullcontext() if random_state is None else random_state
-        sentence_feature_minibatch = {
-            k: v[begin:end] for k, v in sentence_feature.items()
-        }
+        sentence_feature_minibatch = _create_minibatch(sentence_feature, begin, end)
         with random_state_context:
             with grad_context():
                 # If we need a new random-state copy, create it
                 random_state = (
-                    RandContext(*sentence_feature_minibatch.values())
+                    RandContext(
+                        *(
+                            v
+                            for v in sentence_feature_minibatch.values()
+                            if isinstance(v, torch.Tensor)
+                        )
+                    )
                     if copy_random_state
                     else None
                 )
@@ -208,7 +219,7 @@ class CachedContrastive(nn.Module):
         """Yields chunks of embeddings (and corresponding RandContext) for the given
         sentence_feature, respecting the mini_batch_size limit.
         """
-        bsz = next(iter(sentence_feature.values())).size(0)
+        bsz = _get_batch_size(sentence_feature)
         for i, b in enumerate(
             tqdm.trange(
                 0,

--- a/pylate/losses/cached_contrastive.py
+++ b/pylate/losses/cached_contrastive.py
@@ -19,6 +19,7 @@ from ..models import ColBERT
 from ..scores import ColBERTScores
 from ..utils import all_gather, all_gather_with_gradients, get_rank, get_world_size
 from .contrastive import extract_skiplist_mask
+from .padding import pad_embeddings_and_masks
 
 
 class RandContext:
@@ -284,6 +285,16 @@ class CachedContrastive(nn.Module):
         # Possibly gather the embeddings across devices to have more in-batch negatives. For GradCache, we only need to gather them to compute the scores matrix and nowhere else.
         # Note that we only gather the documents embeddings and not the queries embeddings, but are keeping gradients. This is to lower the memory usage, see https://github.com/mlfoundations/open_clip/issues/616
         if self.gather_across_devices:
+            # all_gather requires identical shapes across ranks. Multimodal
+            # inputs produce variable-length token sequences per rank, so
+            # pad to the global max seq_len before gathering.
+            local_max = max(e.size(1) for e in embeddings_other)
+            global_max = torch.tensor(local_max, device=embeddings_other[0].device)
+            torch.distributed.all_reduce(global_max, op=torch.distributed.ReduceOp.MAX)
+            embeddings_other, doc_masks = pad_embeddings_and_masks(
+                embeddings_other, masks[1:], target_len=global_max.item()
+            )
+            masks = [masks[0], *doc_masks]
             embeddings_other = [
                 torch.cat(all_gather_with_gradients(embeddings))
                 for embeddings in embeddings_other
@@ -301,6 +312,14 @@ class CachedContrastive(nn.Module):
         )
 
         N = len(embeddings_other)
+        # Pad document groups to the same seq length so they can be stacked.
+        # Different columns (positive, negative_0, ...) may have different
+        # token counts when images produce variable-length visual tokens.
+        if N > 1:
+            embeddings_other, doc_masks = pad_embeddings_and_masks(
+                embeddings_other, masks[1:]
+            )
+            masks = [masks[0], *doc_masks]
         docs_stacked = torch.stack(embeddings_other, dim=1)
         docs_mask_stacked = torch.stack(masks[1:], dim=1)
         q_mask = masks[0] if not do_query_expansion else None

--- a/pylate/losses/cached_contrastive.py
+++ b/pylate/losses/cached_contrastive.py
@@ -17,7 +17,13 @@ from torch.utils.checkpoint import get_device_states, set_device_states
 
 from ..models import ColBERT
 from ..scores import ColBERTScores
-from ..utils import all_gather, all_gather_with_gradients, get_rank, get_world_size
+from ..utils import (
+    all_gather,
+    all_gather_with_gradients,
+    all_reduce_max,
+    get_rank,
+    get_world_size,
+)
 from .contrastive import extract_skiplist_mask
 from .padding import pad_embeddings_and_masks
 
@@ -290,7 +296,7 @@ class CachedContrastive(nn.Module):
             # pad to the global max seq_len before gathering.
             local_max = max(e.size(1) for e in embeddings_other)
             global_max = torch.tensor(local_max, device=embeddings_other[0].device)
-            torch.distributed.all_reduce(global_max, op=torch.distributed.ReduceOp.MAX)
+            all_reduce_max(global_max)
             embeddings_other, doc_masks = pad_embeddings_and_masks(
                 embeddings_other, masks[1:], target_len=global_max.item()
             )

--- a/pylate/losses/contrastive.py
+++ b/pylate/losses/contrastive.py
@@ -48,9 +48,14 @@ def extract_skiplist_mask(
         sentence_feature["attention_mask"] for sentence_feature in sentence_features
     ]
 
-    skiplist_masks = [
-        torch.ones_like(sentence_features[0]["input_ids"], dtype=torch.bool)
-    ]
+    # For the query (first feature): if input_ids available use ones_like, else use attention_mask shape
+    first_feature = sentence_features[0]
+    if "input_ids" in first_feature:
+        query_mask = torch.ones_like(first_feature["input_ids"], dtype=torch.bool)
+    else:
+        query_mask = torch.ones_like(first_feature["attention_mask"], dtype=torch.bool)
+
+    skiplist_masks = [query_mask]
 
     # We skip the first sentence feature because it is the query.
     skiplist_masks.extend(
@@ -58,6 +63,8 @@ def extract_skiplist_mask(
             ColBERT.skiplist_mask(
                 input_ids=sentence_feature["input_ids"], skiplist=skiplist
             )
+            if "input_ids" in sentence_feature
+            else sentence_feature["attention_mask"].bool()
             for sentence_feature in sentence_features[1:]
         ]
     )

--- a/pylate/losses/contrastive.py
+++ b/pylate/losses/contrastive.py
@@ -102,15 +102,15 @@ class Contrastive(nn.Module):
 
     >>> loss = losses.Contrastive(model=model)
 
-    >>> anchor = model.tokenize([
+    >>> anchor = model.preprocess([
     ...     "fruits are healthy.",
     ... ], is_query=True)
 
-    >>> positive = model.tokenize([
+    >>> positive = model.preprocess([
     ...     "fruits are good for health.",
     ... ], is_query=False)
 
-    >>> negative = model.tokenize([
+    >>> negative = model.preprocess([
     ...     "fruits are bad for health.",
     ... ], is_query=False)
 

--- a/pylate/losses/contrastive.py
+++ b/pylate/losses/contrastive.py
@@ -189,8 +189,6 @@ class Contrastive(nn.Module):
             # all_gather requires identical shapes across ranks. Multimodal
             # inputs produce variable-length token sequences per rank, so
             # pad to the global max seq_len before gathering.
-            import torch.distributed
-
             local_max = max(e.size(1) for e in embeddings[1:])
             global_max = torch.tensor(local_max, device=embeddings[0].device)
             torch.distributed.all_reduce(global_max, op=torch.distributed.ReduceOp.MAX)

--- a/pylate/losses/contrastive.py
+++ b/pylate/losses/contrastive.py
@@ -9,6 +9,7 @@ from torch import Tensor, nn
 from ..models import ColBERT
 from ..scores import ColBERTScores
 from ..utils import all_gather, all_gather_with_gradients, get_rank, get_world_size
+from .padding import pad_embeddings_and_masks
 
 
 def extract_skiplist_mask(
@@ -185,6 +186,19 @@ class Contrastive(nn.Module):
         batch_size = embeddings[0].size(0)
         # Possibly gather the embeddings across devices to have more in-batch negatives.
         if self.gather_across_devices:
+            # all_gather requires identical shapes across ranks. Multimodal
+            # inputs produce variable-length token sequences per rank, so
+            # pad to the global max seq_len before gathering.
+            import torch.distributed
+
+            local_max = max(e.size(1) for e in embeddings[1:])
+            global_max = torch.tensor(local_max, device=embeddings[0].device)
+            torch.distributed.all_reduce(global_max, op=torch.distributed.ReduceOp.MAX)
+            doc_embeds, doc_masks = pad_embeddings_and_masks(
+                embeddings[1:], masks[1:], target_len=global_max.item()
+            )
+            embeddings = [embeddings[0], *doc_embeds]
+            masks = [masks[0], *doc_masks]
             # Note that we only gather the documents embeddings and not the queries embeddings (embeddings[0]), but are keeping gradients. This is to lower the memory usage, see https://github.com/mlfoundations/open_clip/issues/616
             embeddings = [
                 embeddings[0],
@@ -202,6 +216,11 @@ class Contrastive(nn.Module):
         # Note: the queries mask is not used by default; if it's fed through, take care that
         # expansion tokens are not masked from scoring (they may be masked during encoding).
         N = len(embeddings) - 1
+        # Pad document groups to the same seq length so they can be stacked.
+        if N > 1:
+            doc_embeds, doc_masks = pad_embeddings_and_masks(embeddings[1:], masks[1:])
+            embeddings = [embeddings[0], *doc_embeds]
+            masks = [masks[0], *doc_masks]
         docs_stacked = torch.stack(embeddings[1:], dim=1)
         docs_mask_stacked = torch.stack(masks[1:], dim=1)
         q_mask = masks[0] if not do_query_expansion else None

--- a/pylate/losses/contrastive.py
+++ b/pylate/losses/contrastive.py
@@ -8,7 +8,13 @@ from torch import Tensor, nn
 
 from ..models import ColBERT
 from ..scores import ColBERTScores
-from ..utils import all_gather, all_gather_with_gradients, get_rank, get_world_size
+from ..utils import (
+    all_gather,
+    all_gather_with_gradients,
+    all_reduce_max,
+    get_rank,
+    get_world_size,
+)
 from .padding import pad_embeddings_and_masks
 
 
@@ -191,7 +197,7 @@ class Contrastive(nn.Module):
             # pad to the global max seq_len before gathering.
             local_max = max(e.size(1) for e in embeddings[1:])
             global_max = torch.tensor(local_max, device=embeddings[0].device)
-            torch.distributed.all_reduce(global_max, op=torch.distributed.ReduceOp.MAX)
+            all_reduce_max(global_max)
             doc_embeds, doc_masks = pad_embeddings_and_masks(
                 embeddings[1:], masks[1:], target_len=global_max.item()
             )

--- a/pylate/losses/distillation.py
+++ b/pylate/losses/distillation.py
@@ -33,11 +33,11 @@ class Distillation(torch.nn.Module):
 
     >>> distillation = losses.Distillation(model=model)
 
-    >>> query = model.tokenize([
+    >>> query = model.preprocess([
     ...     "fruits are healthy.",
     ... ], is_query=True)
 
-    >>> documents = model.tokenize([
+    >>> documents = model.preprocess([
     ...     "fruits are good for health.",
     ...     "fruits are bad for health."
     ... ], is_query=False)

--- a/pylate/losses/padding.py
+++ b/pylate/losses/padding.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import torch
 import torch.nn.functional as F
 from torch import Tensor
 

--- a/pylate/losses/padding.py
+++ b/pylate/losses/padding.py
@@ -18,9 +18,7 @@ def pad_embeddings_and_masks(
     if target_len is None:
         target_len = max(e.size(1) for e in embeddings)
     embeddings = [
-        F.pad(e, (0, 0, 0, target_len - e.size(1)))
-        if e.size(1) < target_len
-        else e
+        F.pad(e, (0, 0, 0, target_len - e.size(1))) if e.size(1) < target_len else e
         for e in embeddings
     ]
     masks = [

--- a/pylate/losses/padding.py
+++ b/pylate/losses/padding.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+
+def pad_embeddings_and_masks(
+    embeddings: list[Tensor],
+    masks: list[Tensor],
+    target_len: int | None = None,
+) -> tuple[list[Tensor], list[Tensor]]:
+    """Pad variable-length multi-vector embeddings and masks to a common seq length.
+
+    When ``target_len`` is given, pad to that length; otherwise pad to the max
+    across the provided lists.  Embeddings are zero-padded (masked out by the
+    corresponding ``False`` entries in the mask during MaxSim scoring).
+    """
+    if target_len is None:
+        target_len = max(e.size(1) for e in embeddings)
+    embeddings = [
+        F.pad(e, (0, 0, 0, target_len - e.size(1)))
+        if e.size(1) < target_len
+        else e
+        for e in embeddings
+    ]
+    masks = [
+        F.pad(m, (0, target_len - m.size(1)), value=False)
+        if m.size(1) < target_len
+        else m
+        for m in masks
+    ]
+    return embeddings, masks

--- a/pylate/models/Dense.py
+++ b/pylate/models/Dense.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-import json
 import logging
 import os
 
 import torch
 from safetensors import safe_open
-from safetensors.torch import load_model as load_safetensors_model
-from sentence_transformers.models import Dense as DenseSentenceTransformer
-from sentence_transformers.util import import_from_string
+from sentence_transformers.base.modules import Dense as DenseSentenceTransformer
+from sentence_transformers.util import fullname, import_from_string
 from torch import nn
 from transformers.utils import cached_file
 
@@ -28,6 +26,8 @@ class Dense(DenseSentenceTransformer):
         Size of the output embeddings after linear projection
     bias
         Add a bias vector
+    activation_function
+        Activation function applied after the linear layer.
     init_weight
         Initial value for the matrix of the linear layer
     init_bias
@@ -55,6 +55,16 @@ class Dense(DenseSentenceTransformer):
 
     """
 
+    config_keys: list[str] = [
+        "in_features",
+        "out_features",
+        "bias",
+        "activation_function",
+        "module_input_name",
+        "module_output_name",
+        "use_residual",
+    ]
+
     def __init__(
         self,
         in_features: int,
@@ -64,9 +74,18 @@ class Dense(DenseSentenceTransformer):
         init_weight: torch.Tensor = None,
         init_bias: torch.Tensor = None,
         use_residual: bool = False,
+        module_input_name: str = "token_embeddings",
+        module_output_name: str | None = None,
     ) -> None:
         super(Dense, self).__init__(
-            in_features, out_features, bias, activation_function, init_weight, init_bias
+            in_features,
+            out_features,
+            bias,
+            activation_function,
+            init_weight,
+            init_bias,
+            module_input_name=module_input_name,
+            module_output_name=module_output_name or module_input_name,
         )
         self.use_residual = use_residual
         if use_residual and self.in_features != self.out_features:
@@ -74,14 +93,14 @@ class Dense(DenseSentenceTransformer):
 
     def forward(self, features: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """Performs linear projection on the token embeddings."""
-        token_embeddings = features["token_embeddings"]
+        token_embeddings = features[self.module_input_name]
         projected_embeddings = self.activation_function(self.linear(token_embeddings))
         if self.use_residual:
             residual_embeddings = token_embeddings
             if self.in_features != self.out_features:
                 residual_embeddings = self.residual(token_embeddings)
             projected_embeddings = projected_embeddings + residual_embeddings
-        features["token_embeddings"] = projected_embeddings
+        features[self.module_output_name] = projected_embeddings
         return features
 
     @staticmethod
@@ -90,9 +109,10 @@ class Dense(DenseSentenceTransformer):
         Our Dense model does not have the activation function.
         """
         config = dense.get_config_dict()
-        config["activation_function"] = import_from_string(
-            config["activation_function"]
-        )()
+        if "activation_function" in config:
+            act_fn = config["activation_function"]
+            if isinstance(act_fn, str):
+                config["activation_function"] = import_from_string(act_fn)()
         model = Dense(**config)
         model.load_state_dict(dense.state_dict())
         return model
@@ -186,28 +206,46 @@ class Dense(DenseSentenceTransformer):
         return model
 
     def get_config_dict(self):
-        return {**super().get_config_dict(), "use_residual": self.use_residual}
+        config = super().get_config_dict()
+        config["activation_function"] = fullname(self.activation_function)
+        return config
 
-    @staticmethod
-    def load(input_path) -> "Dense":
+    def save(self, output_path: str, *args, safe_serialization: bool = True, **kwargs) -> None:
+        self.save_config(output_path)
+        self.save_torch_weights(output_path, safe_serialization=safe_serialization)
+
+    @classmethod
+    def load(
+        cls,
+        model_name_or_path: str,
+        subfolder: str = "",
+        token: bool | str | None = None,
+        cache_folder: str | None = None,
+        revision: str | None = None,
+        local_files_only: bool = False,
+        trust_remote_code: bool = False,
+        **kwargs,
+    ) -> "Dense":
         """Load a Dense layer."""
-        with open(os.path.join(input_path, "config.json")) as fIn:
-            config = json.load(fIn)
-
-        config["activation_function"] = import_from_string(
-            config["activation_function"]
-        )()
-
-        model = Dense(**config)
-
-        if os.path.exists(os.path.join(input_path, "model.safetensors")):
-            load_safetensors_model(model, os.path.join(input_path, "model.safetensors"))
-            return model
-
-        model.load_state_dict(
-            torch.load(
-                os.path.join(input_path, "pytorch_model.bin"),
-                map_location=torch.device("cpu"),
-            )
-        )
+        hub_kwargs = {
+            "subfolder": subfolder,
+            "token": token,
+            "cache_folder": cache_folder,
+            "revision": revision,
+            "local_files_only": local_files_only,
+        }
+        config = cls.load_config(model_name_or_path=model_name_or_path, **hub_kwargs)
+        if "activation_function" in config:
+            if trust_remote_code or config["activation_function"].startswith("torch."):
+                config["activation_function"] = import_from_string(config["activation_function"])()
+            else:
+                logger.warning(
+                    f"Activation function path '{config['activation_function']}' is not trusted, "
+                    "falling back to the default activation function (Identity). "
+                    "Please load the model with `trust_remote_code=True` to allow loading custom activation "
+                    "functions via the configuration."
+                )
+                del config["activation_function"]
+        model = cls(**config)
+        model = cls.load_torch_weights(model_name_or_path=model_name_or_path, model=model, **hub_kwargs)
         return model

--- a/pylate/models/Dense.py
+++ b/pylate/models/Dense.py
@@ -210,7 +210,9 @@ class Dense(DenseSentenceTransformer):
         config["activation_function"] = fullname(self.activation_function)
         return config
 
-    def save(self, output_path: str, *args, safe_serialization: bool = True, **kwargs) -> None:
+    def save(
+        self, output_path: str, *args, safe_serialization: bool = True, **kwargs
+    ) -> None:
         self.save_config(output_path)
         self.save_torch_weights(output_path, safe_serialization=safe_serialization)
 
@@ -237,7 +239,9 @@ class Dense(DenseSentenceTransformer):
         config = cls.load_config(model_name_or_path=model_name_or_path, **hub_kwargs)
         if "activation_function" in config:
             if trust_remote_code or config["activation_function"].startswith("torch."):
-                config["activation_function"] = import_from_string(config["activation_function"])()
+                config["activation_function"] = import_from_string(
+                    config["activation_function"]
+                )()
             else:
                 logger.warning(
                     f"Activation function path '{config['activation_function']}' is not trusted, "
@@ -247,5 +251,7 @@ class Dense(DenseSentenceTransformer):
                 )
                 del config["activation_function"]
         model = cls(**config)
-        model = cls.load_torch_weights(model_name_or_path=model_name_or_path, model=model, **hub_kwargs)
+        model = cls.load_torch_weights(
+            model_name_or_path=model_name_or_path, model=model, **hub_kwargs
+        )
         return model

--- a/pylate/models/Dense.py
+++ b/pylate/models/Dense.py
@@ -113,6 +113,18 @@ class Dense(DenseSentenceTransformer):
             act_fn = config["activation_function"]
             if isinstance(act_fn, str):
                 config["activation_function"] = import_from_string(act_fn)()
+        # In the ColBERT pipeline the projection always runs on token
+        # embeddings. ST checkpoints whose Dense sits after Pooling (e.g.
+        # sentence-t5, LaBSE) declare "sentence_embedding" as input, which no
+        # longer exists once Pooling is filtered out — reuse the weights
+        # per-token instead.
+        if config.get("module_input_name", "token_embeddings") != "token_embeddings":
+            logger.info(
+                "Converting a sentence-level Dense layer (input "
+                f"'{config['module_input_name']}') to a token-level projection."
+            )
+        config["module_input_name"] = "token_embeddings"
+        config["module_output_name"] = "token_embeddings"
         model = Dense(**config)
         model.load_state_dict(dense.state_dict())
         return model

--- a/pylate/models/_chat_templates.py
+++ b/pylate/models/_chat_templates.py
@@ -28,7 +28,6 @@ no entry, the caller is expected to fall back to the processor's existing
 
 from __future__ import annotations
 
-
 # Shared template for the Qwen2-VL / Qwen2.5-VL / Qwen3-VL / Qwen3.5 family.
 # Matches ColQwen2/2.5/3/3.5 ``visual_prompt_prefix``:
 #     "<|im_start|>user\n<|vision_start|><|image_pad|><|vision_end|>"

--- a/pylate/models/_chat_templates.py
+++ b/pylate/models/_chat_templates.py
@@ -1,0 +1,112 @@
+"""Chat templates that reproduce ``colpali_engine``'s per-processor visual prompts.
+
+Each registered template renders to exactly the string that the corresponding
+``colpali_engine`` processor sends to ``processor(text=..., images=...)``. The
+goal is bit-identical preprocessing when training/inference goes through
+``processor.apply_chat_template`` instead of the colpali_engine processor.
+
+Contract for every template:
+
+- Input: a single conversation (list of messages). Only ``messages[0]`` is
+  consulted; we never emit multi-turn formatting.
+- ``messages[0].content`` is a list of typed dicts (``{type, text/image/video/...}``)
+  because the ST input formatter always picks the ``"structured"`` message
+  format for these VLMs.
+- Image-bearing inputs render the ColPali ``visual_prompt_prefix``, substituting
+  the user-supplied text item (when present) for the default ``"Describe the
+  image."`` placeholder. Audio/video placeholders are not supported here
+  (qwen_omni / video-capable backbones still need bespoke handling).
+- Text-only inputs render the raw text with no chat wrapping, matching
+  ``colpali_engine``'s ``process_texts`` which calls the processor directly on
+  the raw query string. Query augmentation is appended later in
+  ``ColBERT.preprocess``.
+
+The keys are ``transformers`` ``config.model_type`` strings. When a backbone has
+no entry, the caller is expected to fall back to the processor's existing
+``chat_template``.
+"""
+
+from __future__ import annotations
+
+
+# Shared template for the Qwen2-VL / Qwen2.5-VL / Qwen3-VL / Qwen3.5 family.
+# Matches ColQwen2/2.5/3/3.5 ``visual_prompt_prefix``:
+#     "<|im_start|>user\n<|vision_start|><|image_pad|><|vision_end|>"
+#     "Describe the image.<|im_end|><|endoftext|>"
+_QWEN_VL_TEMPLATE = (
+    "{%- set msg = messages[0] -%}"
+    "{%- set ns = namespace(has_image=false, text='') -%}"
+    "{%- for item in msg.content -%}"
+    "{%- if item.type == 'image' -%}{%- set ns.has_image = true -%}"
+    "{%- elif item.type == 'text' -%}{%- set ns.text = item.text -%}"
+    "{%- endif -%}"
+    "{%- endfor -%}"
+    "{%- if ns.has_image -%}"
+    "<|im_start|>user\n"
+    "<|vision_start|><|image_pad|><|vision_end|>"
+    "{{ ns.text if ns.text else 'Describe the image.' }}"
+    "<|im_end|><|endoftext|>"
+    "{%- else -%}"
+    "{{ ns.text }}"
+    "{%- endif -%}"
+)
+
+
+# ColPali (PaliGemma). Matches ``visual_prompt_prefix = "<image><bos>Describe the image."``
+# and the query path ``bos_token + query`` from ``ColPaliProcessor.process_texts``.
+_PALIGEMMA_TEMPLATE = (
+    "{%- set msg = messages[0] -%}"
+    "{%- set ns = namespace(has_image=false, text='') -%}"
+    "{%- for item in msg.content -%}"
+    "{%- if item.type == 'image' -%}{%- set ns.has_image = true -%}"
+    "{%- elif item.type == 'text' -%}{%- set ns.text = item.text -%}"
+    "{%- endif -%}"
+    "{%- endfor -%}"
+    "{%- if ns.has_image -%}"
+    "<image><bos>{{ ns.text if ns.text else 'Describe the image.' }}"
+    "{%- else -%}"
+    "<bos>{{ ns.text }}"
+    "{%- endif -%}"
+)
+
+
+# ColIdefics3. Matches
+#     "<|im_start|>User:<image>Describe the image.<end_of_utterance>\nAssistant:"
+_IDEFICS3_TEMPLATE = (
+    "{%- set msg = messages[0] -%}"
+    "{%- set ns = namespace(has_image=false, text='') -%}"
+    "{%- for item in msg.content -%}"
+    "{%- if item.type == 'image' -%}{%- set ns.has_image = true -%}"
+    "{%- elif item.type == 'text' -%}{%- set ns.text = item.text -%}"
+    "{%- endif -%}"
+    "{%- endfor -%}"
+    "{%- if ns.has_image -%}"
+    "<|im_start|>User:<image>"
+    "{{ ns.text if ns.text else 'Describe the image.' }}"
+    "<end_of_utterance>\nAssistant:"
+    "{%- else -%}"
+    "{{ ns.text }}"
+    "{%- endif -%}"
+)
+
+
+COLPALI_CHAT_TEMPLATES: dict[str, str] = {
+    # PaliGemma backbone — original ColPali.
+    "paligemma": _PALIGEMMA_TEMPLATE,
+    # Qwen2-VL family (Qwen2 / Qwen2.5 / Qwen3 / Qwen3.5 all share the same prompt).
+    "qwen2_vl": _QWEN_VL_TEMPLATE,
+    "qwen2_5_vl": _QWEN_VL_TEMPLATE,
+    "qwen3_vl": _QWEN_VL_TEMPLATE,
+    "qwen3_vl_moe": _QWEN_VL_TEMPLATE,
+    # Idefics3 backbone.
+    "idefics3": _IDEFICS3_TEMPLATE,
+    # ColModernVBert: same prompt structure as Idefics3 but with a <|begin_of_text|>
+    # opener instead of <|im_start|>. Registered under the upstream model_type
+    # (left as TODO until the model_type string is confirmed at load time).
+}
+
+
+# Key under which we register the ColPali-flavored template in
+# ``processor.chat_template``. Matches the file name HF writes under
+# ``additional_chat_templates/<name>.jinja`` on save.
+COLPALI_TEMPLATE_NAME = "sentence_transformers"

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -250,7 +250,7 @@ class ColBERT(SentenceTransformer):
             model_card_data=model_card_data,
             backend=backend,
         )
-        hidden_size = self[0].get_word_embedding_dimension()
+        hidden_size = self[0].get_embedding_dimension()
 
         # Add a linear projection layer to the model in order to project the embeddings to the desired size.
         if len(self) < 2:

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -1862,13 +1862,44 @@ class ColBERT(SentenceTransformer):
         try:
             config = AutoConfig.from_pretrained(model_name_or_path, **config_kwargs)
         except Exception:
-            return None, None
+            # LoRA adapter repos have no config.json — resolve via adapter_config.json.
+            config = ColBERT._resolve_adapter_config(
+                model_name_or_path, config_kwargs
+            )
+            if config is None:
+                return None, None
         architectures = getattr(config, "architectures", None) or []
         for arch in architectures:
             if arch in _COLPALI_TO_BASE_ARCHITECTURE:
                 return arch, config
         return None, config
-        return None
+
+    @staticmethod
+    def _resolve_adapter_config(
+        model_name_or_path: str,
+        config_kwargs: dict[str, Any],
+    ) -> Any | None:
+        """Try to load the base model config from a LoRA adapter repo."""
+        import json
+
+        from transformers import AutoConfig
+
+        try:
+            from huggingface_hub import hf_hub_download
+
+            hub_kwargs = {
+                k: v
+                for k, v in config_kwargs.items()
+                if k in ("token", "revision", "local_files_only")
+            }
+            adapter_path = hf_hub_download(
+                model_name_or_path, "adapter_config.json", **hub_kwargs
+            )
+            with open(adapter_path) as f:
+                base_model = json.loads(f.read())["base_model_name_or_path"]
+            return AutoConfig.from_pretrained(base_model, **config_kwargs)
+        except Exception:
+            return None
 
     @staticmethod
     def _extract_colpali_projection(

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -1362,6 +1362,23 @@ class ColBERT(SentenceTransformer):
 
         return [transformer_model], None
 
+    @staticmethod
+    def _filter_non_colbert_modules(
+        modules: list[nn.Module] | OrderedDict[str, nn.Module],
+    ) -> list[nn.Module] | OrderedDict[str, nn.Module]:
+        """Filter modules to only keep Transformer and Dense modules (remove Pooling, etc.)."""
+        if isinstance(modules, OrderedDict):
+            return OrderedDict(
+                (name, module)
+                for name, module in modules.items()
+                if isinstance(module, (Transformer, DenseSentenceTransformer))
+            )
+        return [
+            module
+            for module in modules
+            if isinstance(module, (Transformer, DenseSentenceTransformer))
+        ]
+
     def _load_config_modules(
         self,
         model_name_or_path: str,
@@ -1386,21 +1403,7 @@ class ColBERT(SentenceTransformer):
             processor_kwargs=processor_kwargs,
             config_kwargs=config_kwargs,
         )
-
-        # Filter to only Transformer + Dense modules (no Pooling)
-        if isinstance(modules, OrderedDict):
-            filtered = OrderedDict()
-            for name, module in modules.items():
-                if isinstance(module, (Transformer, DenseSentenceTransformer)):
-                    filtered[name] = module
-            return filtered, module_kwargs
-        else:
-            filtered = [
-                module
-                for module in modules
-                if isinstance(module, (Transformer, DenseSentenceTransformer))
-            ]
-            return filtered, module_kwargs
+        return self._filter_non_colbert_modules(modules), module_kwargs
 
     def _load_converted_modules(
         self,
@@ -1428,21 +1431,7 @@ class ColBERT(SentenceTransformer):
             processor_kwargs=processor_kwargs,
             config_kwargs=config_kwargs,
         )
-
-        # Filter to only Transformer + Dense modules (no Pooling)
-        if isinstance(modules, OrderedDict):
-            filtered = OrderedDict()
-            for name, module in modules.items():
-                if isinstance(module, (Transformer, DenseSentenceTransformer)):
-                    filtered[name] = module
-            return filtered, module_kwargs
-        else:
-            filtered = [
-                module
-                for module in modules
-                if isinstance(module, (Transformer, DenseSentenceTransformer))
-            ]
-            return filtered, module_kwargs
+        return self._filter_non_colbert_modules(modules), module_kwargs
 
     def _get_model_type(
         self,

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -1449,6 +1449,11 @@ class ColBERT(SentenceTransformer):
         .. deprecated::
             Use :meth:`preprocess` instead.
         """
+        warnings.warn(
+            "tokenize() is deprecated, use preprocess() instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
         return self.preprocess(inputs=texts, is_query=is_query, pad=pad, task=task)
 
     def _configure_chat_template(

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -1292,11 +1292,22 @@ class ColBERT(SentenceTransformer):
         max_length = self.query_length if is_query else self.document_length
         prefix_id = self.query_prefix_id if is_query else self.document_prefix_id
         use_prefix = prefix_id is not None
-        target_length = max_length - 1 if use_prefix else max_length
 
-        text_kwargs: dict[str, Any] = {"max_length": target_length}
-        if pad or (is_query and self.do_query_expansion):
-            text_kwargs["padding"] = "max_length"
+        # ColPali models use suffix-based query expansion: append N expansion
+        # tokens after the full query text (matching colpali_engine's
+        # ``process_queries`` which appends ``query_augmentation_token * N``).
+        # Classic ColBERT uses pad-to-fixed-length expansion instead.
+        use_suffix_expansion = (
+            is_query and self.do_query_expansion and self._is_colpali_model
+        )
+
+        if use_suffix_expansion:
+            text_kwargs: dict[str, Any] = {}
+        else:
+            target_length = max_length - 1 if use_prefix else max_length
+            text_kwargs = {"max_length": target_length}
+            if pad or (is_query and self.do_query_expansion):
+                text_kwargs["padding"] = "max_length"
 
         # For multimodal inputs (images, etc.), skip text processing_kwargs:
         # VLM processors expand visual placeholders (e.g. <|image_pad|>) in the
@@ -1306,8 +1317,15 @@ class ColBERT(SentenceTransformer):
         # tokenizer max_length.
         tokenized_outputs = self._first_module().preprocess(
             inputs,
-            processing_kwargs={"text": text_kwargs} if self._is_text_input(inputs) else None,
+            processing_kwargs={"text": text_kwargs}
+            if self._is_text_input(inputs)
+            else None,
         )
+
+        if use_suffix_expansion:
+            tokenized_outputs = self._append_expansion_tokens(
+                tokenized_outputs, n_tokens=10,
+            )
 
         if use_prefix:
             tokenized_outputs["input_ids"] = self.insert_prefix_token(
@@ -1321,10 +1339,54 @@ class ColBERT(SentenceTransformer):
                     tokenized_outputs["token_type_ids"], 0
                 )
 
-        if is_query and self.attend_to_expansion_tokens:
+        if is_query and self.attend_to_expansion_tokens and "attention_mask" in tokenized_outputs:
             tokenized_outputs["attention_mask"].fill_(1)
 
         return tokenized_outputs
+
+    def _append_expansion_tokens(
+        self,
+        features: dict[str, torch.Tensor],
+        n_tokens: int,
+    ) -> dict[str, torch.Tensor]:
+        """Append *n_tokens* expansion tokens (pad_token_id) to each sequence.
+
+        Unlike pad-to-fixed-length expansion, this preserves the full query
+        text and always appends exactly *n_tokens* regardless of input length,
+        matching ``colpali_engine``'s ``process_queries`` behavior.
+        """
+        batch_size = features["input_ids"].shape[0]
+        device = features["input_ids"].device
+
+        pad_ids = torch.full(
+            (batch_size, n_tokens),
+            self.tokenizer.pad_token_id,
+            dtype=features["input_ids"].dtype,
+            device=device,
+        )
+        features["input_ids"] = torch.cat([features["input_ids"], pad_ids], dim=1)
+
+        if "attention_mask" in features:
+            ones = torch.ones(
+                batch_size, n_tokens,
+                dtype=features["attention_mask"].dtype,
+                device=device,
+            )
+            features["attention_mask"] = torch.cat(
+                [features["attention_mask"], ones], dim=1,
+            )
+
+        if "token_type_ids" in features:
+            zeros = torch.zeros(
+                batch_size, n_tokens,
+                dtype=features["token_type_ids"].dtype,
+                device=device,
+            )
+            features["token_type_ids"] = torch.cat(
+                [features["token_type_ids"], zeros], dim=1,
+            )
+
+        return features
 
     def tokenize(
         self,

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -149,9 +149,7 @@ def _load_colpali_proj_tensors(
             lora_r = adapter_cfg.get("r", 1)
             scaling = lora_alpha / lora_r
 
-            base_hub_kwargs = {
-                k: v for k, v in hub_kwargs.items() if k != "revision"
-            }
+            base_hub_kwargs = {k: v for k, v in hub_kwargs.items() if k != "revision"}
             base_tensors = _load_colpali_proj_tensors(
                 base_model_name, weight_key, bias_key, **base_hub_kwargs
             )
@@ -171,7 +169,6 @@ def _load_colpali_proj_tensors(
             model_name_or_path,
             e,
         )
-
 
     raise ValueError(
         f"Could not find projection weights ending in '{weight_key}' "
@@ -732,10 +729,9 @@ class ColBERT(SentenceTransformer):
                 [e - s for s, e in zip(cu[:-1], cu[1:])], device=flat_emb.device
             )
             T_max = features["input_ids"].shape[1]
-            features["attention_mask"] = (
-                torch.arange(T_max, device=flat_emb.device).unsqueeze(0)
-                < lengths.unsqueeze(1)
-            )
+            features["attention_mask"] = torch.arange(
+                T_max, device=flat_emb.device
+            ).unsqueeze(0) < lengths.unsqueeze(1)
             # Clean up unpadding-specific keys that downstream code doesn't expect
             for key in (
                 "cu_seq_lens_q",

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -1814,6 +1814,11 @@ class ColBERT(SentenceTransformer):
         )
         base_proc_name = PROCESSOR_MAPPING_NAMES.get(config.model_type)
         if base_proc_name is None:
+            logger.warning(
+                f"Could not find a base processor for model_type={config.model_type!r} "
+                f"in PROCESSOR_MAPPING_NAMES — the colpali-engine processor will not be "
+                f"replaced. Consider upgrading transformers."
+            )
             return
 
         base_proc_cls = getattr(importlib.import_module("transformers"), base_proc_name)

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -649,22 +649,7 @@ class ColBERT(SentenceTransformer):
             sentences = [sentences]
             input_was_string = True
 
-        if prompt is not None and prompt_name is not None:
-            logger.warning(
-                "Provide either a `prompt` or a `prompt_name`, not both. "
-                "Ignoring the `prompt_name` in favor of the provided `prompt`."
-            )
-
-        elif prompt is None:
-            if prompt_name is not None:
-                prompt = self.prompts.get(prompt_name)
-                if prompt is None:
-                    raise ValueError(
-                        f"Prompt name '{prompt_name}' not found in the configured prompts dictionary. "
-                        f"Available keys are: {list(self.prompts.keys())!r}."
-                    )
-            else:
-                prompt = self.prompts.get(self.default_prompt_name)
+        prompt = self._resolve_prompt(prompt, prompt_name)
 
         extra_features = {}
         if prompt is not None:

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -1167,7 +1167,7 @@ class ColBERT(SentenceTransformer):
 
         # For multimodal inputs, delegate to the multimodal preprocessing path
         if not self._is_text_input(inputs):
-            return self._preprocess_multimodal(inputs)
+            return self._preprocess_multimodal(inputs, is_query=is_query)
 
         # Set max sequence length based on whether the input is a query or document
         max_length = self.query_length if is_query else self.document_length
@@ -1228,21 +1228,23 @@ class ColBERT(SentenceTransformer):
     def _preprocess_multimodal(
         self,
         inputs: list,
+        is_query: bool = True,
     ) -> dict[str, torch.Tensor]:
         """Preprocess multimodal inputs (images, etc.) by delegating to the base transformer's preprocessor.
 
         For multimodal inputs, we skip prefix token insertion and query expansion
         since the VLM processor handles special tokens natively.
+
+        Parameters
+        ----------
+        inputs
+            A list of multimodal inputs to preprocess.
+        is_query
+            Whether the inputs are queries. Can be used to set different max lengths
+            or add metadata for downstream processing.
         """
         first_module = self._first_module()
-        if hasattr(first_module, "preprocess"):
-            return first_module.preprocess(inputs)
-        elif hasattr(first_module, "tokenize"):
-            return first_module.tokenize(inputs)
-        raise NotImplementedError(
-            "The first module does not support multimodal preprocessing. "
-            "Ensure the transformer module has a `preprocess` method."
-        )
+        return first_module.preprocess(inputs)
 
     def save(
         self,

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -700,48 +700,47 @@ class ColBERT(SentenceTransformer):
     def __len__(self) -> int:
         return len(self._modules)
 
-    def forward(self, features: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
-        features = super().forward(features, **kwargs)
-        # When sentence-transformers' unpadding optimization is active (FA2
-        # with variable-length support), the Transformer forward pass
-        # concatenates all sequences into a single flat tensor:
-        #   token_embeddings: (1, sum_of_lengths, D)
-        #   input_ids:        (1, sum_of_lengths)
-        #   no attention_mask — replaced by cu_seq_lens_q, seq_idx, etc.
-        #
-        # PyLate's encode() and loss functions expect the standard padded
-        # batch layout (B, T, D) with an attention_mask. Re-pad here so
-        # all downstream code sees the usual shapes.
-        if "cu_seq_lens_q" in features:
-            cu = features["cu_seq_lens_q"].tolist()
-            flat_emb = features["token_embeddings"][0]
-            flat_ids = features["input_ids"][0]
-            emb_chunks = [flat_emb[s:e] for s, e in zip(cu[:-1], cu[1:])]
-            id_chunks = [flat_ids[s:e] for s, e in zip(cu[:-1], cu[1:])]
-            features["token_embeddings"] = torch.nn.utils.rnn.pad_sequence(
-                emb_chunks, batch_first=True, padding_value=0.0
-            )
-            features["input_ids"] = torch.nn.utils.rnn.pad_sequence(
-                id_chunks, batch_first=True, padding_value=0
-            )
-            # Reconstruct the attention_mask from the per-sequence lengths
-            lengths = torch.tensor(
-                [e - s for s, e in zip(cu[:-1], cu[1:])], device=flat_emb.device
-            )
-            T_max = features["input_ids"].shape[1]
-            features["attention_mask"] = torch.arange(
-                T_max, device=flat_emb.device
-            ).unsqueeze(0) < lengths.unsqueeze(1)
-            # Clean up unpadding-specific keys that downstream code doesn't expect
-            for key in (
-                "cu_seq_lens_q",
-                "cu_seq_lens_k",
-                "max_length_q",
-                "max_length_k",
-                "seq_idx",
-                "position_ids",
-            ):
-                features.pop(key, None)
+    def forward(self, input: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        return self._repad_unpadded_features(super().forward(input, **kwargs))
+
+    @staticmethod
+    def _repad_unpadded_features(features: dict[str, Any]) -> dict[str, Any]:
+        """Restore padded batch layout from sentence-transformers' unpadding optimization.
+
+        When FA2 with variable-length support is active, the Transformer forward
+        pass concatenates all sequences into a single flat tensor. PyLate's
+        encode() and loss functions expect the standard padded batch layout
+        (B, T, D) with an attention_mask, so we re-pad here.
+        """
+        if "cu_seq_lens_q" not in features:
+            return features
+        cu = features["cu_seq_lens_q"].tolist()
+        flat_emb = features["token_embeddings"][0]
+        flat_ids = features["input_ids"][0]
+        emb_chunks = [flat_emb[s:e] for s, e in zip(cu[:-1], cu[1:])]
+        id_chunks = [flat_ids[s:e] for s, e in zip(cu[:-1], cu[1:])]
+        features["token_embeddings"] = torch.nn.utils.rnn.pad_sequence(
+            emb_chunks, batch_first=True, padding_value=0.0
+        )
+        features["input_ids"] = torch.nn.utils.rnn.pad_sequence(
+            id_chunks, batch_first=True, padding_value=0
+        )
+        lengths = torch.tensor(
+            [e - s for s, e in zip(cu[:-1], cu[1:])], device=flat_emb.device
+        )
+        T_max = features["input_ids"].shape[1]
+        features["attention_mask"] = torch.arange(
+            T_max, device=flat_emb.device
+        ).unsqueeze(0) < lengths.unsqueeze(1)
+        for key in (
+            "cu_seq_lens_q",
+            "cu_seq_lens_k",
+            "max_length_q",
+            "max_length_k",
+            "seq_idx",
+            "position_ids",
+        ):
+            features.pop(key, None)
         return features
 
     @staticmethod

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -4,7 +4,6 @@ import copy
 import json
 import logging
 import math
-import os
 import string
 import warnings
 from collections import OrderedDict
@@ -502,7 +501,9 @@ class ColBERT(SentenceTransformer):
                 return True
             # list of dicts or tuples of strings are text inputs
             if isinstance(first, (dict, tuple)):
-                return isinstance(first, tuple) and all(isinstance(s, str) for s in first)
+                return isinstance(first, tuple) and all(
+                    isinstance(s, str) for s in first
+                )
         return False
 
     @deprecated_kwargs(sentences="inputs")
@@ -1153,6 +1154,8 @@ class ColBERT(SentenceTransformer):
             Task identifier (for compatibility with Router-based models). Defaults to None.
         texts
             Deprecated alias for `inputs`. Use `inputs` instead.
+        **kwargs
+            Additional keyword arguments (ignored, kept for API compatibility).
 
         Returns
         -------
@@ -1299,7 +1302,10 @@ class ColBERT(SentenceTransformer):
             self.query_length = model_config["query_length"]
         if "document_length" in model_config and self.document_length is None:
             self.document_length = model_config["document_length"]
-        if "attend_to_expansion_tokens" in model_config and self.attend_to_expansion_tokens is None:
+        if (
+            "attend_to_expansion_tokens" in model_config
+            and self.attend_to_expansion_tokens is None
+        ):
             self.attend_to_expansion_tokens = model_config["attend_to_expansion_tokens"]
         if "skiplist_words" in model_config and self.skiplist_words is None:
             self.skiplist_words = model_config["skiplist_words"]

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -656,21 +656,19 @@ class ColBERT(SentenceTransformer):
         if not self.do_query_expansion:
             self.attend_to_expansion_tokens = False
 
-        # Flash Attention's unpadding optimization physically removes padding
-        # tokens from the sequence. Query expansion relies on padding queries
-        # to ``query_length`` with expansion tokens — if those get stripped,
-        # expansion silently doesn't happen. Disable unpadding so the
-        # expansion tokens survive through the forward pass.
-        if self.do_query_expansion:
-            first = self._first_module()
-            if getattr(first, "unpad_inputs", None) is not False:
-                first.unpad_inputs = False
-
+        # When expansion tokens are not attended (attention_mask=0), unpadding
+        # physically removes them from the sequence; expansion silently
+        # doesn't happen. Disable unpadding so they survive the forward pass.
+        # When expansion tokens ARE attended, unpadding keeps them, so it's safe.
+        if self.do_query_expansion and not self.attend_to_expansion_tokens:
             # attend_to_expansion_tokens=False is incompatible with Flash
             # Attention: FA does not support arbitrary per-token attention
             # masks, so masking out expansion tokens silently degrades scores.
-            if not self.attend_to_expansion_tokens:
-                self._check_expansion_fa_compat()
+            self._check_expansion_fa_compat()
+
+            first = self._first_module()
+            if getattr(first, "unpad_inputs", None) is not False:
+                first.unpad_inputs = False
 
     def _check_expansion_fa_compat(self) -> None:
         """Raise if expansion tokens would be unattended under Flash Attention.
@@ -704,6 +702,51 @@ class ColBERT(SentenceTransformer):
 
     def __len__(self) -> int:
         return len(self._modules)
+
+    def forward(self, features: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        features = super().forward(features, **kwargs)
+        # When sentence-transformers' unpadding optimization is active (FA2
+        # with variable-length support), the Transformer forward pass
+        # concatenates all sequences into a single flat tensor:
+        #   token_embeddings: (1, sum_of_lengths, D)
+        #   input_ids:        (1, sum_of_lengths)
+        #   no attention_mask — replaced by cu_seq_lens_q, seq_idx, etc.
+        #
+        # PyLate's encode() and loss functions expect the standard padded
+        # batch layout (B, T, D) with an attention_mask. Re-pad here so
+        # all downstream code sees the usual shapes.
+        if "cu_seq_lens_q" in features:
+            cu = features["cu_seq_lens_q"].tolist()
+            flat_emb = features["token_embeddings"][0]
+            flat_ids = features["input_ids"][0]
+            emb_chunks = [flat_emb[s:e] for s, e in zip(cu[:-1], cu[1:])]
+            id_chunks = [flat_ids[s:e] for s, e in zip(cu[:-1], cu[1:])]
+            features["token_embeddings"] = torch.nn.utils.rnn.pad_sequence(
+                emb_chunks, batch_first=True, padding_value=0.0
+            )
+            features["input_ids"] = torch.nn.utils.rnn.pad_sequence(
+                id_chunks, batch_first=True, padding_value=0
+            )
+            # Reconstruct the attention_mask from the per-sequence lengths
+            lengths = torch.tensor(
+                [e - s for s, e in zip(cu[:-1], cu[1:])], device=flat_emb.device
+            )
+            T_max = features["input_ids"].shape[1]
+            features["attention_mask"] = (
+                torch.arange(T_max, device=flat_emb.device).unsqueeze(0)
+                < lengths.unsqueeze(1)
+            )
+            # Clean up unpadding-specific keys that downstream code doesn't expect
+            for key in (
+                "cu_seq_lens_q",
+                "cu_seq_lens_k",
+                "max_length_q",
+                "max_length_k",
+                "seq_idx",
+                "position_ids",
+            ):
+                features.pop(key, None)
+        return features
 
     @staticmethod
     def insert_prefix_token(input_ids: torch.Tensor, prefix_id: int) -> torch.Tensor:

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -470,6 +470,17 @@ class ColBERT(SentenceTransformer):
         if not self.do_query_expansion:
             self.attend_to_expansion_tokens = False
 
+        # TODO: verify — capture the construction-time tokenizer cap so multimodal
+        # preprocess can restore it (see `_preprocess_multimodal`). Mirrors what
+        # colpali_engine does: image processing leaves `model_max_length` alone
+        # and relies on `max_pixels` / `max_num_visual_tokens` to bound the
+        # visual block. The text path here mutates `first_module.max_seq_length`
+        # per call (to `query_length` / `document_length`), which would otherwise
+        # leak into a subsequent multimodal call and truncate the expanded
+        # `<|image_pad|>` block below the visual budget.
+        first_module = self._first_module()
+        self._multimodal_max_seq_length = getattr(first_module, "max_seq_length", None)
+
     @staticmethod
     def load(input_path) -> "ColBERT":
         return ColBERT(model_name_or_path=input_path)
@@ -1260,6 +1271,19 @@ class ColBERT(SentenceTransformer):
         For multimodal inputs, we skip prefix token insertion and query expansion
         since the VLM processor handles special tokens natively.
 
+        TODO: verify — restores the construction-time tokenizer cap captured in
+        ``__init__``. The text branch of ``preprocess`` mutates
+        ``first_module.max_seq_length`` to ``query_length`` /
+        ``document_length`` per call, and that propagates onto the underlying
+        tokenizer's ``model_max_length``. Without restoring here, a prior text
+        encode (e.g. a text query at ``query_length=32``) leaves the cap at 32,
+        the VLM processor's `<|image_pad|>` expansion runs *before*
+        tokenization, and the tokenizer truncates the expanded block —
+        ``processor._check_special_mm_tokens`` then raises a count mismatch.
+        ``colpali_engine`` avoids this by never touching ``model_max_length``
+        in its image/text processing paths and bounding the visual block via
+        ``max_pixels`` / ``max_num_visual_tokens`` instead.
+
         Parameters
         ----------
         inputs
@@ -1269,6 +1293,8 @@ class ColBERT(SentenceTransformer):
             or add metadata for downstream processing.
         """
         first_module = self._first_module()
+        if self._multimodal_max_seq_length is not None:
+            first_module.max_seq_length = self._multimodal_max_seq_length
         return first_module.preprocess(inputs)
 
     def save(

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -726,9 +726,12 @@ class ColBERT(SentenceTransformer):
                 else:
                     if self.do_query_expansion:
                         # We keep all tokens in the query (no skiplist) and we do not want to prune expansion tokens in queries even if we do not attend to them in attention layers
-                        masks = torch.ones_like(
-                            input=out_features["input_ids"], dtype=torch.bool
-                        )
+                        if "input_ids" in out_features:
+                            masks = torch.ones_like(
+                                input=out_features["input_ids"], dtype=torch.bool
+                            )
+                        else:
+                            masks = out_features["attention_mask"].bool()
                     else:
                         # We only keep the original tokens and prune padding tokens
                         masks = out_features["attention_mask"].bool()

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -701,47 +701,7 @@ class ColBERT(SentenceTransformer):
                 features = self._preprocess_multimodal(sentences_batch)
 
             if self.device.type == "hpu":
-                if "input_ids" in features:
-                    curr_tokenize_len = features["input_ids"].shape
-
-                    additional_pad_len = (
-                        2 ** math.ceil(math.log2(curr_tokenize_len[1]))
-                        - curr_tokenize_len[1]
-                    )
-
-                    features["input_ids"] = torch.cat(
-                        tensors=(
-                            features["input_ids"],
-                            torch.ones(
-                                size=(curr_tokenize_len[0], additional_pad_len),
-                                dtype=torch.int8,
-                            ),
-                        ),
-                        dim=-1,
-                    )
-
-                    features["attention_mask"] = torch.cat(
-                        tensors=(
-                            features["attention_mask"],
-                            torch.zeros(
-                                size=(curr_tokenize_len[0], additional_pad_len),
-                                dtype=torch.int8,
-                            ),
-                        ),
-                        dim=-1,
-                    )
-
-                    if "token_type_ids" in features:
-                        features["token_type_ids"] = torch.cat(
-                            tensors=(
-                                features["token_type_ids"],
-                                torch.zeros(
-                                    size=(curr_tokenize_len[0], additional_pad_len),
-                                    dtype=torch.int8,
-                                ),
-                            ),
-                            dim=-1,
-                        )
+                features = self._pad_features_for_hpu(features)
 
             features = batch_to_device(batch=features, target_device=device)
             features.update(extra_features)

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -27,6 +27,7 @@ from transformers.utils import cached_file
 from ..hf_hub.model_card import PylateModelCardData
 from ..scores import SimilarityFunction
 from ..utils import _start_multi_process_pool
+from ._chat_templates import COLPALI_CHAT_TEMPLATES, COLPALI_TEMPLATE_NAME
 from .Dense import Dense
 
 logger = logging.getLogger(__name__)
@@ -249,6 +250,14 @@ class ColBERT(SentenceTransformer):
             model_card_data=model_card_data,
             backend=backend,
         )
+
+        # Wire a ColPali-faithful chat template into the multimodal preprocessor.
+        # Priority: explicit user override in processor_kwargs > template saved
+        # in `additional_chat_templates/sentence_transformers.jinja` on the
+        # checkpoint > built-in registry default for this `config.model_type` >
+        # leave the processor's existing chat_template untouched.
+        self._configure_chat_template(user_processor_kwargs=processor_kwargs)
+
         hidden_size = self[0].get_embedding_dimension()
 
         # Add a linear projection layer to the model in order to project the embeddings to the desired size.
@@ -502,9 +511,7 @@ class ColBERT(SentenceTransformer):
             tensors=[input_ids[:, :1], prefix_tensor, input_ids[:, 1:]], dim=1
         )
 
-    _MULTIMODAL_KEYS = frozenset(
-        {"image", "images", "pixel_values", "audio", "video"}
-    )
+    _MULTIMODAL_KEYS = frozenset({"image", "images", "pixel_values", "audio", "video"})
 
     @staticmethod
     def _is_text_input(inputs) -> bool:
@@ -518,9 +525,9 @@ class ColBERT(SentenceTransformer):
             if isinstance(first, tuple):
                 return all(isinstance(s, str) for s in first)
             if isinstance(first, dict):
-                return not any(
-                    k in ColBERT._MULTIMODAL_KEYS for k in first
-                ) and all(isinstance(v, str) for v in first.values())
+                return not any(k in ColBERT._MULTIMODAL_KEYS for k in first) and all(
+                    isinstance(v, str) for v in first.values()
+                )
         return False
 
     @deprecated_kwargs(sentences="inputs")
@@ -1296,6 +1303,149 @@ class ColBERT(SentenceTransformer):
         if self._multimodal_max_seq_length is not None:
             first_module.max_seq_length = self._multimodal_max_seq_length
         return first_module.preprocess(inputs)
+
+    def _configure_chat_template(
+        self,
+        user_processor_kwargs: dict | None,
+    ) -> None:
+        """Configure a ColPali-faithful chat template on the multimodal processor.
+
+        Run once at construction time, after the parent SentenceTransformer init
+        has loaded the processor. The resolution order is:
+
+        1. **User override at construction**: ``processor_kwargs["chat_template"]``
+           contains a ``chat_template`` entry. Install the user's value under
+           the ``"sentence_transformers"`` slot so ``save_pretrained`` persists
+           it to disk for downstream usage, then rewire the ST kwarg to resolve
+           through the slot. The one exception is when the user's value *is* the
+           slot name — that means "use whatever the slot already holds", so we
+           fall through to cases (2)–(4) to populate it.
+        2. **Persisted ColPali pin**: the loaded module has
+           ``processing_kwargs["chat_template"]["chat_template"] == "sentence_transformers"``
+           in ``sentence_bert_config.json``. This is exactly the shape a prior
+           ``save_pretrained`` of an installed ColBERT writes. Any *other* value
+           (raw Jinja, different named template, unrelated kwarg) is treated as
+           a non-ColPali setup and falls through to the registry — the user
+           gets ColPali-faithful preprocessing by default.
+        3. **Persisted HF processor template**: ``processor.chat_template`` is
+           already a dict containing ``"sentence_transformers"``. HF's
+           ``from_pretrained`` loaded it from
+           ``additional_chat_templates/sentence_transformers.jinja``. Covers
+           checkpoints with the HF half but no ST-side wiring.
+        4. **Registry default**: a built-in entry exists for
+           ``config.model_type``. Install it under the ``"sentence_transformers"``
+           key, preserving the model's original template as ``"default"``.
+        5. **Fallback**: leave ``processor.chat_template`` untouched.
+
+        When option 3 or 4 fires, we also set
+        ``processing_kwargs["chat_template"]["chat_template"] = "sentence_transformers"``
+        on the multimodal Transformer so every ``apply_chat_template`` call
+        resolves the named template. HF's ``processor.save_pretrained`` writes
+        named entries to ``additional_chat_templates/<name>.jinja``
+        automatically, and ST persists the kwarg via
+        ``sentence_bert_config.json``; together they make save/reload land in
+        case (2) or (3) on the next construction.
+        """
+        first_module = self._first_module()
+        processor = getattr(first_module, "processor", None)
+        if processor is None:
+            return
+
+        # (1) Honor any explicit chat_template the user passed at construction time.
+        user_chat_kwargs = (
+            (user_processor_kwargs or {}).get("chat_template")
+            if isinstance(user_processor_kwargs, dict)
+            else None
+        )
+        # If the user passed a chat_template value, install it under our named
+        # slot so ``save_pretrained`` persists it to disk for downstream usage,
+        # and rewire the ST kwarg to resolve through the slot. Skip the install
+        # only when the user's value is literally our slot name — that means
+        # "use whatever the slot holds", so we fall through to cases (2)–(4) to
+        # fill the slot from persisted state or the registry.
+        if isinstance(user_chat_kwargs, dict) and "chat_template" in user_chat_kwargs:
+            user_value = user_chat_kwargs["chat_template"]
+            if user_value != COLPALI_TEMPLATE_NAME:
+                self._install_named_template(processor, user_value)
+                self._set_chat_template_name(first_module)
+                return
+
+        # (2) Respect a chat template already persisted on the ST module — but
+        # ONLY when it's our named pin. ``sentence_bert_config.json`` round-trips
+        # ``processing_kwargs`` (``Transformer.config_keys`` includes it), and a
+        # prior ``save_pretrained`` of an installed ColBERT lands here as
+        # ``{"chat_template": "sentence_transformers"}``. Any other value (a
+        # raw Jinja string, a different named template, or an unrelated kwarg
+        # like ``add_generation_prompt``) is *not* a ColPali pin — fall through
+        # to the registry so the user gets ColPali-faithful preprocessing.
+        module_chat_kwargs = getattr(first_module, "processing_kwargs", {}).get(
+            "chat_template"
+        )
+        if (
+            isinstance(module_chat_kwargs, dict)
+            and module_chat_kwargs.get("chat_template") == COLPALI_TEMPLATE_NAME
+        ):
+            return
+
+        existing = getattr(processor, "chat_template", None)
+
+        # (3) Reuse a previously-saved sentence_transformers template on the
+        # processor itself — HF's ``from_pretrained`` loads it back from
+        # ``additional_chat_templates/sentence_transformers.jinja``. This covers
+        # checkpoints that ship the HF half but not (yet) the ST-side wiring
+        # (e.g. a single-vector ST checkpoint saved before PyLate's install ran).
+        if isinstance(existing, dict) and COLPALI_TEMPLATE_NAME in existing:
+            self._set_chat_template_name(first_module)
+            return
+
+        # (4) Register a built-in default for known ColPali backbones.
+        model_type = getattr(getattr(first_module, "model", None), "config", None)
+        model_type = getattr(model_type, "model_type", None)
+        template = COLPALI_CHAT_TEMPLATES.get(model_type) if model_type else None
+        if template is None:
+            return  # (5) leave the processor's chat_template alone
+
+        self._install_named_template(processor, template)
+        self._set_chat_template_name(first_module)
+
+    @staticmethod
+    def _install_named_template(processor, template: str) -> None:
+        """Install ``template`` under the ``sentence_transformers`` slot of
+        ``processor.chat_template``, preserving the model's original template as
+        the ``default`` key. HF's ``processor.save_pretrained`` walks this dict
+        and writes ``chat_template.jinja`` (default) plus
+        ``additional_chat_templates/sentence_transformers.jinja`` (named entry).
+        """
+        existing = getattr(processor, "chat_template", None)
+        if isinstance(existing, dict):
+            updated = dict(existing)
+            updated[COLPALI_TEMPLATE_NAME] = template
+            # Preserve whatever was already the default key; if none, materialize
+            # one so apply_chat_template(chat_template=None) still works.
+            updated.setdefault("default", existing.get("default", template))
+        elif isinstance(existing, str) and existing:
+            updated = {"default": existing, COLPALI_TEMPLATE_NAME: template}
+        else:
+            # No existing template — use ours as both default and named entry so
+            # save_pretrained writes both files.
+            updated = {"default": template, COLPALI_TEMPLATE_NAME: template}
+        processor.chat_template = updated
+
+    @staticmethod
+    def _set_chat_template_name(first_module) -> None:
+        """Point ST's ``apply_chat_template`` call at our named template.
+
+        Writes a fresh inner dict instead of mutating in place so we never
+        accidentally mutate a dict the caller still references (the user's
+        original ``processor_kwargs["chat_template"]``).
+        """
+        if not hasattr(first_module, "processing_kwargs"):
+            return
+        existing = first_module.processing_kwargs.get("chat_template", {})
+        first_module.processing_kwargs["chat_template"] = {
+            **existing,
+            "chat_template": COLPALI_TEMPLATE_NAME,
+        }
 
     def save(
         self,

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -65,6 +65,10 @@ def _load_colpali_proj_tensors(
     Matches keys by suffix (e.g. any key ending in ``custom_text_proj.weight``)
     so it handles plain, ``model.``-prefixed, and ``base_model.model.``-prefixed
     checkpoints without maintaining an explicit prefix list.
+
+    For LoRA adapter repos (containing ``adapter_model.safetensors`` instead of
+    ``model.safetensors``), the merged projection is reconstructed from the base
+    model weights and the LoRA delta: ``W_merged = W_base + (alpha/r) * B @ A``.
     """
     from safetensors import safe_open
 
@@ -109,10 +113,71 @@ def _load_colpali_proj_tensors(
     except EnvironmentError:
         pass
 
+    # Try LoRA adapter — reconstruct merged projection from base + delta. (ColNomic is a fine tuning of ColQwen)
+    try:
+        adapter_cfg_path = cached_file(
+            model_name_or_path, "adapter_config.json", **hub_kwargs
+        )
+        with open(adapter_cfg_path) as f:
+            adapter_cfg = json.load(f)
+
+        adapter_sf_path = cached_file(
+            model_name_or_path, "adapter_model.safetensors", **hub_kwargs
+        )
+
+        # The adapter may store the full projection (modules_to_save) or LoRA
+        # decompositions.  Check for full weights first.
+        result = _find_in_file(adapter_sf_path)
+        if weight_key in result:
+            return result
+
+        # Look for LoRA A/B matrices for the projection layer.
+        proj_stem = weight_key.removesuffix(".weight")
+        lora_a_suffix = f"{proj_stem}.lora_A.weight"
+        lora_b_suffix = f"{proj_stem}.lora_B.weight"
+        lora_a = lora_b = None
+        with safe_open(adapter_sf_path, framework="pt", device="cpu") as f:
+            for key in f.keys():
+                if key == lora_a_suffix or key.endswith("." + lora_a_suffix):
+                    lora_a = f.get_tensor(key)
+                elif key == lora_b_suffix or key.endswith("." + lora_b_suffix):
+                    lora_b = f.get_tensor(key)
+
+        if lora_a is not None and lora_b is not None:
+            base_model_name = adapter_cfg["base_model_name_or_path"]
+            lora_alpha = adapter_cfg.get("lora_alpha", 1)
+            lora_r = adapter_cfg.get("r", 1)
+            scaling = lora_alpha / lora_r
+
+            base_hub_kwargs = {
+                k: v for k, v in hub_kwargs.items() if k != "revision"
+            }
+            base_tensors = _load_colpali_proj_tensors(
+                base_model_name, weight_key, bias_key, **base_hub_kwargs
+            )
+
+            base_weight = base_tensors[weight_key]
+            merged = base_weight.to(lora_b.dtype) + scaling * (lora_b @ lora_a)
+            merged_result: dict[str, torch.Tensor] = {weight_key: merged}
+            if bias_key in base_tensors:
+                merged_result[bias_key] = base_tensors[bias_key]
+            return merged_result
+    except EnvironmentError:
+        pass
+    except KeyError as e:
+        logger.warning(
+            "Found LoRA adapter in %s but failed to reconstruct projection "
+            "weights: missing key %s",
+            model_name_or_path,
+            e,
+        )
+
+
     raise ValueError(
         f"Could not find projection weights ending in '{weight_key}' "
         f"in {model_name_or_path}. "
-        "Looked for model.safetensors and model.safetensors.index.json."
+        "Looked for model.safetensors, model.safetensors.index.json, "
+        "and adapter_model.safetensors."
     )
 
 

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -1492,6 +1492,7 @@ class ColBERT(SentenceTransformer):
         if (
             is_query
             and self.attend_to_expansion_tokens
+            and not use_suffix_expansion
             and "attention_mask" in tokenized_outputs
         ):
             tokenized_outputs["attention_mask"].fill_(1)
@@ -1508,8 +1509,16 @@ class ColBERT(SentenceTransformer):
         Unlike pad-to-fixed-length expansion, this preserves the full query
         text and always appends exactly *n_tokens* regardless of input length,
         matching ``colpali_engine``'s ``process_queries`` behavior.
+
+        Because expansion tokens and batch-alignment padding share the same
+        token ID (pad_token_id), the input_ids are correct after a simple
+        concat.  The attention mask is recomputed so that exactly the first
+        ``real_length + n_tokens`` positions are attended, which naturally
+        promotes any batch-alignment padding between real tokens and the
+        appended tokens into expansion — giving the right count and positions.
         """
         batch_size = features["input_ids"].shape[0]
+        seq_len = features["input_ids"].shape[1]
         device = features["input_ids"].device
 
         pad_ids = torch.full(
@@ -1521,15 +1530,10 @@ class ColBERT(SentenceTransformer):
         features["input_ids"] = torch.cat([features["input_ids"], pad_ids], dim=1)
 
         if "attention_mask" in features:
-            ones = torch.ones(
-                batch_size,
-                n_tokens,
-                dtype=features["attention_mask"].dtype,
-                device=device,
-            )
-            features["attention_mask"] = torch.cat(
-                [features["attention_mask"], ones],
-                dim=1,
+            real_lengths = features["attention_mask"].sum(dim=1, keepdim=True)
+            positions = torch.arange(seq_len + n_tokens, device=device).unsqueeze(0)
+            features["attention_mask"] = (positions < real_lengths + n_tokens).to(
+                features["attention_mask"].dtype
             )
 
         for key in ("token_type_ids", "mm_token_type_ids"):

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -692,7 +692,7 @@ class ColBERT(SentenceTransformer):
             }
         is_text = self._is_text_input(sentences)
         if is_text:
-            length_sorted_idx = np.argsort([-self._text_length(sen) for sen in sentences])
+            length_sorted_idx = np.argsort([-self._input_length(sen) for sen in sentences])
         else:
             length_sorted_idx = np.arange(len(sentences))
         sentences_sorted = [sentences[int(idx)] for idx in length_sorted_idx]

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -469,19 +469,21 @@ class ColBERT(SentenceTransformer):
         self.to(device)
         self.is_hpu_graph_enabled = False
         # Override the configuration values with the provided arguments, if any. If not set and values have not been read from configs, set to default values.
+        _default_prefix = "" if self._is_colpali_model else "[Q] "
         self.query_prefix = (
             query_prefix
             if query_prefix is not None
             else self.query_prefix
             if self.query_prefix is not None
-            else "[Q] "
+            else _default_prefix
         )
+        _default_prefix = "" if self._is_colpali_model else "[D] "
         self.document_prefix = (
             document_prefix
             if document_prefix is not None
             else self.document_prefix
             if self.document_prefix is not None
-            else "[D] "
+            else _default_prefix
         )
 
         # Try adding the prefixes to the tokenizer. We call resize_token_embeddings twice to ensure the tokens are added only if resize_token_embeddings works. There should be a better way to do this.
@@ -515,9 +517,19 @@ class ColBERT(SentenceTransformer):
             else None
         )
 
-        # Set the padding token ID
+        # Set the padding token ID used for query expansion.
+        # ColPali processors already carry the correct pad_token (e.g.
+        # <|endoftext|> for Qwen-VL, <eos> for PaliGemma) — the model was
+        # trained with that token as the expansion token, so we must not
+        # overwrite it. For classic ColBERT (MLM backbone), we use the MASK
+        # token; for other LLMs we fall back to the EOS token.
+        if self._is_colpali_model and self.tokenizer.pad_token_id is not None:
+            # ColPali query expansion appends expansion tokens as a suffix
+            # (text first, expansion after). PyLate uses tokenizer padding for
+            # this, so we need right-padding to match the trained layout.
+            self.tokenizer.padding_side = "right"
         # If it is a MLM model, use the MASK token
-        if self.tokenizer.mask_token_id is not None:
+        elif self.tokenizer.mask_token_id is not None:
             self.tokenizer.pad_token_id = self.tokenizer.mask_token_id
         # If it's a LLM, use the EOS token
         elif self.tokenizer.eos_token_id is not None:
@@ -552,7 +564,7 @@ class ColBERT(SentenceTransformer):
             if skiplist_words is not None
             else self.skiplist_words
             if self.skiplist_words is not None
-            else list(string.punctuation)
+            else ([] if self._is_colpali_model else list(string.punctuation))
         )
 
         # Convert skiplist words to their corresponding token IDs.
@@ -573,7 +585,7 @@ class ColBERT(SentenceTransformer):
             if attend_to_expansion_tokens is not None
             else self.attend_to_expansion_tokens
             if self.attend_to_expansion_tokens is not None
-            else False
+            else (True if self._is_colpali_model else False)
         )
         # If we do not do query expansion, we do not attend to the expansion tokens
         if not self.do_query_expansion:

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -1417,15 +1417,14 @@ class ColBERT(SentenceTransformer):
                 [features["attention_mask"], ones], dim=1,
             )
 
-        if "token_type_ids" in features:
-            zeros = torch.zeros(
-                batch_size, n_tokens,
-                dtype=features["token_type_ids"].dtype,
-                device=device,
-            )
-            features["token_type_ids"] = torch.cat(
-                [features["token_type_ids"], zeros], dim=1,
-            )
+        for key in ("token_type_ids", "mm_token_type_ids"):
+            if key in features:
+                zeros = torch.zeros(
+                    batch_size, n_tokens,
+                    dtype=features[key].dtype,
+                    device=device,
+                )
+                features[key] = torch.cat([features[key], zeros], dim=1)
 
         return features
 

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -213,8 +213,6 @@ class ColBERT(SentenceTransformer):
         self.do_query_expansion = do_query_expansion
         self.attend_to_expansion_tokens = attend_to_expansion_tokens
         self.skiplist_words = skiplist_words
-        self._embedding_size = embedding_size
-        self._bias = bias
         model_card_data = model_card_data or PylateModelCardData()
         if similarity_fn_name is None:
             similarity_fn_name = "MaxSim"
@@ -1187,12 +1185,9 @@ class ColBERT(SentenceTransformer):
             else {}
         )
 
-        # Tokenize the texts using the transformer module's tokenize/preprocess
+        # Tokenize the texts using the transformer module's preprocess
         first_module = self._first_module()
-        if hasattr(first_module, "tokenize"):
-            tokenized_outputs = first_module.tokenize(inputs, **tokenize_args)
-        else:
-            tokenized_outputs = first_module.preprocess(inputs, **tokenize_args)
+        tokenized_outputs = first_module.preprocess(inputs, **tokenize_args)
 
         if use_prefix:
             # Insert prefix token and update attention mask
@@ -1276,25 +1271,6 @@ class ColBERT(SentenceTransformer):
             train_datasets=train_datasets,
             safe_serialization=safe_serialization,
         )
-
-        # Write PyLate-specific config on top of the base config
-        config_path = os.path.join(path, "config_sentence_transformers.json")
-        if os.path.exists(config_path):
-            with open(config_path, "r") as fIn:
-                config = json.load(fIn)
-        else:
-            config = {}
-
-        config["query_prefix"] = self.query_prefix
-        config["document_prefix"] = self.document_prefix
-        config["query_length"] = self.query_length
-        config["document_length"] = self.document_length
-        config["attend_to_expansion_tokens"] = self.attend_to_expansion_tokens
-        config["skiplist_words"] = self.skiplist_words
-        config["do_query_expansion"] = self.do_query_expansion
-
-        with open(config_path, "w") as fOut:
-            json.dump(config, fOut, indent=2)
 
     def _get_model_config(self) -> dict[str, Any]:
         """Return the model configuration dictionary for saving."""

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -591,6 +591,47 @@ class ColBERT(SentenceTransformer):
         if not self.do_query_expansion:
             self.attend_to_expansion_tokens = False
 
+        # Flash Attention's unpadding optimization physically removes padding
+        # tokens from the sequence. Query expansion relies on padding queries
+        # to ``query_length`` with expansion tokens — if those get stripped,
+        # expansion silently doesn't happen. Disable unpadding so the
+        # expansion tokens survive through the forward pass.
+        if self.do_query_expansion:
+            first = self._first_module()
+            if getattr(first, "unpad_inputs", None) is not False:
+                first.unpad_inputs = False
+
+            # attend_to_expansion_tokens=False is incompatible with Flash
+            # Attention: FA does not support arbitrary per-token attention
+            # masks, so masking out expansion tokens silently degrades scores.
+            if not self.attend_to_expansion_tokens:
+                self._check_expansion_fa_compat()
+
+    def _check_expansion_fa_compat(self) -> None:
+        """Raise if expansion tokens would be unattended under Flash Attention.
+
+        FA does not properly mask padding tokens — the resulting embeddings
+        are dull/garbage even when ``attention_mask`` marks them as padding.
+        With ``attend_to_expansion_tokens=False`` those broken embeddings
+        leak into MaxSim scoring and silently degrade retrieval quality.
+        """
+        try:
+            from transformers.utils.generic import is_flash_attention_requested
+        except ImportError:
+            return
+        config = getattr(self._first_module(), "config", None)
+        attn_impl = getattr(config, "_attn_implementation", None)
+        if attn_impl and is_flash_attention_requested(
+            requested_attention_implementation=attn_impl
+        ):
+            raise ValueError(
+                "do_query_expansion=True with attend_to_expansion_tokens=False "
+                "is incompatible with Flash Attention. FA does not properly "
+                "mask padding tokens — expansion token embeddings are dull and "
+                "silently degrade retrieval scores. "
+                "Set attend_to_expansion_tokens=True or use "
+                "attn_implementation='sdpa'."
+            )
 
     @staticmethod
     def load(input_path) -> "ColBERT":

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -11,6 +11,7 @@ from typing import Any, Iterable, Literal, Optional
 
 import numpy as np
 import torch
+import torch.nn.functional as F
 from numpy import ndarray
 from scipy.cluster import hierarchy
 from sentence_transformers import SentenceTransformer
@@ -1177,20 +1178,36 @@ class ColBERT(SentenceTransformer):
         prefix_id = self.query_prefix_id if is_query else self.document_prefix_id
         # The only case where prefix_id is None is when prefix was an empty string. Else it's a the id corresponding the prefix set (eventually defaulting to [D] or [Q])
         use_prefix = prefix_id is not None
-        self._first_module().max_seq_length = (
-            max_length - 1 if use_prefix else max_length
-        )
-
-        # Pad queries (if query expansion) and handle padding for documents if specified
-        tokenize_args = (
-            {"padding": "max_length"}
-            if pad or (is_query and self.do_query_expansion)
-            else {}
-        )
+        target_length = max_length - 1 if use_prefix else max_length
+        first_module = self._first_module()
+        first_module.max_seq_length = target_length
 
         # Tokenize the texts using the transformer module's preprocess
-        first_module = self._first_module()
-        tokenized_outputs = first_module.preprocess(inputs, **tokenize_args)
+        tokenized_outputs = first_module.preprocess(inputs)
+
+        # TODO: discuss if this is the best solution. ST v5.4's Transformer.preprocess no
+        # longer accepts padding kwargs (it always pads to longest-in-batch), so pad-to-
+        # max-length is done manually here. Required for query expansion (queries must
+        # reach `query_length` with [MASK] tokens; pad_token_id is set to mask_token_id
+        # at init) and for users who request `pad=True` (e.g. for the XTR-style
+        # `torch.stack` across positives/negatives in Contrastive/CachedContrastive).
+        # Alternative worth considering: pad in the loss after embedding, only up to
+        # max-seq-len in the batch — cheaper memory but moves the constraint into the
+        # loss instead of preprocess.
+        if pad or (is_query and self.do_query_expansion):
+            n = target_length - tokenized_outputs["input_ids"].size(1)
+            if n > 0:
+                pad_id = first_module.tokenizer.pad_token_id
+                tokenized_outputs["input_ids"] = F.pad(
+                    tokenized_outputs["input_ids"], (0, n), value=pad_id
+                )
+                tokenized_outputs["attention_mask"] = F.pad(
+                    tokenized_outputs["attention_mask"], (0, n), value=0
+                )
+                if "token_type_ids" in tokenized_outputs:
+                    tokenized_outputs["token_type_ids"] = F.pad(
+                        tokenized_outputs["token_type_ids"], (0, n), value=0
+                    )
 
         if use_prefix:
             # Insert prefix token and update attention mask

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -6,17 +6,19 @@ import logging
 import math
 import os
 import string
-from typing import Iterable, Literal, Optional
+import warnings
+from collections import OrderedDict
+from typing import Any, Iterable, Literal, Optional
 
 import numpy as np
 import torch
 from numpy import ndarray
 from scipy.cluster import hierarchy
 from sentence_transformers import SentenceTransformer
-from sentence_transformers.models import Dense as DenseSentenceTransformer
-from sentence_transformers.models import Transformer
-from sentence_transformers.quantization import quantize_embeddings
+from sentence_transformers.base.modules import Dense as DenseSentenceTransformer
+from sentence_transformers.base.modules import Transformer
 from sentence_transformers.util import batch_to_device, load_file_path
+from sentence_transformers.util.quantization import quantize_embeddings
 from torch import nn
 from tqdm.autonotebook import trange
 from transformers.utils import cached_file
@@ -73,8 +75,6 @@ class ColBERT(SentenceTransformer):
         Whether or not to only look at local files (i.e., do not try to download the model).
     token
         Hugging Face authentication token to download private models.
-    use_auth_token
-        Deprecated argument. Please use `token` instead.
     truncate_dim
         The dimension to truncate sentence embeddings to. `None` does no truncation. Truncation is only applicable
         during inference when :meth:`SentenceTransformer.encode` is called.
@@ -99,41 +99,12 @@ class ColBERT(SentenceTransformer):
     skiplist_words
         A list of words to skip from the documents scoring (note that these tokens are used for encoding and are only skipped during the scoring). Default is the list of string.punctuation.
     model_kwargs : dict, optional
-        Additional model configuration parameters to be passed to the Huggingface Transformers model. Particularly
-        useful options are:
-
-        - ``torch_dtype``: Override the default `torch.dtype` and load the model under a specific `dtype`. The
-            different options are:
-
-                1. ``torch.float16``, ``torch.bfloat16`` or ``torch.float``: load in a specified ``dtype``,
-                ignoring the model's ``config.torch_dtype`` if one exists. If not specified - the model will get
-                loaded in ``torch.float`` (fp32).
-
-                2. ``"auto"`` - A ``torch_dtype`` entry in the ``config.json`` file of the model will be attempted
-                to be used. If this entry isn't found then next check the ``dtype`` of the first weight in the
-                checkpoint that's of a floating point type and use that as ``dtype``. This will load the model using
-                the ``dtype`` it was saved in at the end of the training. It can't be used as an indicator of how the
-                model was trained. Since it could be trained in one of half precision dtypes, but saved in fp32.
-        - ``attn_implementation``: The attention implementation to use in the model (if relevant). Can be any of
-            `"eager"` (manual implementation of the attention), `"sdpa"` (using `F.scaled_dot_product_attention
-            <https://pytorch.org/docs/master/generated/torch.nn.functional.scaled_dot_product_attention.html>`_),
-            or `"flash_attention_2"` (using `Dao-AILab/flash-attention
-            <https://github.com/Dao-AILab/flash-attention>`_). By default, if available, SDPA will be used for
-            torch>=2.1.1. The default is otherwise the manual `"eager"` implementation.
-
-        See the `PreTrainedModel.from_pretrained
-        <https://huggingface.co/docs/transformers/en/main_classes/model#transformers.PreTrainedModel.from_pretrained>`_
-        documentation for more details.
-    tokenizer_kwargs
-        Additional tokenizer configuration parameters to be passed to the Huggingface Transformers tokenizer. See the
-        `AutoTokenizer.from_pretrained
-        <https://huggingface.co/docs/transformers/en/model_doc/auto#transformers.AutoTokenizer.from_pretrained>`_
-        documentation for more details.
+        Additional model configuration parameters to be passed to the Huggingface Transformers model.
+    processor_kwargs
+        Additional processor/tokenizer configuration parameters to be passed to the Huggingface Transformers
+        processor/tokenizer.
     config_kwargs
-        Additional model configuration parameters to be passed to the Huggingface Transformers config. See the
-        `AutoConfig.from_pretrained
-        <https://huggingface.co/docs/transformers/en/model_doc/auto#transformers.AutoConfig.from_pretrained>`_
-        documentation for more details.
+        Additional model configuration parameters to be passed to the Huggingface Transformers config.
     model_card_data
         A model card data object that contains information about the model. This is used to generate a model card when
         saving the model. If not set, a default model card data object is created.
@@ -190,6 +161,7 @@ class ColBERT(SentenceTransformer):
     def __init__(
         self,
         model_name_or_path: str | None = None,
+        *,
         modules: Optional[Iterable[nn.Module]] = None,
         device: str | None = None,
         prompts: dict[str, str] | None = None,
@@ -213,10 +185,26 @@ class ColBERT(SentenceTransformer):
         attend_to_expansion_tokens: bool | None = None,
         skiplist_words: list[str] | None = None,
         model_kwargs: dict | None = None,
+        processor_kwargs: dict | None = None,
         tokenizer_kwargs: dict | None = None,
         config_kwargs: dict | None = None,
         model_card_data: PylateModelCardData | None = None,
+        backend: Literal["torch", "onnx", "openvino"] = "torch",
     ) -> None:
+        # Handle deprecated tokenizer_kwargs
+        if tokenizer_kwargs is not None:
+            warnings.warn(
+                "The `tokenizer_kwargs` argument is deprecated. Use `processor_kwargs` instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            if processor_kwargs is not None:
+                raise ValueError(
+                    "Both `processor_kwargs` and `tokenizer_kwargs` are specified. "
+                    "Please only specify `processor_kwargs`."
+                )
+            processor_kwargs = tokenizer_kwargs
+
         self.query_prefix = query_prefix
         self.document_prefix = document_prefix
         self.query_length = query_length
@@ -224,9 +212,24 @@ class ColBERT(SentenceTransformer):
         self.do_query_expansion = do_query_expansion
         self.attend_to_expansion_tokens = attend_to_expansion_tokens
         self.skiplist_words = skiplist_words
+        self._embedding_size = embedding_size
+        self._bias = bias
         model_card_data = model_card_data or PylateModelCardData()
         if similarity_fn_name is None:
             similarity_fn_name = "MaxSim"
+
+        # Handle deprecated use_auth_token
+        if use_auth_token is not None:
+            warnings.warn(
+                "The `use_auth_token` argument is deprecated. Use `token` instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            if token is not None:
+                raise ValueError(
+                    "Both `token` and `use_auth_token` are specified. Please only specify `token`."
+                )
+            token = use_auth_token
 
         super(ColBERT, self).__init__(
             model_name_or_path=model_name_or_path,
@@ -240,12 +243,12 @@ class ColBERT(SentenceTransformer):
             revision=revision,
             local_files_only=local_files_only,
             token=token,
-            use_auth_token=use_auth_token,
             truncate_dim=truncate_dim,
             model_kwargs=model_kwargs,
-            tokenizer_kwargs=tokenizer_kwargs,
+            processor_kwargs=processor_kwargs,
             config_kwargs=config_kwargs,
             model_card_data=model_card_data,
+            backend=backend,
         )
         hidden_size = self[0].get_word_embedding_dimension()
 
@@ -263,7 +266,6 @@ class ColBERT(SentenceTransformer):
                         revision,
                         local_files_only,
                         token,
-                        use_auth_token,
                     )
                 )
                 logger.info("Loaded the weights from Stanford NLP model.")
@@ -275,7 +277,6 @@ class ColBERT(SentenceTransformer):
                         revision=revision,
                         local_files_only=local_files_only,
                         token=token,
-                        use_auth_token=use_auth_token,
                     )
                     with open(metadata, "r") as f:
                         metadata = json.load(f)
@@ -491,6 +492,20 @@ class ColBERT(SentenceTransformer):
             tensors=[input_ids[:, :1], prefix_tensor, input_ids[:, 1:]], dim=1
         )
 
+    @staticmethod
+    def _is_text_input(inputs) -> bool:
+        """Check whether inputs are text (strings) vs multimodal (images, etc)."""
+        if isinstance(inputs, str):
+            return True
+        if isinstance(inputs, (list, tuple)) and len(inputs) > 0:
+            first = inputs[0]
+            if isinstance(first, str):
+                return True
+            # list of dicts or tuples of strings are text inputs
+            if isinstance(first, (dict, tuple)):
+                return isinstance(first, tuple) and all(isinstance(s, str) for s in first)
+        return False
+
     def encode(
         self,
         sentences: str | list[str],
@@ -629,11 +644,6 @@ class ColBERT(SentenceTransformer):
             convert_to_tensor = True
         convert_to_numpy = not convert_to_tensor
 
-        # TODO: We cannot convert to tensor/numpy for token embeddings as they are not the same size
-        # if output_value != "sentence_embedding":
-        # convert_to_tensor = False
-        # convert_to_numpy = False
-
         input_was_string = False
         if isinstance(sentences, str) or not hasattr(sentences, "__len__"):
             sentences = [sentences]
@@ -662,7 +672,7 @@ class ColBERT(SentenceTransformer):
 
             # Some models require removing the prompt before pooling (e.g. Instructor, Grit).
             # Tracking the prompt length allow us to remove the prompt during pooling.
-            tokenized_prompt = self.tokenize([prompt])
+            tokenized_prompt = self.preprocess([prompt])
             if "input_ids" in tokenized_prompt:
                 extra_features["prompt_length"] = (
                     tokenized_prompt["input_ids"].shape[-1] - 1
@@ -680,7 +690,11 @@ class ColBERT(SentenceTransformer):
                 "attention_mask": [],
                 "masks": [],
             }
-        length_sorted_idx = np.argsort([-self._text_length(sen) for sen in sentences])
+        is_text = self._is_text_input(sentences)
+        if is_text:
+            length_sorted_idx = np.argsort([-self._text_length(sen) for sen in sentences])
+        else:
+            length_sorted_idx = np.arange(len(sentences))
         sentences_sorted = [sentences[int(idx)] for idx in length_sorted_idx]
 
         for start_index in trange(
@@ -693,7 +707,13 @@ class ColBERT(SentenceTransformer):
             disable=not show_progress_bar,
         ):
             sentences_batch = sentences_sorted[start_index : start_index + batch_size]
-            features = self.tokenize(texts=sentences_batch, is_query=is_query)
+
+            # Use preprocess for both text and multimodal inputs
+            if is_text:
+                features = self.preprocess(inputs=sentences_batch, is_query=is_query)
+            else:
+                # Multimodal path: use the base transformer's preprocess directly
+                features = self._preprocess_multimodal(sentences_batch)
 
             if self.device.type == "hpu":
                 if "input_ids" in features:
@@ -742,19 +762,22 @@ class ColBERT(SentenceTransformer):
             features.update(extra_features)
 
             with torch.no_grad():
-                # TODO: add the truncate/sliding window logic here
                 out_features = self.forward(input=features)
                 if self.device.type == "hpu":
                     out_features = copy.deepcopy(out_features)
 
                 if not is_query:
                     # Compute the mask for the skiplist (punctuation symbols)
-                    skiplist_mask = self.skiplist_mask(
-                        input_ids=features["input_ids"], skiplist=self.skiplist
-                    )
-                    masks = torch.logical_and(
-                        input=skiplist_mask, other=out_features["attention_mask"]
-                    )
+                    if "input_ids" in features:
+                        skiplist_mask = self.skiplist_mask(
+                            input_ids=features["input_ids"], skiplist=self.skiplist
+                        )
+                        masks = torch.logical_and(
+                            input=skiplist_mask, other=out_features["attention_mask"]
+                        )
+                    else:
+                        # Multimodal: no skiplist, use attention mask directly
+                        masks = out_features["attention_mask"].bool()
                 else:
                     if self.do_query_expansion:
                         # We keep all tokens in the query (no skiplist) and we do not want to prune expansion tokens in queries even if we do not attend to them in attention layers
@@ -859,6 +882,22 @@ class ColBERT(SentenceTransformer):
         if input_was_string:
             return {key: values[0] for key, values in all_outputs.items()}
         return all_outputs
+
+    def encode_query(
+        self,
+        sentences: str | list[str],
+        **kwargs,
+    ) -> list[torch.Tensor] | ndarray | torch.Tensor:
+        """Convenience method to encode queries (sets is_query=True)."""
+        return self.encode(sentences, is_query=True, **kwargs)
+
+    def encode_document(
+        self,
+        sentences: str | list[str],
+        **kwargs,
+    ) -> list[torch.Tensor] | ndarray | torch.Tensor:
+        """Convenience method to encode documents (sets is_query=False)."""
+        return self.encode(sentences, is_query=False, **kwargs)
 
     def pool_embeddings_hierarchical(
         self,
@@ -1141,26 +1180,47 @@ class ColBERT(SentenceTransformer):
         )
         return [np.concatenate(result[1]) for result in results_list]
 
-    def tokenize(
+    def preprocess(
         self,
-        texts: list[str] | list[dict] | list[tuple[str, str]],
+        inputs: list[str] | list[dict] | list[tuple[str, str]] | None = None,
         is_query: bool = True,
         pad: bool = False,
-        task: str
-        | None = None,  # this is to be compatible with the new collator that supports "task". It isn't used here, only if the model is a router, but I find it cleaner than kwargs
+        task: str | None = None,
+        # Backward compat: accept 'texts' as alias for 'inputs'
+        texts: list[str] | list[dict] | list[tuple[str, str]] | None = None,
+        **kwargs,
     ) -> dict[str, torch.Tensor]:
         """
-        Tokenizes the input texts.
+        Preprocesses/tokenizes the input texts.
 
-        Args:
-            texts (Union[list[str], list[dict], list[tuple[str, str]]]): A list of texts to be tokenized.
-            is_query (bool): Flag to indicate if the texts are queries. Defaults to True.
-            pad (bool): Flag to indicate if elements should be padded to max length. Defaults to False.
+        Parameters
+        ----------
+        inputs
+            A list of texts to be tokenized.
+        is_query
+            Flag to indicate if the texts are queries. Defaults to True.
+        pad
+            Flag to indicate if elements should be padded to max length. Defaults to False.
+        task
+            Task identifier (for compatibility with Router-based models). Defaults to None.
+        texts
+            Deprecated alias for `inputs`. Use `inputs` instead.
 
-        Returns:
-            dict[str, torch.Tensor]: A dictionary of tensors with the tokenized texts, including "input_ids",
-                "attention_mask", and optionally "token_type_ids".
+        Returns
+        -------
+        dict[str, torch.Tensor]
+            A dictionary of tensors with the tokenized texts.
         """
+        # Handle backward compatibility: 'texts' -> 'inputs'
+        if texts is not None and inputs is None:
+            inputs = texts
+        if inputs is None:
+            raise ValueError("Either `inputs` or `texts` must be provided.")
+
+        # For multimodal inputs, delegate to the multimodal preprocessing path
+        if not self._is_text_input(inputs):
+            return self._preprocess_multimodal(inputs)
+
         # Set max sequence length based on whether the input is a query or document
         max_length = self.query_length if is_query else self.document_length
         prefix_id = self.query_prefix_id if is_query else self.document_prefix_id
@@ -1177,8 +1237,12 @@ class ColBERT(SentenceTransformer):
             else {}
         )
 
-        # Tokenize the texts
-        tokenized_outputs = self._first_module().tokenize(texts, **tokenize_args)
+        # Tokenize the texts using the transformer module's tokenize/preprocess
+        first_module = self._first_module()
+        if hasattr(first_module, "tokenize"):
+            tokenized_outputs = first_module.tokenize(inputs, **tokenize_args)
+        else:
+            tokenized_outputs = first_module.preprocess(inputs, **tokenize_args)
 
         if use_prefix:
             # Insert prefix token and update attention mask
@@ -1200,6 +1264,40 @@ class ColBERT(SentenceTransformer):
             tokenized_outputs["attention_mask"].fill_(1)
 
         return tokenized_outputs
+
+    def tokenize(
+        self,
+        texts: list[str] | list[dict] | list[tuple[str, str]],
+        is_query: bool = True,
+        pad: bool = False,
+        task: str | None = None,
+    ) -> dict[str, torch.Tensor]:
+        """
+        Backward-compatible wrapper around :meth:`preprocess`.
+
+        .. deprecated::
+            Use :meth:`preprocess` instead.
+        """
+        return self.preprocess(inputs=texts, is_query=is_query, pad=pad, task=task)
+
+    def _preprocess_multimodal(
+        self,
+        inputs: list,
+    ) -> dict[str, torch.Tensor]:
+        """Preprocess multimodal inputs (images, etc.) by delegating to the base transformer's preprocessor.
+
+        For multimodal inputs, we skip prefix token insertion and query expansion
+        since the VLM processor handles special tokens natively.
+        """
+        first_module = self._first_module()
+        if hasattr(first_module, "preprocess"):
+            return first_module.preprocess(inputs)
+        elif hasattr(first_module, "tokenize"):
+            return first_module.tokenize(inputs)
+        raise NotImplementedError(
+            "The first module does not support multimodal preprocessing. "
+            "Ensure the transformer module has a `preprocess` method."
+        )
 
     def save(
         self,
@@ -1229,21 +1327,58 @@ class ColBERT(SentenceTransformer):
             safe_serialization=safe_serialization,
         )
 
-        with open(os.path.join(path, "config_sentence_transformers.json"), "w") as fOut:
-            config = self._model_config.copy()
-            config["prompts"] = self.prompts
-            config["default_prompt_name"] = self.default_prompt_name
-            config["similarity_fn_name"] = self.similarity_fn_name
-            config["query_prefix"] = self.query_prefix
-            config["document_prefix"] = self.document_prefix
-            config["query_length"] = self.query_length
-            config["document_length"] = self.document_length
-            config["attend_to_expansion_tokens"] = self.attend_to_expansion_tokens
-            config["skiplist_words"] = self.skiplist_words
-            config["do_query_expansion"] = self.do_query_expansion
+        # Write PyLate-specific config on top of the base config
+        config_path = os.path.join(path, "config_sentence_transformers.json")
+        if os.path.exists(config_path):
+            with open(config_path, "r") as fIn:
+                config = json.load(fIn)
+        else:
+            config = {}
+
+        config["query_prefix"] = self.query_prefix
+        config["document_prefix"] = self.document_prefix
+        config["query_length"] = self.query_length
+        config["document_length"] = self.document_length
+        config["attend_to_expansion_tokens"] = self.attend_to_expansion_tokens
+        config["skiplist_words"] = self.skiplist_words
+        config["do_query_expansion"] = self.do_query_expansion
+
+        with open(config_path, "w") as fOut:
             json.dump(config, fOut, indent=2)
 
-    def _load_auto_model(
+    def _get_model_config(self) -> dict[str, Any]:
+        """Return the model configuration dictionary for saving."""
+        config = super()._get_model_config()
+        config["query_prefix"] = self.query_prefix
+        config["document_prefix"] = self.document_prefix
+        config["query_length"] = self.query_length
+        config["document_length"] = self.document_length
+        config["attend_to_expansion_tokens"] = self.attend_to_expansion_tokens
+        config["skiplist_words"] = self.skiplist_words
+        config["do_query_expansion"] = self.do_query_expansion
+        return config
+
+    def _parse_model_config(self, model_config: dict[str, Any]) -> None:
+        """Parse model config and load PyLate-specific parameters."""
+        super()._parse_model_config(model_config)
+
+        # Loading the query/document prefixes and query_length from config
+        if "query_prefix" in model_config and self.query_prefix is None:
+            self.query_prefix = model_config["query_prefix"]
+        if "document_prefix" in model_config and self.document_prefix is None:
+            self.document_prefix = model_config["document_prefix"]
+        if "query_length" in model_config and self.query_length is None:
+            self.query_length = model_config["query_length"]
+        if "document_length" in model_config and self.document_length is None:
+            self.document_length = model_config["document_length"]
+        if "attend_to_expansion_tokens" in model_config and self.attend_to_expansion_tokens is None:
+            self.attend_to_expansion_tokens = model_config["attend_to_expansion_tokens"]
+        if "skiplist_words" in model_config and self.skiplist_words is None:
+            self.skiplist_words = model_config["skiplist_words"]
+        if "do_query_expansion" in model_config and self.do_query_expansion is None:
+            self.do_query_expansion = model_config["do_query_expansion"]
+
+    def _load_default_modules(
         self,
         model_name_or_path: str,
         token: bool | str | None,
@@ -1251,53 +1386,15 @@ class ColBERT(SentenceTransformer):
         revision: str | None = None,
         trust_remote_code: bool = False,
         local_files_only: bool = False,
-        model_kwargs: dict | None = None,
-        tokenizer_kwargs: dict | None = None,
-        config_kwargs: dict | None = None,
-        has_modules: bool = False,
-    ) -> list[nn.Module]:
-        """Create a Transformer model from a model name or path. This module is distinct
-        from SentenceTransformer as it do not set the pooling layer.
+        model_kwargs: dict[str, Any] | None = None,
+        processor_kwargs: dict[str, Any] | None = None,
+        config_kwargs: dict[str, Any] | None = None,
+    ) -> tuple[list[nn.Module], dict[str, Any]]:
+        """Create a Transformer model from a model name or path.
 
-        Parameters
-        ----------
-        model_name_or_path
-            The name or path of the pre-trained model.
-        token
-            The token to use for the model.
-        cache_folder
-            The folder to cache the model.
-        revision
-            The revision of the model. Defaults to None.
-        trust_remote_code
-            Whether to trust remote code. Defaults to False.
-        local_files_only
-            Whether to use only local files. Defaults to False.
-        model_kwargs
-            Additional keyword arguments for the model. Defaults to None.
-        tokenizer_kwargs
-            Additional keyword arguments for the tokenizer. Defaults to None.
-        config_kwargs
-            Additional keyword arguments for the config. Defaults to None.
-        has_modules
-            Whether the model has modules.json. Defaults to False.
-
+        This module is distinct from SentenceTransformer as it does not set the pooling layer.
+        Called when no modules.json is found (creating a new ColBERT from a base model).
         """
-        # Due to a change in ST, load_sbert is now only call by default for PyLate models directly (because the class name match the config name). However, ST models needs to be called with load_sbert to load the modules, so if the model has modules, we load it with load_sbert even if the class name is not ColBERT (it is a ST model)
-        if has_modules:
-            model, module_kwargs = self._load_sbert_model(
-                model_name_or_path=model_name_or_path,
-                token=token,
-                cache_folder=cache_folder,
-                revision=revision,
-                trust_remote_code=trust_remote_code,
-                local_files_only=local_files_only,
-                model_kwargs=model_kwargs,
-                tokenizer_kwargs=tokenizer_kwargs,
-                config_kwargs=config_kwargs,
-            )
-            return model
-
         logger.warning(
             f"No sentence-transformers model found with name {model_name_or_path}."
         )
@@ -1313,13 +1410,13 @@ class ColBERT(SentenceTransformer):
             shared_kwargs if model_kwargs is None else {**shared_kwargs, **model_kwargs}
         )
 
-        tokenizer_kwargs = (
+        processor_kwargs_merged = (
             shared_kwargs
-            if tokenizer_kwargs is None
-            else {**shared_kwargs, **tokenizer_kwargs}
+            if processor_kwargs is None
+            else {**shared_kwargs, **processor_kwargs}
         )
 
-        config_kwargs = (
+        config_kwargs_merged = (
             shared_kwargs
             if config_kwargs is None
             else {**shared_kwargs, **config_kwargs}
@@ -1328,18 +1425,18 @@ class ColBERT(SentenceTransformer):
         transformer_model = Transformer(
             model_name_or_path=model_name_or_path,
             cache_dir=cache_folder,
-            model_args=model_kwargs,
-            tokenizer_args=tokenizer_kwargs,
-            config_args=config_kwargs,
+            model_kwargs=model_kwargs,
+            processor_kwargs=processor_kwargs_merged,
+            config_kwargs=config_kwargs_merged,
         )
 
         self.model_card_data.set_base_model(
             model_id=model_name_or_path, revision=revision
         )
 
-        return [transformer_model]
+        return [transformer_model], None
 
-    def _load_sbert_model(
+    def _load_config_modules(
         self,
         model_name_or_path: str,
         token: bool | str | None,
@@ -1347,12 +1444,12 @@ class ColBERT(SentenceTransformer):
         revision: str | None = None,
         trust_remote_code: bool = False,
         local_files_only: bool = False,
-        model_kwargs: dict | None = None,
-        tokenizer_kwargs: dict | None = None,
-        config_kwargs: dict | None = None,
-    ) -> list[nn.Module]:
-        """Create a Sentence Transformer model from a model name or path."""
-        modules, module_kwargs = super()._load_sbert_model(
+        model_kwargs: dict[str, Any] | None = None,
+        processor_kwargs: dict[str, Any] | None = None,
+        config_kwargs: dict[str, Any] | None = None,
+    ) -> tuple[OrderedDict[str, nn.Module], dict[str, Any]]:
+        """Load a ColBERT model from a model name or path (has modules.json)."""
+        modules, module_kwargs = super()._load_config_modules(
             model_name_or_path=model_name_or_path,
             token=token,
             cache_folder=cache_folder,
@@ -1360,47 +1457,66 @@ class ColBERT(SentenceTransformer):
             trust_remote_code=trust_remote_code,
             local_files_only=local_files_only,
             model_kwargs=model_kwargs,
-            tokenizer_kwargs=tokenizer_kwargs,
+            processor_kwargs=processor_kwargs,
             config_kwargs=config_kwargs,
         )
 
-        config_sentence_transformers_json_path = load_file_path(
+        # Filter to only Transformer + Dense modules (no Pooling)
+        if isinstance(modules, OrderedDict):
+            filtered = OrderedDict()
+            for name, module in modules.items():
+                if isinstance(module, (Transformer, DenseSentenceTransformer)):
+                    filtered[name] = module
+            return filtered, module_kwargs
+        else:
+            filtered = [
+                module
+                for module in modules
+                if isinstance(module, (Transformer, DenseSentenceTransformer))
+            ]
+            return filtered, module_kwargs
+
+    def _load_converted_modules(
+        self,
+        model_name_or_path: str,
+        token: bool | str | None,
+        cache_folder: str | None,
+        revision: str | None = None,
+        trust_remote_code: bool = False,
+        local_files_only: bool = False,
+        model_kwargs: dict[str, Any] | None = None,
+        processor_kwargs: dict[str, Any] | None = None,
+        config_kwargs: dict[str, Any] | None = None,
+        model_type: str | None = None,
+    ) -> tuple[list[nn.Module] | OrderedDict[str, nn.Module], dict[str, Any]]:
+        """Convert a non-ColBERT model (e.g. SentenceTransformer) to ColBERT modules."""
+        # For SentenceTransformer models, load them via _load_config_modules and filter out Pooling
+        modules, module_kwargs = super()._load_config_modules(
             model_name_or_path=model_name_or_path,
-            filename="config_sentence_transformers.json",
             token=token,
             cache_folder=cache_folder,
             revision=revision,
+            trust_remote_code=trust_remote_code,
             local_files_only=local_files_only,
+            model_kwargs=model_kwargs,
+            processor_kwargs=processor_kwargs,
+            config_kwargs=config_kwargs,
         )
 
-        if config_sentence_transformers_json_path is not None:
-            with open(file=config_sentence_transformers_json_path) as fIn:
-                self._model_config = json.load(fp=fIn)
-
-            # Loading the query/document prefixes and query_length
-            if "query_prefix" in self._model_config:
-                self.query_prefix = self._model_config["query_prefix"]
-            if "document_prefix" in self._model_config:
-                self.document_prefix = self._model_config["document_prefix"]
-            if "query_length" in self._model_config:
-                self.query_length = self._model_config["query_length"]
-            if "document_length" in self._model_config:
-                self.document_length = self._model_config["document_length"]
-            if "attend_to_expansion_tokens" in self._model_config:
-                self.attend_to_expansion_tokens = self._model_config[
-                    "attend_to_expansion_tokens"
-                ]
-            if "skiplist_words" in self._model_config:
-                self.skiplist_words = self._model_config["skiplist_words"]
-            if "do_query_expansion" in self._model_config:
-                self.do_query_expansion = self._model_config["do_query_expansion"]
-
-        return [
-            module
-            for module in modules.values()
-            if isinstance(module, Transformer)
-            or isinstance(module, DenseSentenceTransformer)
-        ], module_kwargs
+        # Filter to only Transformer + Dense modules (no Pooling)
+        if isinstance(modules, OrderedDict):
+            filtered = OrderedDict()
+            for name, module in modules.items():
+                if isinstance(module, (Transformer, DenseSentenceTransformer)):
+                    filtered[name] = module
+            return filtered, module_kwargs
+        else:
+            filtered = [
+                module
+                for module in modules
+                if isinstance(module, (Transformer, DenseSentenceTransformer))
+            ]
+            return filtered, module_kwargs
 
     def _get_model_type(
         self,
@@ -1409,9 +1525,9 @@ class ColBERT(SentenceTransformer):
         cache_folder: str | None,
         revision: str | None = None,
         local_files_only: bool = False,
-    ) -> str | None:
+    ) -> str:
         """
-        Overwrite the _get_model_type method to return the model type from the config_sentence_transformers.json file and default to "ColBERT". This is because, ST only use load_sbert_model if the model_type is equals to the class name, else it will use load_auto_model.
+        Overwrite the _get_model_type method to return the model type from the config_sentence_transformers.json file and default to "ColBERT". This is because, ST only use load_config_modules if the model_type is equals to the class name, else it will use load_converted_modules.
 
         Args:
             model_name_or_path (str): The name or path of the pre-trained model.
@@ -1421,7 +1537,7 @@ class ColBERT(SentenceTransformer):
             local_files_only (bool, optional): Whether to use only local files. Defaults to False.
 
         Returns:
-            Optional[str]: The model type (SentenceTransformer or SparseEncoder) if available, None otherwise.
+            str: The model type (SentenceTransformer or SparseEncoder) if available, None otherwise.
         """
         config_sentence_transformers_json_path = load_file_path(
             model_name_or_path,
@@ -1439,4 +1555,4 @@ class ColBERT(SentenceTransformer):
             config = json.load(fIn)
             return config.get(
                 "model_type", "ColBERT"
-            )  # Default to "SentenceTransformer" if not specified
+            )  # Default to "ColBERT" if not specified

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -1863,9 +1863,7 @@ class ColBERT(SentenceTransformer):
             config = AutoConfig.from_pretrained(model_name_or_path, **config_kwargs)
         except Exception:
             # LoRA adapter repos have no config.json — resolve via adapter_config.json.
-            config = ColBERT._resolve_adapter_config(
-                model_name_or_path, config_kwargs
-            )
+            config = ColBERT._resolve_adapter_config(model_name_or_path, config_kwargs)
             if config is None:
                 return None, None
         architectures = getattr(config, "architectures", None) or []

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -491,6 +491,10 @@ class ColBERT(SentenceTransformer):
             tensors=[input_ids[:, :1], prefix_tensor, input_ids[:, 1:]], dim=1
         )
 
+    _MULTIMODAL_KEYS = frozenset(
+        {"image", "images", "pixel_values", "audio", "video"}
+    )
+
     @staticmethod
     def _is_text_input(inputs) -> bool:
         """Check whether inputs are text (strings) vs multimodal (images, etc)."""
@@ -500,11 +504,12 @@ class ColBERT(SentenceTransformer):
             first = inputs[0]
             if isinstance(first, str):
                 return True
-            # list of dicts or tuples of strings are text inputs
-            if isinstance(first, (dict, tuple)):
-                return isinstance(first, tuple) and all(
-                    isinstance(s, str) for s in first
-                )
+            if isinstance(first, tuple):
+                return all(isinstance(s, str) for s in first)
+            if isinstance(first, dict):
+                return not any(
+                    k in ColBERT._MULTIMODAL_KEYS for k in first
+                ) and all(isinstance(v, str) for v in first.values())
         return False
 
     @deprecated_kwargs(sentences="inputs")

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -18,6 +18,7 @@ from sentence_transformers import SentenceTransformer
 from sentence_transformers.base.modules import Dense as DenseSentenceTransformer
 from sentence_transformers.base.modules import Transformer
 from sentence_transformers.util import batch_to_device, load_file_path
+from sentence_transformers.util.decorators import deprecated_kwargs
 from sentence_transformers.util.quantization import quantize_embeddings
 from torch import nn
 from tqdm.autonotebook import trange
@@ -506,9 +507,10 @@ class ColBERT(SentenceTransformer):
                 return isinstance(first, tuple) and all(isinstance(s, str) for s in first)
         return False
 
+    @deprecated_kwargs(sentences="inputs")
     def encode(
         self,
-        sentences: str | list[str],
+        inputs: str | list[str] = None,
         prompt_name: str | None = None,
         prompt: str | None = None,
         batch_size: int = 32,
@@ -529,8 +531,8 @@ class ColBERT(SentenceTransformer):
 
         Parameters
         ----------
-        sentences
-            The sentences to embed.
+        inputs
+            The inputs to embed.
         prompt_name
             The name of the prompt to use for encoding. Must be a key in the `prompts` dictionary, which is either set in
             the constructor or loaded from the model configuration. For example, if `prompt_name` is "query" and the
@@ -592,14 +594,14 @@ class ColBERT(SentenceTransformer):
                 "output_value=None is not compatible with pool_factor > 1."
             )
 
-        if isinstance(sentences, list):
-            # If we have a list of list of sentences, we encode each list separately.
-            if isinstance(sentences[0], list):
+        if isinstance(inputs, list):
+            # If we have a list of list of inputs, we encode each list separately.
+            if isinstance(inputs[0], list):
                 embeddings = []
 
-                for batch in sentences:
+                for batch in inputs:
                     batch_embeddings = self.encode(
-                        sentences=batch,
+                        inputs=batch,
                         prompt_name=prompt_name,
                         prompt=prompt,
                         batch_size=batch_size,
@@ -645,15 +647,15 @@ class ColBERT(SentenceTransformer):
         convert_to_numpy = not convert_to_tensor
 
         input_was_string = False
-        if isinstance(sentences, str) or not hasattr(sentences, "__len__"):
-            sentences = [sentences]
+        if isinstance(inputs, str) or not hasattr(inputs, "__len__"):
+            inputs = [inputs]
             input_was_string = True
 
         prompt = self._resolve_prompt(prompt, prompt_name)
 
         extra_features = {}
         if prompt is not None:
-            sentences = [prompt + sentence for sentence in sentences]
+            inputs = [prompt + inp for inp in inputs]
 
             # Some models require removing the prompt before pooling (e.g. Instructor, Grit).
             # Tracking the prompt length allow us to remove the prompt during pooling.
@@ -675,30 +677,30 @@ class ColBERT(SentenceTransformer):
                 "attention_mask": [],
                 "masks": [],
             }
-        is_text = self._is_text_input(sentences)
+        is_text = self._is_text_input(inputs)
         if is_text:
-            length_sorted_idx = np.argsort([-self._input_length(sen) for sen in sentences])
+            length_sorted_idx = np.argsort([-self._input_length(inp) for inp in inputs])
         else:
-            length_sorted_idx = np.arange(len(sentences))
-        sentences_sorted = [sentences[int(idx)] for idx in length_sorted_idx]
+            length_sorted_idx = np.arange(len(inputs))
+        inputs_sorted = [inputs[int(idx)] for idx in length_sorted_idx]
 
         for start_index in trange(
             0,
-            len(sentences),
+            len(inputs),
             batch_size,
             desc=f"Encoding queries (bs={batch_size})"
             if is_query
             else f"Encoding documents (bs={batch_size})",
             disable=not show_progress_bar,
         ):
-            sentences_batch = sentences_sorted[start_index : start_index + batch_size]
+            inputs_batch = inputs_sorted[start_index : start_index + batch_size]
 
             # Use preprocess for both text and multimodal inputs
             if is_text:
-                features = self.preprocess(inputs=sentences_batch, is_query=is_query)
+                features = self.preprocess(inputs=inputs_batch, is_query=is_query)
             else:
                 # Multimodal path: use the base transformer's preprocess directly
-                features = self._preprocess_multimodal(sentences_batch)
+                features = self._preprocess_multimodal(inputs_batch, is_query=is_query)
 
             if self.device.type == "hpu":
                 features = self._pad_features_for_hpu(features)
@@ -833,19 +835,19 @@ class ColBERT(SentenceTransformer):
 
     def encode_query(
         self,
-        sentences: str | list[str],
+        inputs: str | list[str],
         **kwargs,
     ) -> list[torch.Tensor] | ndarray | torch.Tensor:
         """Convenience method to encode queries (sets is_query=True)."""
-        return self.encode(sentences, is_query=True, **kwargs)
+        return self.encode(inputs, is_query=True, **kwargs)
 
     def encode_document(
         self,
-        sentences: str | list[str],
+        inputs: str | list[str],
         **kwargs,
     ) -> list[torch.Tensor] | ndarray | torch.Tensor:
         """Convenience method to encode documents (sets is_query=False)."""
-        return self.encode(sentences, is_query=False, **kwargs)
+        return self.encode(inputs, is_query=False, **kwargs)
 
     def pool_embeddings_hierarchical(
         self,

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -11,7 +11,6 @@ from typing import Any, Iterable, Literal, Optional
 
 import numpy as np
 import torch
-import torch.nn.functional as F
 from numpy import ndarray
 from scipy.cluster import hierarchy
 from sentence_transformers import SentenceTransformer
@@ -479,16 +478,6 @@ class ColBERT(SentenceTransformer):
         if not self.do_query_expansion:
             self.attend_to_expansion_tokens = False
 
-        # TODO: verify — capture the construction-time tokenizer cap so multimodal
-        # preprocess can restore it (see `_preprocess_multimodal`). Mirrors what
-        # colpali_engine does: image processing leaves `model_max_length` alone
-        # and relies on `max_pixels` / `max_num_visual_tokens` to bound the
-        # visual block. The text path here mutates `first_module.max_seq_length`
-        # per call (to `query_length` / `document_length`), which would otherwise
-        # leak into a subsequent multimodal call and truncate the expanded
-        # `<|image_pad|>` block below the visual budget.
-        first_module = self._first_module()
-        self._multimodal_max_seq_length = getattr(first_module, "max_seq_length", None)
 
     @staticmethod
     def load(input_path) -> "ColBERT":
@@ -718,12 +707,7 @@ class ColBERT(SentenceTransformer):
         ):
             inputs_batch = inputs_sorted[start_index : start_index + batch_size]
 
-            # Use preprocess for both text and multimodal inputs
-            if is_text:
-                features = self.preprocess(inputs=inputs_batch, is_query=is_query)
-            else:
-                # Multimodal path: use the base transformer's preprocess directly
-                features = self._preprocess_multimodal(inputs_batch, is_query=is_query)
+            features = self.preprocess(inputs=inputs_batch, is_query=is_query)
 
             if self.device.type == "hpu":
                 features = self._pad_features_for_hpu(features)
@@ -1192,9 +1176,8 @@ class ColBERT(SentenceTransformer):
         if inputs is None:
             raise ValueError("Either `inputs` or `texts` must be provided.")
 
-        # For multimodal inputs, delegate to the multimodal preprocessing path
         if not self._is_text_input(inputs):
-            return self._preprocess_multimodal(inputs, is_query=is_query)
+            return self._first_module().preprocess(inputs)
 
         # Set max sequence length based on whether the input is a query or document
         max_length = self.query_length if is_query else self.document_length
@@ -1203,34 +1186,15 @@ class ColBERT(SentenceTransformer):
         use_prefix = prefix_id is not None
         target_length = max_length - 1 if use_prefix else max_length
         first_module = self._first_module()
-        first_module.max_seq_length = target_length
 
-        # Tokenize the texts using the transformer module's preprocess
-        tokenized_outputs = first_module.preprocess(inputs)
-
-        # TODO: discuss if this is the best solution. ST v5.4's Transformer.preprocess no
-        # longer accepts padding kwargs (it always pads to longest-in-batch), so pad-to-
-        # max-length is done manually here. Required for query expansion (queries must
-        # reach `query_length` with [MASK] tokens; pad_token_id is set to mask_token_id
-        # at init) and for users who request `pad=True` (e.g. for the XTR-style
-        # `torch.stack` across positives/negatives in Contrastive/CachedContrastive).
-        # Alternative worth considering: pad in the loss after embedding, only up to
-        # max-seq-len in the batch — cheaper memory but moves the constraint into the
-        # loss instead of preprocess.
+        text_kwargs: dict[str, Any] = {"max_length": target_length}
         if pad or (is_query and self.do_query_expansion):
-            n = target_length - tokenized_outputs["input_ids"].size(1)
-            if n > 0:
-                pad_id = first_module.tokenizer.pad_token_id
-                tokenized_outputs["input_ids"] = F.pad(
-                    tokenized_outputs["input_ids"], (0, n), value=pad_id
-                )
-                tokenized_outputs["attention_mask"] = F.pad(
-                    tokenized_outputs["attention_mask"], (0, n), value=0
-                )
-                if "token_type_ids" in tokenized_outputs:
-                    tokenized_outputs["token_type_ids"] = F.pad(
-                        tokenized_outputs["token_type_ids"], (0, n), value=0
-                    )
+            text_kwargs["padding"] = "max_length"
+
+        tokenized_outputs = first_module.preprocess(
+            inputs,
+            processing_kwargs={"text": text_kwargs},
+        )
 
         if use_prefix:
             # Insert prefix token and update attention mask
@@ -1267,42 +1231,6 @@ class ColBERT(SentenceTransformer):
             Use :meth:`preprocess` instead.
         """
         return self.preprocess(inputs=texts, is_query=is_query, pad=pad, task=task)
-
-    def _preprocess_multimodal(
-        self,
-        inputs: list,
-        is_query: bool = True,
-    ) -> dict[str, torch.Tensor]:
-        """Preprocess multimodal inputs (images, etc.) by delegating to the base transformer's preprocessor.
-
-        For multimodal inputs, we skip prefix token insertion and query expansion
-        since the VLM processor handles special tokens natively.
-
-        TODO: verify — restores the construction-time tokenizer cap captured in
-        ``__init__``. The text branch of ``preprocess`` mutates
-        ``first_module.max_seq_length`` to ``query_length`` /
-        ``document_length`` per call, and that propagates onto the underlying
-        tokenizer's ``model_max_length``. Without restoring here, a prior text
-        encode (e.g. a text query at ``query_length=32``) leaves the cap at 32,
-        the VLM processor's `<|image_pad|>` expansion runs *before*
-        tokenization, and the tokenizer truncates the expanded block —
-        ``processor._check_special_mm_tokens`` then raises a count mismatch.
-        ``colpali_engine`` avoids this by never touching ``model_max_length``
-        in its image/text processing paths and bounding the visual block via
-        ``max_pixels`` / ``max_num_visual_tokens`` instead.
-
-        Parameters
-        ----------
-        inputs
-            A list of multimodal inputs to preprocess.
-        is_query
-            Whether the inputs are queries. Can be used to set different max lengths
-            or add metadata for downstream processing.
-        """
-        first_module = self._first_module()
-        if self._multimodal_max_seq_length is not None:
-            first_module.max_seq_length = self._multimodal_max_seq_length
-        return first_module.preprocess(inputs)
 
     def _configure_chat_template(
         self,

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -1176,42 +1176,38 @@ class ColBERT(SentenceTransformer):
         if inputs is None:
             raise ValueError("Either `inputs` or `texts` must be provided.")
 
-        if not self._is_text_input(inputs):
-            return self._first_module().preprocess(inputs)
-
-        # Set max sequence length based on whether the input is a query or document
         max_length = self.query_length if is_query else self.document_length
         prefix_id = self.query_prefix_id if is_query else self.document_prefix_id
-        # The only case where prefix_id is None is when prefix was an empty string. Else it's a the id corresponding the prefix set (eventually defaulting to [D] or [Q])
         use_prefix = prefix_id is not None
         target_length = max_length - 1 if use_prefix else max_length
-        first_module = self._first_module()
 
         text_kwargs: dict[str, Any] = {"max_length": target_length}
         if pad or (is_query and self.do_query_expansion):
             text_kwargs["padding"] = "max_length"
 
-        tokenized_outputs = first_module.preprocess(
+        # For multimodal inputs (images, etc.), skip text processing_kwargs:
+        # VLM processors expand visual placeholders (e.g. <|image_pad|>) in the
+        # text string *before* tokenization, so max_length would truncate the
+        # expanded visual tokens. The visual token budget is controlled upstream
+        # by image processor settings (max_pixels, longest_edge, etc.), not by
+        # tokenizer max_length.
+        tokenized_outputs = self._first_module().preprocess(
             inputs,
-            processing_kwargs={"text": text_kwargs},
+            processing_kwargs={"text": text_kwargs} if self._is_text_input(inputs) else None,
         )
 
         if use_prefix:
-            # Insert prefix token and update attention mask
             tokenized_outputs["input_ids"] = self.insert_prefix_token(
                 tokenized_outputs["input_ids"], prefix_id
             )
             tokenized_outputs["attention_mask"] = self.insert_prefix_token(
                 tokenized_outputs["attention_mask"], 1
             )
-
-            # Update token type IDs if they exist
             if "token_type_ids" in tokenized_outputs:
                 tokenized_outputs["token_type_ids"] = self.insert_prefix_token(
                     tokenized_outputs["token_type_ids"], 0
                 )
 
-        # Adjust attention mask for expansion tokens if required
         if is_query and self.attend_to_expansion_tokens:
             tokenized_outputs["attention_mask"].fill_(1)
 

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -358,10 +358,17 @@ class ColBERT(SentenceTransformer):
                 )
             )
 
-        # Ensure all tensors in the model are of the same dtype as the first tensor
+        # Ensure non-transformer modules (e.g. the Dense projection) match
+        # the backbone dtype. We skip the Transformer module itself — it was
+        # already loaded in the correct dtype by ``from_pretrained``, and a
+        # blanket ``self.to(dtype)`` would downcast internal buffers like
+        # rotary embedding ``inv_freq`` from fp32 to bf16, causing position
+        # encoding drift.
         try:
             dtype = next(self.parameters()).dtype
-            self.to(dtype)
+            for module in self:
+                if not isinstance(module, Transformer):
+                    module.to(dtype)
         except StopIteration:
             pass
 

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -31,6 +31,90 @@ from .Dense import Dense
 
 logger = logging.getLogger(__name__)
 
+# ColPali architecture → base VLM architecture that AutoModel can load
+# without colpali_engine installed. Keys are the class names that appear
+# in config.architectures; values are the base-model class names.
+_COLPALI_TO_BASE_ARCHITECTURE: dict[str, str] = {
+    "ColPali": "PaliGemmaForConditionalGeneration",
+    "ColQwen2": "Qwen2VLModel",
+    "ColQwen2_5": "Qwen2_5_VLModel",
+    "ColQwen3": "Qwen3VLModel",
+    "ColQwen3_5": "Qwen3_5VLModel",
+    "ColGemma3": "Gemma3Model",
+    "ColIdefics3": "Idefics3Model",
+    "ColModernVBert": "ModernVBertModel",
+    "ColQwen2_5Omni": "Qwen2_5OmniThinkerForConditionalGeneration",
+}
+
+# Weight key prefix for the projection layer in each ColPali architecture.
+# Most use "custom_text_proj"; ColIdefics3 uses "linear".
+_COLPALI_PROJ_KEY: dict[str, str] = {
+    "ColIdefics3": "linear",
+}
+_DEFAULT_PROJ_KEY = "custom_text_proj"
+
+
+def _load_colpali_proj_tensors(
+    model_name_or_path: str,
+    weight_key: str,
+    bias_key: str,
+    **hub_kwargs,
+) -> dict[str, torch.Tensor]:
+    """Read projection layer tensors from a safetensors checkpoint.
+
+    Matches keys by suffix (e.g. any key ending in ``custom_text_proj.weight``)
+    so it handles plain, ``model.``-prefixed, and ``base_model.model.``-prefixed
+    checkpoints without maintaining an explicit prefix list.
+    """
+    from safetensors import safe_open
+
+    def _find_in_file(sf_path: str) -> dict[str, torch.Tensor]:
+        result = {}
+        with safe_open(sf_path, framework="pt", device="cpu") as f:
+            for key in f.keys():
+                if key == weight_key or key.endswith("." + weight_key):
+                    result[weight_key] = f.get_tensor(key)
+                elif key == bias_key or key.endswith("." + bias_key):
+                    result[bias_key] = f.get_tensor(key)
+        return result
+
+    # Try single safetensors file.
+    try:
+        sf_path = cached_file(model_name_or_path, "model.safetensors", **hub_kwargs)
+        result = _find_in_file(sf_path)
+        if weight_key in result:
+            return result
+    except EnvironmentError:
+        pass
+
+    # Try sharded safetensors — scan each shard via the index.
+    try:
+        index_path = cached_file(
+            model_name_or_path, "model.safetensors.index.json", **hub_kwargs
+        )
+        with open(index_path) as f:
+            weight_map = json.load(f)["weight_map"]
+
+        shard_files = {
+            v
+            for k, v in weight_map.items()
+            if k.endswith(weight_key) or k.endswith(bias_key)
+        }
+        result: dict[str, torch.Tensor] = {}
+        for shard_file in shard_files:
+            shard_path = cached_file(model_name_or_path, shard_file, **hub_kwargs)
+            result.update(_find_in_file(shard_path))
+        if weight_key in result:
+            return result
+    except EnvironmentError:
+        pass
+
+    raise ValueError(
+        f"Could not find projection weights ending in '{weight_key}' "
+        f"in {model_name_or_path}. "
+        "Looked for model.safetensors and model.safetensors.index.json."
+    )
+
 
 __version__ = "3.0.0"
 __MODEL_HUB_ORGANIZATION__ = "sentence-transformers"
@@ -213,6 +297,7 @@ class ColBERT(SentenceTransformer):
         self.do_query_expansion = do_query_expansion
         self.attend_to_expansion_tokens = attend_to_expansion_tokens
         self.skiplist_words = skiplist_words
+        self._is_colpali_model = False
         model_card_data = model_card_data or PylateModelCardData()
         if similarity_fn_name is None:
             similarity_fn_name = "MaxSim"
@@ -249,6 +334,15 @@ class ColBERT(SentenceTransformer):
             model_card_data=model_card_data,
             backend=backend,
         )
+
+        # Detect multimodal models from the loaded modality config. This
+        # covers both pre-trained ColPali checkpoints (detected via
+        # _COLPALI_TO_BASE_ARCHITECTURE in _load_default_modules) and
+        # custom-trained multimodal ColBERT models on VL backbones.
+        if not self._is_colpali_model:
+            modality_config = getattr(self._first_module(), "modality_config", {})
+            if "image" in modality_config:
+                self._is_colpali_model = True
 
         # Wire a ColPali-faithful chat template into the multimodal preprocessor.
         # Priority: explicit user override in processor_kwargs > template saved
@@ -1457,6 +1551,12 @@ class ColBERT(SentenceTransformer):
 
         This module is distinct from SentenceTransformer as it does not set the pooling layer.
         Called when no modules.json is found (creating a new ColBERT from a base model).
+
+        For ColPali-family models (ColQwen2, ColQwen2_5, …) the checkpoint is
+        loaded as the underlying base VLM and the ``custom_text_proj`` weights
+        are extracted into a separate :class:`Dense` module, yielding the
+        standard ``[Transformer, Dense]`` pipeline without requiring
+        ``colpali_engine``.
         """
         logger.warning(
             f"No sentence-transformers model found with name {model_name_or_path}."
@@ -1485,6 +1585,22 @@ class ColBERT(SentenceTransformer):
             else {**shared_kwargs, **config_kwargs}
         )
 
+        # Detect ColPali-family models and override the architecture so
+        # AutoModel loads the base VLM (no colpali_engine dependency).
+        colpali_arch = self._detect_colpali_architecture(
+            model_name_or_path, config_kwargs_merged
+        )
+        if colpali_arch is not None:
+            base_arch = _COLPALI_TO_BASE_ARCHITECTURE[colpali_arch]
+            config_kwargs_merged = {
+                **config_kwargs_merged,
+                "architectures": [base_arch],
+            }
+            logger.info(
+                f"Detected ColPali architecture '{colpali_arch}', "
+                f"loading as base VLM '{base_arch}'."
+            )
+
         transformer_model = Transformer(
             model_name_or_path=model_name_or_path,
             cache_dir=cache_folder,
@@ -1497,7 +1613,196 @@ class ColBERT(SentenceTransformer):
             model_id=model_name_or_path, revision=revision
         )
 
-        return [transformer_model], None
+        modules: list[nn.Module] = [transformer_model]
+
+        if colpali_arch is not None:
+            self._fix_colpali_processor(
+                transformer_model,
+                model_name_or_path,
+                processor_kwargs_merged,
+            )
+
+            proj_key = _COLPALI_PROJ_KEY.get(colpali_arch, _DEFAULT_PROJ_KEY)
+            dense = self._extract_colpali_projection(
+                model_name_or_path,
+                transformer_model,
+                proj_key=proj_key,
+                cache_folder=cache_folder,
+                token=token,
+                revision=revision,
+                local_files_only=local_files_only,
+            )
+            modules.append(dense)
+            self._is_colpali_model = True
+            logger.info(
+                f"Extracted '{proj_key}' → Dense({dense.in_features}, {dense.out_features})"
+            )
+
+        return modules, None
+
+    # ------------------------------------------------------------------
+    # ColPali helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _fix_colpali_processor(
+        transformer_model: Transformer,
+        model_name_or_path: str,
+        processor_kwargs: dict[str, Any],
+    ) -> None:
+        """Replace the ColPali processor with the base VLM processor.
+
+        Why we patch instead of loading the right processor upfront:
+        ``Transformer.__init__`` always loads the processor via
+        ``AutoProcessor.from_pretrained(model_name_or_path)``, which reads
+        ``preprocessor_config.json`` from the repo. ColPali repos declare a
+        ColPali-specific ``processor_class`` there (e.g. ``ColQwen2Processor``,
+        ``ColQwen2_5_Processor``). Those custom processors either reject mixed
+        text+image inputs or don't even exist in transformers — causing
+        ``AutoProcessor`` to fall back to a plain tokenizer with no image
+        processing. ``Transformer`` exposes no way to override the processor
+        class, so we have to swap it after construction.
+
+        Why we also re-infer modality config and force structured messages:
+        ``Transformer.__init__`` runs ``infer_modalities(model, processor)``
+        at construction time — *before* we can swap the processor. When the
+        original processor was a plain tokenizer (no image support) or a
+        ColPali processor that ST doesn't fully recognize, the inferred
+        config is wrong (missing ``image`` modality, ``flat`` message format
+        instead of ``structured``). After swapping we re-infer, and force
+        ``structured`` because ColPali models always use typed content items
+        (``[{type: 'image'}, {type: 'text', text: ...}]``) — even when
+        ``infer_modalities`` guesses ``flat`` for newer VL processors that
+        ST doesn't fully support yet (e.g. ``Qwen2_5_VLProcessor``).
+        """
+        import importlib
+
+        from transformers import AutoConfig
+        from transformers.models.auto.processing_auto import (
+            PROCESSOR_MAPPING_NAMES,
+        )
+
+        config = AutoConfig.from_pretrained(
+            model_name_or_path,
+            **{
+                k: v
+                for k, v in processor_kwargs.items()
+                if k in ("token", "trust_remote_code", "revision", "local_files_only")
+            },
+        )
+        base_proc_name = PROCESSOR_MAPPING_NAMES.get(config.model_type)
+        if base_proc_name is None:
+            return
+
+        base_proc_cls = getattr(importlib.import_module("transformers"), base_proc_name)
+        old_proc = getattr(transformer_model, "processor", None)
+        old_template = getattr(old_proc, "chat_template", None)
+
+        base_processor = base_proc_cls.from_pretrained(
+            model_name_or_path,
+            **processor_kwargs,
+        )
+        if old_template:
+            base_processor.chat_template = old_template
+
+        transformer_model.processor = base_processor
+
+        transformer_model.modality_config, transformer_model.module_output_name = (
+            transformer_model.infer_modalities(
+                transformer_model.model,
+                base_processor,
+            )
+        )
+        if "message" in transformer_model.modality_config:
+            transformer_model.modality_config["message"]["format"] = "structured"
+        transformer_model.input_formatter.supported_modalities = list(
+            transformer_model.modality_config.keys()
+        )
+        transformer_model.input_formatter.message_format = "structured"
+
+        old_name = type(old_proc).__name__ if old_proc else "None"
+        logger.info(
+            f"Replaced ColPali processor {old_name} "
+            f"with {type(base_processor).__name__}"
+        )
+
+    @staticmethod
+    def _detect_colpali_architecture(
+        model_name_or_path: str,
+        config_kwargs: dict[str, Any],
+    ) -> str | None:
+        """Return the ColPali architecture name if this is a ColPali model, else None."""
+        from transformers import AutoConfig
+
+        try:
+            config = AutoConfig.from_pretrained(model_name_or_path, **config_kwargs)
+        except Exception:
+            return None
+        architectures = getattr(config, "architectures", None) or []
+        for arch in architectures:
+            if arch in _COLPALI_TO_BASE_ARCHITECTURE:
+                return arch
+        return None
+
+    @staticmethod
+    def _extract_colpali_projection(
+        model_name_or_path: str,
+        transformer_model: Transformer,
+        proj_key: str,
+        cache_folder: str | None,
+        token: bool | str | None,
+        revision: str | None,
+        local_files_only: bool,
+    ) -> Dense:
+        """Extract the projection layer weights from a ColPali checkpoint.
+
+        Checks whether the loaded ``auto_model`` already carries the projection
+        (happens when ``colpali_engine`` is installed and ``trust_remote_code``
+        was used). Otherwise falls back to reading the safetensors files
+        directly.
+        """
+        weight_key = f"{proj_key}.weight"
+        bias_key = f"{proj_key}.bias"
+
+        auto_model = transformer_model.auto_model
+
+        # Path 1: model was loaded with colpali_engine — projection is an attribute
+        if hasattr(auto_model, proj_key):
+            proj_module = getattr(auto_model, proj_key)
+            proj_weight = proj_module.weight.data.clone()
+            proj_bias = (
+                proj_module.bias.data.clone() if proj_module.bias is not None else None
+            )
+            delattr(auto_model, proj_key)
+            return Dense(
+                in_features=proj_weight.shape[1],
+                out_features=proj_weight.shape[0],
+                bias=proj_bias is not None,
+                init_weight=proj_weight,
+                init_bias=proj_bias,
+            )
+
+        # Path 2: base VLM loaded — projection keys were ignored, read from files
+        hub_kwargs = {
+            "cache_dir": cache_folder,
+            "token": token,
+            "revision": revision,
+            "local_files_only": local_files_only,
+        }
+
+        proj_tensors = _load_colpali_proj_tensors(
+            model_name_or_path, weight_key, bias_key, **hub_kwargs
+        )
+
+        proj_weight = proj_tensors[weight_key]
+        proj_bias = proj_tensors.get(bias_key)
+        return Dense(
+            in_features=proj_weight.shape[1],
+            out_features=proj_weight.shape[0],
+            bias=proj_bias is not None,
+            init_weight=proj_weight,
+            init_bias=proj_bias,
+        )
 
     @staticmethod
     def _filter_non_colbert_modules(

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -1008,8 +1008,15 @@ class ColBERT(SentenceTransformer):
                         masks = out_features["attention_mask"].bool()
                 else:
                     if self.do_query_expansion:
-                        # We keep all tokens in the query (no skiplist) and we do not want to prune expansion tokens in queries even if we do not attend to them in attention layers
-                        if "input_ids" in out_features:
+                        if self._is_colpali_model:
+                            # Suffix expansion: the attention mask already spans
+                            # text + expansion tokens; anything beyond it is
+                            # batch-alignment padding whose embeddings must not
+                            # leak into MaxSim (they make scores depend on the
+                            # batch composition).
+                            masks = out_features["attention_mask"].bool()
+                        elif "input_ids" in out_features:
+                            # We keep all tokens in the query (no skiplist) and we do not want to prune expansion tokens in queries even if we do not attend to them in attention layers
                             masks = torch.ones_like(
                                 input=out_features["input_ids"], dtype=torch.bool
                             )

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -1714,7 +1714,7 @@ class ColBERT(SentenceTransformer):
 
         # Detect ColPali-family models and override the architecture so
         # AutoModel loads the base VLM (no colpali_engine dependency).
-        colpali_arch = self._detect_colpali_architecture(
+        colpali_arch, detected_config = self._detect_colpali_architecture(
             model_name_or_path, config_kwargs_merged
         )
         if colpali_arch is not None:
@@ -1747,6 +1747,7 @@ class ColBERT(SentenceTransformer):
                 transformer_model,
                 model_name_or_path,
                 processor_kwargs_merged,
+                model_type=detected_config.model_type,
             )
 
             proj_key = _COLPALI_PROJ_KEY.get(colpali_arch, _DEFAULT_PROJ_KEY)
@@ -1776,6 +1777,7 @@ class ColBERT(SentenceTransformer):
         transformer_model: Transformer,
         model_name_or_path: str,
         processor_kwargs: dict[str, Any],
+        model_type: str,
     ) -> None:
         """Replace the ColPali processor with the base VLM processor.
 
@@ -1804,23 +1806,14 @@ class ColBERT(SentenceTransformer):
         """
         import importlib
 
-        from transformers import AutoConfig
         from transformers.models.auto.processing_auto import (
             PROCESSOR_MAPPING_NAMES,
         )
 
-        config = AutoConfig.from_pretrained(
-            model_name_or_path,
-            **{
-                k: v
-                for k, v in processor_kwargs.items()
-                if k in ("token", "trust_remote_code", "revision", "local_files_only")
-            },
-        )
-        base_proc_name = PROCESSOR_MAPPING_NAMES.get(config.model_type)
+        base_proc_name = PROCESSOR_MAPPING_NAMES.get(model_type)
         if base_proc_name is None:
             logger.warning(
-                f"Could not find a base processor for model_type={config.model_type!r} "
+                f"Could not find a base processor for model_type={model_type!r} "
                 f"in PROCESSOR_MAPPING_NAMES — the colpali-engine processor will not be "
                 f"replaced. Consider upgrading transformers."
             )
@@ -1862,18 +1855,19 @@ class ColBERT(SentenceTransformer):
     def _detect_colpali_architecture(
         model_name_or_path: str,
         config_kwargs: dict[str, Any],
-    ) -> str | None:
-        """Return the ColPali architecture name if this is a ColPali model, else None."""
+    ) -> tuple[str | None, Any]:
+        """Return (colpali_arch, config) if this is a ColPali model, else (None, config)."""
         from transformers import AutoConfig
 
         try:
             config = AutoConfig.from_pretrained(model_name_or_path, **config_kwargs)
         except Exception:
-            return None
+            return None, None
         architectures = getattr(config, "architectures", None) or []
         for arch in architectures:
             if arch in _COLPALI_TO_BASE_ARCHITECTURE:
-                return arch
+                return arch, config
+        return None, config
         return None
 
     @staticmethod

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -7,6 +7,7 @@ import math
 import string
 import warnings
 from collections import OrderedDict
+from contextlib import nullcontext
 from typing import Any, Iterable, Literal, Optional
 
 import numpy as np
@@ -776,6 +777,22 @@ class ColBERT(SentenceTransformer):
                 )
         return False
 
+    def _autocast_context(self):
+        """Return an autocast context matching the model's dtype.
+
+        During training the HF Trainer wraps the forward pass in autocast,
+        which keeps operations like LayerNorm in fp32 even when the model
+        weights are bf16/fp16. Standalone ``encode()`` runs outside the
+        Trainer, so we replicate that behaviour here. For fp32 models or
+        CPU-only runs this returns a no-op context.
+        """
+        if self.device.type not in ("cuda", "xpu"):
+            return nullcontext()
+        param = next(self.parameters(), None)
+        if param is None or param.dtype == torch.float32:
+            return nullcontext()
+        return torch.autocast(device_type=self.device.type, dtype=param.dtype)
+
     @deprecated_kwargs(sentences="inputs")
     def encode(
         self,
@@ -972,7 +989,7 @@ class ColBERT(SentenceTransformer):
             features = batch_to_device(batch=features, target_device=device)
             features.update(extra_features)
 
-            with torch.no_grad():
+            with torch.no_grad(), self._autocast_context():
                 out_features = self.forward(input=features)
                 if self.device.type == "hpu":
                     out_features = copy.deepcopy(out_features)

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -1365,7 +1365,8 @@ class ColBERT(SentenceTransformer):
 
         if use_suffix_expansion:
             tokenized_outputs = self._append_expansion_tokens(
-                tokenized_outputs, n_tokens=10,
+                tokenized_outputs,
+                n_tokens=10,
             )
 
         if use_prefix:
@@ -1380,7 +1381,11 @@ class ColBERT(SentenceTransformer):
                     tokenized_outputs["token_type_ids"], 0
                 )
 
-        if is_query and self.attend_to_expansion_tokens and "attention_mask" in tokenized_outputs:
+        if (
+            is_query
+            and self.attend_to_expansion_tokens
+            and "attention_mask" in tokenized_outputs
+        ):
             tokenized_outputs["attention_mask"].fill_(1)
 
         return tokenized_outputs
@@ -1409,18 +1414,21 @@ class ColBERT(SentenceTransformer):
 
         if "attention_mask" in features:
             ones = torch.ones(
-                batch_size, n_tokens,
+                batch_size,
+                n_tokens,
                 dtype=features["attention_mask"].dtype,
                 device=device,
             )
             features["attention_mask"] = torch.cat(
-                [features["attention_mask"], ones], dim=1,
+                [features["attention_mask"], ones],
+                dim=1,
             )
 
         for key in ("token_type_ids", "mm_token_type_ids"):
             if key in features:
                 zeros = torch.zeros(
-                    batch_size, n_tokens,
+                    batch_size,
+                    n_tokens,
                     dtype=features[key].dtype,
                     device=device,
                 )

--- a/pylate/utils/__init__.py
+++ b/pylate/utils/__init__.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
 from .collator import ColBERTCollator
-from .distributed import all_gather, all_gather_with_gradients, get_rank, get_world_size
+from .distributed import (
+    all_gather,
+    all_gather_with_gradients,
+    all_reduce_max,
+    get_rank,
+    get_world_size,
+)
 from .huggingface_models import HUGGINGFACE_MODELS
 from .iter_batch import iter_batch
 from .multi_process import _start_multi_process_pool
@@ -17,6 +23,7 @@ __all__ = [
     "_start_multi_process_pool",
     "all_gather",
     "all_gather_with_gradients",
+    "all_reduce_max",
     "get_rank",
     "get_world_size",
 ]

--- a/pylate/utils/collator.py
+++ b/pylate/utils/collator.py
@@ -2,15 +2,25 @@ from __future__ import annotations
 
 import itertools
 import logging
-from typing import Callable
+from dataclasses import dataclass, field
+from typing import Any, Callable
 
 import torch
+from sentence_transformers.base.data_collator import BaseDataCollator
 
 logger = logging.getLogger(__name__)
 
 
-class ColBERTCollator:
+@dataclass
+class ColBERTCollator(BaseDataCollator):
     """Collator for ColBERT model.
+
+    Extends :class:`BaseDataCollator` with ColBERT-specific behavior:
+    - Detects query vs document columns (``is_query``) based on column name
+    - Flattens list-of-list columns (e.g. multiple documents per query)
+    - Skips ``_id`` columns
+    - Always passes ``pad=True`` to the preprocess function
+    - Optionally tracks prompt lengths for prompt-aware pooling
 
     Parameters
     ----------
@@ -72,6 +82,12 @@ class ColBERTCollator:
 
     """
 
+    include_prompt_lengths: bool = False
+    all_special_ids: set[int] = field(default_factory=set)
+    _prompt_length_mapping: dict[tuple[str, str | None], int] = field(
+        default_factory=dict, init=False, repr=False
+    )
+
     def __init__(
         self,
         preprocess_fn: Callable | None = None,
@@ -81,36 +97,44 @@ class ColBERTCollator:
         prompts: dict[str, str] | dict[str, dict[str, str]] | None = None,
         include_prompt_lengths: bool = False,
         all_special_ids: set[int] | None = None,
-        _prompt_length_mapping: dict[str, int] | None = None,
+        _prompt_length_mapping: dict | None = None,
         _warned_columns: set[tuple[str]] | None = None,
     ):
         # Support both preprocess_fn and deprecated tokenize_fn
         if preprocess_fn is not None:
-            self.preprocess_fn = preprocess_fn
+            actual_fn = preprocess_fn
         elif tokenize_fn is not None:
-            self.preprocess_fn = tokenize_fn
+            actual_fn = tokenize_fn
         else:
             raise ValueError("Either `preprocess_fn` or `tokenize_fn` must be provided.")
-
-        # Keep backward compat alias
-        self.tokenize_fn = self.preprocess_fn
-
-        self.router_mapping = router_mapping if router_mapping is not None else {}
-        self.prompts = prompts if prompts is not None else {}
-        self.all_special_ids = all_special_ids if all_special_ids is not None else set()
-        self._prompt_length_mapping = (
-            _prompt_length_mapping if _prompt_length_mapping is not None else {}
-        )
-        self._warned_columns = _warned_columns if _warned_columns is not None else set()
 
         if valid_label_columns is None:
             valid_label_columns = ["label", "scores"]
 
-        self.valid_label_columns = valid_label_columns
-        self.include_prompt_lengths = include_prompt_lengths
+        # Initialize the dataclass fields via the parent
+        super().__init__(
+            preprocess_fn=actual_fn,
+            valid_label_columns=valid_label_columns,
+            router_mapping=router_mapping if router_mapping is not None else {},
+            prompts=prompts if prompts is not None else {},
+        )
 
-    def __call__(self, features: list[dict]) -> dict[str, torch.Tensor]:
+        # Keep backward compat alias
+        self.tokenize_fn = self.preprocess_fn
+
+        self.include_prompt_lengths = include_prompt_lengths
+        self.all_special_ids = all_special_ids if all_special_ids is not None else set()
+        self._prompt_length_mapping = (
+            _prompt_length_mapping if _prompt_length_mapping is not None else {}
+        )
+        if _warned_columns is not None:
+            self._warned_columns = _warned_columns
+
+    def __call__(self, features: list[dict]) -> dict[str, Any]:
         """Collate a list of features into a batch."""
+        if not features:
+            return {}
+
         column_names = list(features[0].keys())
 
         # We should always be able to return a loss, label or not:
@@ -123,62 +147,21 @@ class ColBERTCollator:
         if tuple(column_names) not in self._warned_columns:
             self.maybe_warn_about_column_order(column_names)
 
-        # Extract the label column if it exists
+        # Extract the label column if it exists (inherited logic)
         for label_column in self.valid_label_columns:
             if label_column in column_names:
                 batch["label"] = torch.tensor([row[label_column] for row in features])
                 column_names.remove(label_column)
                 break
 
-        router_mapping = self.router_mapping
-        # If the router_mapping is a nested dict, then the outer keys are the column names, and we should
-        # grab the inner mapping for the specific dataset if it exists.
-        if (
-            router_mapping
-            and isinstance(router_mapping, dict)
-            and isinstance(next(iter(router_mapping.values())), dict)
-        ):
-            if "dataset_name" in batch and batch["dataset_name"] in router_mapping:
-                # Use the mapping for the specific dataset
-                router_mapping = router_mapping[batch["dataset_name"]]
-            else:
-                router_mapping = {}
-
-        prompts = self.prompts
-        if prompts and isinstance(prompts, dict):
-            # If the prompts are a mapping, we should check if the outer keys are dataset names.
-            is_multi_dataset = "dataset_name" in batch
-            if is_multi_dataset and batch["dataset_name"] in prompts:
-                # Use the prompts for the specific dataset
-                prompts = prompts[batch["dataset_name"]]
-            elif isinstance(next(iter(prompts.values())), dict):
-                # If the prompts are a nested dictionary, but we are not in a multi-dataset setting,
-                # we should raise an error. If we are in a multi-dataset setting, but this dataset
-                # does not have prompts, we use an empty dictionary to denote no prompt.
-                if not is_multi_dataset:
-                    raise ValueError(
-                        "The prompts provided to the trainer are a nested dictionary. In this setting, the first "
-                        "level of the dictionary should map to dataset names and the second level to column names. "
-                        "However, as the provided dataset is a not a DatasetDict, no dataset names can be inferred. "
-                        f"The keys to the provided prompts dictionary are {list(prompts.keys())!r}"
-                    )
-                else:
-                    logger.warning(
-                        "Prompts were provided as a nested dictionary for multiple datasets, but no prompts were "
-                        "found for dataset %r. Available datasets with prompts are: %r. Proceeding without prompts "
-                        "for this dataset.",
-                        batch["dataset_name"],
-                        list(prompts.keys()),
-                    )
-                    prompts = {}
+        router_mapping = self._resolve_router_mapping(batch)
+        prompts = self._resolve_prompts(batch)
 
         for column_name in column_names:
-            # We do not tokenize columns containing the ids. It would be better to throw them away during the dataset processing (TODO), but this break sentence transformers datasets extraction.
+            # We do not tokenize columns containing the ids.
             if "_id" in column_name:
                 continue
 
-            # Users can specify a router_mapping via the training arguments, which maps column names to "task types",
-            # useful for the Router module (among others). This has to be provided to the tokenization function.
             task = router_mapping.get(column_name, None)
             texts = [row[column_name] for row in features]
             # Flatten the list of texts if it is a list of lists (e.g, documents)
@@ -189,14 +172,9 @@ class ColBERTCollator:
             is_multimodal = not self._is_text_column(texts)
 
             # Get the string prompt for the column, if it exists.
-            prompt = None
-            if isinstance(prompts, str):
-                prompt = prompts
-            elif isinstance(prompts, dict) and column_name in prompts:
-                prompt = prompts[column_name]
+            prompt = self._get_prompt_for_column(prompts, column_name)
 
-            # If a prompt is provided, we prepend it to the column values. Some Pooling setups require removing the
-            # prompt tokens from the pooled embeddings, so we also store the prompt length which can be used for that.
+            # If a prompt is provided, we prepend it to the column values.
             if prompt and not is_multimodal:
                 if self.include_prompt_lengths:
                     prompt_length = self._get_prompt_length(prompt, task=task)
@@ -228,57 +206,12 @@ class ColBERTCollator:
 
         tokenized_prompt = self.preprocess_fn([prompt], task=task)
         if "input_ids" not in tokenized_prompt:
-            # If the tokenizer does not return input_ids, we cannot determine the prompt length.
-            # This can happen with some tokenizers that do not use input_ids.
             return None
         prompt_length = tokenized_prompt["input_ids"].shape[-1]
         # If the tokenizer adds a special EOS token, we do not count it as part of the prompt length.
-        # This is to ensure that the prompt length does not include the EOS token.
         last_token = tokenized_prompt["input_ids"][..., -1].item()
         if last_token in self.all_special_ids:
             prompt_length -= 1
 
         self._prompt_length_mapping[(prompt, task)] = prompt_length
         return prompt_length
-
-    def maybe_warn_about_column_order(self, column_names: list[str]) -> None:
-        """Warn the user if the columns are likely not in the expected order."""
-        # A mapping from common column names to the expected index in the dataset
-        column_name_to_expected_idx = {
-            "anchor": 0,
-            "positive": 1,
-            "negative": 2,
-            "question": 0,
-            "answer": 1,
-            "query": 0,
-            "response": 1,
-            "hypothesis": 0,
-            "entailment": 1,
-            "contradiction": 2,
-        }
-        for column_name, expected_idx in column_name_to_expected_idx.items():
-            if (
-                column_name in column_names
-                and column_names.index(column_name) != expected_idx
-            ):
-                if column_name in ("anchor", "positive", "negative"):
-                    proposed_fix_columns = ["anchor", "positive", "negative"]
-                elif column_name in ("question", "answer"):
-                    proposed_fix_columns = ["question", "answer"]
-                elif column_name in ("query", "response"):
-                    proposed_fix_columns = ["query", "response"]
-                elif column_name in ("hypothesis", "entailment", "contradiction"):
-                    proposed_fix_columns = ["hypothesis", "entailment", "contradiction"]
-
-                logger.warning(
-                    f"Column {column_name!r} is at index {column_names.index(column_name)}, whereas "
-                    f"a column with this name is usually expected at index {expected_idx}. Note that the column "
-                    "order can be important for some losses, e.g. MultipleNegativesRankingLoss will always "
-                    "consider the first column as the anchor and the second as the positive, regardless of "
-                    "the dataset column names. Consider renaming the columns to match the expected order, e.g.:\n"
-                    f"dataset = dataset.select_columns({proposed_fix_columns})"
-                )
-                # We only need to warn once per list of column names to prevent spamming the user
-                break
-
-        self._warned_columns.add(tuple(column_names))

--- a/pylate/utils/collator.py
+++ b/pylate/utils/collator.py
@@ -106,7 +106,9 @@ class ColBERTCollator(BaseDataCollator):
         elif tokenize_fn is not None:
             actual_fn = tokenize_fn
         else:
-            raise ValueError("Either `preprocess_fn` or `tokenize_fn` must be provided.")
+            raise ValueError(
+                "Either `preprocess_fn` or `tokenize_fn` must be provided."
+            )
 
         if valid_label_columns is None:
             valid_label_columns = ["label", "scores"]
@@ -185,7 +187,9 @@ class ColBERTCollator(BaseDataCollator):
                 texts = [prompt + text for text in texts]
 
             is_query = "query" in column_name or "anchor" in column_name
-            tokenized = self.preprocess_fn(texts, is_query=is_query, pad=True, task=task)
+            tokenized = self.preprocess_fn(
+                texts, is_query=is_query, pad=True, task=task
+            )
 
             for key, value in tokenized.items():
                 batch[f"{column_name}_{key}"] = value

--- a/pylate/utils/collator.py
+++ b/pylate/utils/collator.py
@@ -14,8 +14,11 @@ class ColBERTCollator:
 
     Parameters
     ----------
+    preprocess_fn
+        The function to preprocess/tokenize the input text. This should be
+        ``model.preprocess`` (or the deprecated ``model.tokenize``).
     tokenize_fn
-        The function to tokenize the input text.
+        Deprecated alias for ``preprocess_fn``. Use ``preprocess_fn`` instead.
     valid_label_columns
         The name of the columns that contain the labels: scores or labels.
     router_mapping
@@ -36,7 +39,7 @@ class ColBERTCollator:
     ... )
 
     >>> collator = utils.ColBERTCollator(
-    ...     tokenize_fn=model.tokenize,
+    ...     preprocess_fn=model.preprocess,
     ... )
 
     >>> features = [
@@ -71,7 +74,8 @@ class ColBERTCollator:
 
     def __init__(
         self,
-        tokenize_fn: Callable,
+        preprocess_fn: Callable | None = None,
+        tokenize_fn: Callable | None = None,
         valid_label_columns: list[str] | None = None,
         router_mapping: dict[str, str] | dict[str, dict[str, str]] | None = None,
         prompts: dict[str, str] | dict[str, dict[str, str]] | None = None,
@@ -80,7 +84,17 @@ class ColBERTCollator:
         _prompt_length_mapping: dict[str, int] | None = None,
         _warned_columns: set[tuple[str]] | None = None,
     ):
-        self.tokenize_fn = tokenize_fn
+        # Support both preprocess_fn and deprecated tokenize_fn
+        if preprocess_fn is not None:
+            self.preprocess_fn = preprocess_fn
+        elif tokenize_fn is not None:
+            self.preprocess_fn = tokenize_fn
+        else:
+            raise ValueError("Either `preprocess_fn` or `tokenize_fn` must be provided.")
+
+        # Keep backward compat alias
+        self.tokenize_fn = self.preprocess_fn
+
         self.router_mapping = router_mapping if router_mapping is not None else {}
         self.prompts = prompts if prompts is not None else {}
         self.all_special_ids = all_special_ids if all_special_ids is not None else set()
@@ -171,6 +185,9 @@ class ColBERTCollator:
             if isinstance(texts[0], list):
                 texts = list(itertools.chain(*texts))
 
+            # Detect if inputs are multimodal (non-text)
+            is_multimodal = not self._is_text_column(texts)
+
             # Get the string prompt for the column, if it exists.
             prompt = None
             if isinstance(prompts, str):
@@ -180,7 +197,7 @@ class ColBERTCollator:
 
             # If a prompt is provided, we prepend it to the column values. Some Pooling setups require removing the
             # prompt tokens from the pooled embeddings, so we also store the prompt length which can be used for that.
-            if prompt:
+            if prompt and not is_multimodal:
                 if self.include_prompt_lengths:
                     prompt_length = self._get_prompt_length(prompt, task=task)
                     if prompt_length is not None:
@@ -188,19 +205,28 @@ class ColBERTCollator:
                             [prompt_length] * len(features), dtype=torch.int
                         )
                 texts = [prompt + text for text in texts]
+
             is_query = "query" in column_name or "anchor" in column_name
-            tokenized = self.tokenize_fn(texts, is_query=is_query, pad=True, task=task)
+            tokenized = self.preprocess_fn(texts, is_query=is_query, pad=True, task=task)
 
             for key, value in tokenized.items():
                 batch[f"{column_name}_{key}"] = value
 
         return batch
 
+    @staticmethod
+    def _is_text_column(values: list) -> bool:
+        """Check if column values are text strings."""
+        if not values:
+            return True
+        first = values[0]
+        return isinstance(first, str)
+
     def _get_prompt_length(self, prompt: str, task: str | None = None) -> int:
         if (prompt, task) in self._prompt_length_mapping:
             return self._prompt_length_mapping[(prompt, task)]
 
-        tokenized_prompt = self.tokenize_fn([prompt], task=task)
+        tokenized_prompt = self.preprocess_fn([prompt], task=task)
         if "input_ids" not in tokenized_prompt:
             # If the tokenizer does not return input_ids, we cannot determine the prompt length.
             # This can happen with some tokenizers that do not use input_ids.

--- a/pylate/utils/distributed.py
+++ b/pylate/utils/distributed.py
@@ -12,6 +12,11 @@ logger = logging.getLogger(__name__)
 _has_warned_dist_not_initialized = False
 
 
+def is_distributed() -> bool:
+    """Return True if torch.distributed is available and initialized."""
+    return dist.is_available() and dist.is_initialized()
+
+
 def all_gather(tensor: torch.Tensor) -> Sequence[torch.Tensor]:
     """Gathers a tensor from each distributed rank into a list. The tensor for the local rank is the original one, with the gradients while the others have no gradients.
 
@@ -37,8 +42,7 @@ def all_gather(tensor: torch.Tensor) -> Sequence[torch.Tensor]:
     """
     global _has_warned_dist_not_initialized
 
-    # Check if torch.distributed is properly available and initialized.
-    if dist.is_available() and dist.is_initialized():
+    if is_distributed():
         world_size = dist.get_world_size()
         gathered_tensors = [torch.zeros_like(tensor) for _ in range(world_size)]
 
@@ -86,8 +90,7 @@ def all_gather_with_gradients(tensor: torch.Tensor) -> Sequence[torch.Tensor]:
     """
     global _has_warned_dist_not_initialized
 
-    # Check if torch.distributed is properly available and initialized.
-    if dist.is_available() and dist.is_initialized():
+    if is_distributed():
         tensor = dist.nn.all_gather(tensor)
         return tensor
 
@@ -104,17 +107,25 @@ def all_gather_with_gradients(tensor: torch.Tensor) -> Sequence[torch.Tensor]:
     return [tensor]
 
 
+def all_reduce_max(tensor: torch.Tensor) -> torch.Tensor:
+    """In-place all-reduce with MAX op across ranks.
+
+    No-op when distributed is not initialized (single-GPU / non-distributed).
+    """
+    if is_distributed():
+        dist.all_reduce(tensor, op=dist.ReduceOp.MAX)
+    return tensor
+
+
 def get_rank() -> int:
     """Returns the current rank in a distributed training."""
-    # Check if torch.distributed is properly available and initialized.
-    if dist.is_available() and dist.is_initialized():
+    if is_distributed():
         return dist.get_rank()
     return 0
 
 
 def get_world_size() -> int:
     """Returns the world size in a distributed training."""
-    # Check if torch.distributed is properly available and initialized.
-    if dist.is_available() and dist.is_initialized():
+    if is_distributed():
         return dist.get_world_size()
     return 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ locale = "en"
 extend-ignore-words-re = [
     "arange",
     "(?i)^lik$",
+    "thw",
 ]
 extend-ignore-re = [
     "xlm-mlm-ende-1024",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "sentence-transformers == 5.3.0",
+    "sentence-transformers >= 5.4.0",
     "datasets >= 2.20.0",
     "accelerate >= 0.31.0",
     "pandas >= 2.2.1",
@@ -62,6 +62,7 @@ flash-maxsim = ["flash-maxsim >= 0.2.1"]
 lik = [
     "late-interaction-kernels >=0.4.0,<0.5.0",
 ]
+image = ["Pillow", "sentence-transformers[image]"]
 
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "sentence-transformers >= 5.5.0",
+    "sentence-transformers == 5.5.1",
     "datasets >= 2.20.0",
     "accelerate >= 0.31.0",
     "pandas >= 2.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "sentence-transformers >= 5.4.0",
+    "sentence-transformers >= 5.5.0",
     "datasets >= 2.20.0",
     "accelerate >= 0.31.0",
     "pandas >= 2.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ flash-maxsim = ["flash-maxsim >= 0.2.1"]
 lik = [
     "late-interaction-kernels >=0.4.0,<0.5.0",
 ]
-image = ["Pillow", "sentence-transformers[image]"]
+image = ["sentence-transformers[image]"]
 
 
 [dependency-groups]
@@ -72,6 +72,7 @@ docs = [
     "mkdocs-jupyter == 0.24.8",
     "mkdocs_charts_plugin == 0.0.10",
     "numpydoc == 1.8.0",
+    "Pillow",
 ]
 
 [tool.setuptools]

--- a/tests/test_cached_contrastive.py
+++ b/tests/test_cached_contrastive.py
@@ -11,7 +11,7 @@ from sentence_transformers import (
     SentenceTransformerTrainer,
     SentenceTransformerTrainingArguments,
 )
-from sentence_transformers.training_args import BatchSamplers
+from sentence_transformers.sentence_transformer.training_args import BatchSamplers
 
 from pylate import evaluation, losses, models, utils
 

--- a/tests/test_cached_contrastive.py
+++ b/tests/test_cached_contrastive.py
@@ -61,7 +61,7 @@ def test_contrastive_training() -> None:
         eval_dataset=eval_dataset,
         loss=train_loss,
         evaluator=dev_evaluation,
-        data_collator=utils.ColBERTCollator(tokenize_fn=model.tokenize),
+        data_collator=utils.ColBERTCollator(preprocess_fn=model.preprocess),
     )
 
     trainer.train()

--- a/tests/test_chat_template.py
+++ b/tests/test_chat_template.py
@@ -39,11 +39,15 @@ def _configure(module, user_processor_kwargs=None):
     """
     colbert = ColBERT.__new__(ColBERT)
     colbert._first_module = lambda: module  # type: ignore[method-assign]
-    ColBERT._configure_chat_template(colbert, user_processor_kwargs=user_processor_kwargs)
+    ColBERT._configure_chat_template(
+        colbert, user_processor_kwargs=user_processor_kwargs
+    )
 
 
 def test_registry_default_installed_for_qwen2_5_vl():
-    module = _make_module(model_type="qwen2_5_vl", existing_chat_template="old qwen tmpl")
+    module = _make_module(
+        model_type="qwen2_5_vl", existing_chat_template="old qwen tmpl"
+    )
     _configure(module)
 
     assert isinstance(module.processor.chat_template, dict)
@@ -139,10 +143,10 @@ def test_persisted_colpali_pin_is_respected():
     # When sentence_bert_config.json round-trips our named pin, the loaded
     # module comes back with processing_kwargs["chat_template"]["chat_template"]
     # == "sentence_transformers". That's our checkpoint signature; leave it.
-    module = _make_module(model_type="qwen2_5_vl", existing_chat_template="orig-not-a-dict")
-    module.processing_kwargs["chat_template"] = {
-        "chat_template": COLPALI_TEMPLATE_NAME
-    }
+    module = _make_module(
+        model_type="qwen2_5_vl", existing_chat_template="orig-not-a-dict"
+    )
+    module.processing_kwargs["chat_template"] = {"chat_template": COLPALI_TEMPLATE_NAME}
 
     _configure(module, user_processor_kwargs=None)
 
@@ -271,7 +275,9 @@ def test_save_load_round_trip_writes_named_jinja_file(tmp_path):
     tokenizer.save_pretrained(tmp_path)
 
     addl = tmp_path / "additional_chat_templates" / f"{COLPALI_TEMPLATE_NAME}.jinja"
-    assert addl.is_file(), "named template was not written to additional_chat_templates/"
+    assert addl.is_file(), (
+        "named template was not written to additional_chat_templates/"
+    )
     assert addl.read_text() == template
     assert (tmp_path / "chat_template.jinja").is_file()  # default template
 

--- a/tests/test_chat_template.py
+++ b/tests/test_chat_template.py
@@ -1,0 +1,325 @@
+"""Smoke tests for :meth:`ColBERT._configure_chat_template`.
+
+These exercise the resolution priority and the save/load round-trip without
+loading a real VLM (which is expensive). We construct a minimal stand-in for the
+loaded ``Transformer`` module and processor and call ``_configure_chat_template``
+directly.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from pylate.models._chat_templates import (
+    COLPALI_CHAT_TEMPLATES,
+    COLPALI_TEMPLATE_NAME,
+)
+from pylate.models.colbert import ColBERT
+
+
+def _make_module(model_type: str | None, existing_chat_template) -> SimpleNamespace:
+    """Build the minimal duck-typed surface ``_configure_chat_template`` reads."""
+    processor = SimpleNamespace(chat_template=existing_chat_template)
+    config = SimpleNamespace(model_type=model_type) if model_type else None
+    model = SimpleNamespace(config=config) if config else None
+    return SimpleNamespace(
+        processor=processor,
+        model=model,
+        processing_kwargs={},
+    )
+
+
+def _configure(module, user_processor_kwargs=None):
+    """Drive ``_configure_chat_template`` with a stand-in ``first_module``.
+
+    We bypass ``ColBERT.__init__`` and just patch ``_first_module`` so the method
+    sees our fake module.
+    """
+    colbert = ColBERT.__new__(ColBERT)
+    colbert._first_module = lambda: module  # type: ignore[method-assign]
+    ColBERT._configure_chat_template(colbert, user_processor_kwargs=user_processor_kwargs)
+
+
+def test_registry_default_installed_for_qwen2_5_vl():
+    module = _make_module(model_type="qwen2_5_vl", existing_chat_template="old qwen tmpl")
+    _configure(module)
+
+    assert isinstance(module.processor.chat_template, dict)
+    assert module.processor.chat_template["default"] == "old qwen tmpl"
+    assert (
+        module.processor.chat_template[COLPALI_TEMPLATE_NAME]
+        == COLPALI_CHAT_TEMPLATES["qwen2_5_vl"]
+    )
+    assert (
+        module.processing_kwargs["chat_template"]["chat_template"]
+        == COLPALI_TEMPLATE_NAME
+    )
+
+
+def test_unknown_model_type_leaves_template_alone():
+    module = _make_module(model_type="bert", existing_chat_template=None)
+    _configure(module)
+
+    assert module.processor.chat_template is None
+    assert "chat_template" not in module.processing_kwargs
+
+
+def test_user_override_is_installed_into_slot_for_persistence():
+    # When the user pins a chat_template at construction, we install their
+    # value under the sentence_transformers slot so save_pretrained writes it
+    # to disk (additional_chat_templates/sentence_transformers.jinja), and we
+    # rewire the ST kwarg to resolve through the slot.
+    module = _make_module(model_type="qwen2_5_vl", existing_chat_template="orig")
+
+    _configure(
+        module,
+        user_processor_kwargs={"chat_template": {"chat_template": "{{ messages[0] }}"}},
+    )
+
+    # The user's template lives in the slot; the model's original is preserved.
+    assert isinstance(module.processor.chat_template, dict)
+    assert module.processor.chat_template[COLPALI_TEMPLATE_NAME] == "{{ messages[0] }}"
+    assert module.processor.chat_template["default"] == "orig"
+    # The kwarg is rewired to the slot name so apply_chat_template resolves to it.
+    assert (
+        module.processing_kwargs["chat_template"]["chat_template"]
+        == COLPALI_TEMPLATE_NAME
+    )
+    # Registry must NOT win over the user's pin even when model_type matches.
+    assert (
+        module.processor.chat_template[COLPALI_TEMPLATE_NAME]
+        != COLPALI_CHAT_TEMPLATES["qwen2_5_vl"]
+    )
+
+
+def test_user_passing_slot_name_falls_through():
+    # If the user passes chat_template="sentence_transformers" they're saying
+    # "use whatever the slot holds" — installing the literal name as content
+    # would be a broken self-referential template. Fall through to cases (2)–
+    # (4) so the registry (or persisted state) fills the slot.
+    module = _make_module(model_type="qwen2_5_vl", existing_chat_template="orig")
+
+    _configure(
+        module,
+        user_processor_kwargs={
+            "chat_template": {"chat_template": COLPALI_TEMPLATE_NAME}
+        },
+    )
+
+    # Registry fired because case (1) deferred.
+    assert isinstance(module.processor.chat_template, dict)
+    assert (
+        module.processor.chat_template[COLPALI_TEMPLATE_NAME]
+        == COLPALI_CHAT_TEMPLATES["qwen2_5_vl"]
+    )
+    assert (
+        module.processing_kwargs["chat_template"]["chat_template"]
+        == COLPALI_TEMPLATE_NAME
+    )
+
+
+def test_user_override_does_not_mutate_caller_dict():
+    # _set_chat_template_name must NOT mutate the inner dict the user passed —
+    # ST stores processing_kwargs by reference, so an in-place mutation would
+    # surprise callers holding a reference to their original dict.
+    user_inner = {"chat_template": "user-jinja", "add_generation_prompt": False}
+    user_outer = {"chat_template": user_inner}
+    module = _make_module(model_type="qwen2_5_vl", existing_chat_template="orig")
+
+    _configure(module, user_processor_kwargs=user_outer)
+
+    # The user's outer dict and inner dict are unchanged.
+    assert user_outer == {"chat_template": user_inner}
+    assert user_inner == {"chat_template": "user-jinja", "add_generation_prompt": False}
+
+
+def test_persisted_colpali_pin_is_respected():
+    # When sentence_bert_config.json round-trips our named pin, the loaded
+    # module comes back with processing_kwargs["chat_template"]["chat_template"]
+    # == "sentence_transformers". That's our checkpoint signature; leave it.
+    module = _make_module(model_type="qwen2_5_vl", existing_chat_template="orig-not-a-dict")
+    module.processing_kwargs["chat_template"] = {
+        "chat_template": COLPALI_TEMPLATE_NAME
+    }
+
+    _configure(module, user_processor_kwargs=None)
+
+    # Registry must NOT touch the processor; persisted wiring stays as-is.
+    assert module.processor.chat_template == "orig-not-a-dict"
+    assert (
+        module.processing_kwargs["chat_template"]["chat_template"]
+        == COLPALI_TEMPLATE_NAME
+    )
+
+
+def test_persisted_non_colpali_pin_falls_through_to_registry():
+    # If the persisted kwarg is anything *other* than our named pin (e.g. a raw
+    # Jinja string the user previously set, or a different named template), we
+    # treat it as "not a ColPali pin" and the registry default wins. This lets
+    # users load a generic VLM checkpoint and still get ColPali preprocessing
+    # without manual intervention.
+    module = _make_module(model_type="qwen2_5_vl", existing_chat_template="orig")
+    module.processing_kwargs["chat_template"] = {"chat_template": "some-other-tmpl"}
+
+    _configure(module, user_processor_kwargs=None)
+
+    # Registry installed.
+    assert isinstance(module.processor.chat_template, dict)
+    assert (
+        module.processor.chat_template[COLPALI_TEMPLATE_NAME]
+        == COLPALI_CHAT_TEMPLATES["qwen2_5_vl"]
+    )
+    # And the named pin is overwritten with ours.
+    assert (
+        module.processing_kwargs["chat_template"]["chat_template"]
+        == COLPALI_TEMPLATE_NAME
+    )
+
+
+def test_unrelated_chat_template_kwargs_dont_block_registry():
+    # processing_kwargs["chat_template"] might carry other apply_chat_template
+    # kwargs (e.g. add_generation_prompt=False) without a "chat_template" key.
+    # That's not a pin — registry must still install.
+    module = _make_module(model_type="qwen2_5_vl", existing_chat_template="orig")
+    module.processing_kwargs["chat_template"] = {"add_generation_prompt": False}
+
+    _configure(module, user_processor_kwargs=None)
+
+    assert isinstance(module.processor.chat_template, dict)
+    assert COLPALI_TEMPLATE_NAME in module.processor.chat_template
+    # The unrelated kwarg survives.
+    assert module.processing_kwargs["chat_template"]["add_generation_prompt"] is False
+    # And our named pin is added alongside it.
+    assert (
+        module.processing_kwargs["chat_template"]["chat_template"]
+        == COLPALI_TEMPLATE_NAME
+    )
+
+
+def test_persisted_hf_template_is_respected():
+    # If the checkpoint shipped `additional_chat_templates/sentence_transformers.jinja`
+    # (HF processor mechanism) but the ST-side wiring wasn't persisted, we still
+    # honor the HF half — and re-wire the kwarg so apply_chat_template uses it.
+    saved = "{# previously-saved colpali template via HF processor #}"
+    existing = {"default": "model default", COLPALI_TEMPLATE_NAME: saved}
+    module = _make_module(model_type="qwen2_5_vl", existing_chat_template=existing)
+
+    _configure(module, user_processor_kwargs=None)
+
+    assert module.processor.chat_template is existing
+    assert (
+        module.processing_kwargs["chat_template"]["chat_template"]
+        == COLPALI_TEMPLATE_NAME
+    )
+
+
+def test_saved_sentence_transformers_template_is_reused():
+    # Simulate a checkpoint that already shipped additional_chat_templates/sentence_transformers.jinja:
+    # HF's `from_pretrained` would have populated `processor.chat_template` as a
+    # dict containing our key.
+    saved = "{# pretend this is a previously-saved colpali template #}"
+    existing = {"default": "model default", COLPALI_TEMPLATE_NAME: saved}
+    module = _make_module(model_type="qwen2_5_vl", existing_chat_template=existing)
+
+    _configure(module)
+
+    # The saved template wins over the registry default — checkpoint is source of truth.
+    assert module.processor.chat_template is existing
+    assert module.processor.chat_template[COLPALI_TEMPLATE_NAME] == saved
+    assert (
+        module.processing_kwargs["chat_template"]["chat_template"]
+        == COLPALI_TEMPLATE_NAME
+    )
+
+
+def test_no_processor_is_noop():
+    module = SimpleNamespace(processor=None)
+
+    colbert = ColBERT.__new__(ColBERT)
+    colbert._first_module = lambda: module  # type: ignore[method-assign]
+    # Should not raise.
+    ColBERT._configure_chat_template(colbert, user_processor_kwargs=None)
+
+
+def test_save_load_round_trip_writes_named_jinja_file(tmp_path):
+    """Verify the dict shape we install actually persists as
+    ``additional_chat_templates/sentence_transformers.jinja`` and reloads.
+
+    Uses a tokenizer (not a full multimodal processor) because tokenizers
+    share the same save/load contract for ``chat_template`` dicts and the tiny
+    Qwen2 test fixture is cheap to load offline. ``ProcessorMixin.save_pretrained``
+    runs the same code path on the same ``chat_template`` attribute.
+
+    Skipped when the fixture isn't in the local HF cache (e.g. CI without it).
+    """
+    from transformers import AutoTokenizer
+
+    try:
+        tokenizer = AutoTokenizer.from_pretrained(
+            "hf-internal-testing/tiny-random-Qwen2VLForConditionalGeneration"
+        )
+    except Exception as exc:
+        pytest.skip(f"tiny qwen2 fixture unavailable: {exc}")
+
+    template = COLPALI_CHAT_TEMPLATES["qwen2_5_vl"]
+    tokenizer.chat_template = {
+        "default": tokenizer.chat_template,
+        COLPALI_TEMPLATE_NAME: template,
+    }
+    tokenizer.save_pretrained(tmp_path)
+
+    addl = tmp_path / "additional_chat_templates" / f"{COLPALI_TEMPLATE_NAME}.jinja"
+    assert addl.is_file(), "named template was not written to additional_chat_templates/"
+    assert addl.read_text() == template
+    assert (tmp_path / "chat_template.jinja").is_file()  # default template
+
+    # Reload via HF and confirm the dict round-trips.
+    reloaded = AutoTokenizer.from_pretrained(tmp_path)
+    assert isinstance(reloaded.chat_template, dict)
+    assert reloaded.chat_template[COLPALI_TEMPLATE_NAME] == template
+    assert "default" in reloaded.chat_template
+
+
+@pytest.mark.parametrize("model_type", sorted(COLPALI_CHAT_TEMPLATES))
+def test_every_registered_template_renders_without_error(model_type):
+    """Every registered Jinja template must compile and render both modalities."""
+    import jinja2
+
+    template_src = COLPALI_CHAT_TEMPLATES[model_type]
+    template = jinja2.Environment().from_string(template_src)
+
+    image_msg = [{"role": "user", "content": [{"type": "image", "image": object()}]}]
+    text_msg = [{"role": "user", "content": [{"type": "text", "text": "hello"}]}]
+    image_text_msg = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image", "image": object()},
+                {"type": "text", "text": "custom doc prompt"},
+            ],
+        }
+    ]
+
+    image_render = template.render(messages=image_msg)
+    text_render = template.render(messages=text_msg)
+    both_render = template.render(messages=image_text_msg)
+
+    # Image branch must include the model's image placeholder token.
+    image_tokens = {
+        "paligemma": "<image>",
+        "qwen2_vl": "<|image_pad|>",
+        "qwen2_5_vl": "<|image_pad|>",
+        "qwen3_vl": "<|image_pad|>",
+        "qwen3_vl_moe": "<|image_pad|>",
+        "idefics3": "<image>",
+    }
+    assert image_tokens[model_type] in image_render
+    # Default caption appears when no text item is provided.
+    assert "Describe the image." in image_render
+    # Provided text overrides the default caption.
+    assert "custom doc prompt" in both_render
+    assert "Describe the image." not in both_render
+    # Text-only renders the raw query (PaliGemma prepends <bos>, others emit raw).
+    assert "hello" in text_render

--- a/tests/test_collator_multimodal.py
+++ b/tests/test_collator_multimodal.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pylate.utils.collator import ColBERTCollator
+
+
+class TestIsTextColumn:
+    """Test ColBERTCollator._is_text_column detection."""
+
+    def test_empty_list(self):
+        assert ColBERTCollator._is_text_column([]) is True
+
+    def test_strings(self):
+        assert ColBERTCollator._is_text_column(["hello", "world"]) is True
+
+    def test_dicts(self):
+        assert ColBERTCollator._is_text_column([{"image": "x"}]) is False
+
+    def test_integers(self):
+        assert ColBERTCollator._is_text_column([42, 43]) is False
+
+    def test_none_values(self):
+        assert ColBERTCollator._is_text_column([None]) is False
+
+
+class TestCollatorMultimodalSkipsPrompt:
+    """Test that the collator skips prompt prepending for multimodal columns."""
+
+    def test_prompt_not_prepended_to_multimodal(self):
+        """Multimodal inputs should not have prompts prepended."""
+        calls = []
+
+        def fake_preprocess(texts, is_query=True, pad=False, task=None):
+            calls.append({"texts": texts, "is_query": is_query})
+            import torch
+
+            n = len(texts)
+            return {
+                "input_ids": torch.zeros(n, 5, dtype=torch.long),
+                "attention_mask": torch.ones(n, 5, dtype=torch.long),
+            }
+
+        collator = ColBERTCollator(preprocess_fn=fake_preprocess)
+        collator.prompts = {"query": "search: "}
+
+        features = [
+            {"query": {"image": "img1.jpg"}, "document": {"image": "img2.jpg"}},
+            {"query": {"image": "img3.jpg"}, "document": {"image": "img4.jpg"}},
+        ]
+
+        collator(features)
+
+        # The collator should have called preprocess with the raw dicts,
+        # NOT with "search: " prepended (which would fail for dicts)
+        for call in calls:
+            for text in call["texts"]:
+                if isinstance(text, str):
+                    assert not text.startswith("search: ")
+
+    def test_prompt_prepended_to_text(self):
+        """Text inputs should have prompts prepended."""
+        calls = []
+
+        def fake_preprocess(texts, is_query=True, pad=False, task=None):
+            calls.append({"texts": texts, "is_query": is_query})
+            import torch
+
+            n = len(texts)
+            return {
+                "input_ids": torch.zeros(n, 5, dtype=torch.long),
+                "attention_mask": torch.ones(n, 5, dtype=torch.long),
+            }
+
+        collator = ColBERTCollator(preprocess_fn=fake_preprocess)
+        collator.prompts = {"query": "search: "}
+
+        features = [
+            {"query": "what is AI", "document": "AI is cool"},
+            {"query": "hello world", "document": "hello back"},
+        ]
+
+        collator(features)
+
+        query_call = [c for c in calls if c["is_query"]][0]
+        for text in query_call["texts"]:
+            assert text.startswith("search: ")

--- a/tests/test_colpali.py
+++ b/tests/test_colpali.py
@@ -14,9 +14,7 @@ COLPALI_ADAPTER = "vidore/colqwen2.5-v0.2"
 class TestDetectColpaliArchitecture:
     def test_detects_colpali_base_model(self):
         """Base ColPali repo has config.json with ColQwen2_5 architecture."""
-        arch, config = models.ColBERT._detect_colpali_architecture(
-            COLPALI_BASE, {}
-        )
+        arch, config = models.ColBERT._detect_colpali_architecture(COLPALI_BASE, {})
         assert arch is not None
         assert arch in _COLPALI_TO_BASE_ARCHITECTURE
         assert config is not None
@@ -24,9 +22,7 @@ class TestDetectColpaliArchitecture:
 
     def test_adapter_repo_detected(self):
         """LoRA adapter repos resolve via adapter_config.json -> base model config."""
-        arch, config = models.ColBERT._detect_colpali_architecture(
-            COLPALI_ADAPTER, {}
-        )
+        arch, config = models.ColBERT._detect_colpali_architecture(COLPALI_ADAPTER, {})
         assert arch is not None
         assert arch in _COLPALI_TO_BASE_ARCHITECTURE
         assert config is not None
@@ -70,9 +66,7 @@ class TestColpaliBaseModelLoading:
         assert dense.out_features == 128
 
     def test_encode_text_query(self, colpali_model):
-        embeddings = colpali_model.encode(
-            ["what is machine learning?"], is_query=True
-        )
+        embeddings = colpali_model.encode(["what is machine learning?"], is_query=True)
         assert len(embeddings) == 1
         assert embeddings[0].ndim == 2
         assert embeddings[0].shape[-1] == 128

--- a/tests/test_colpali.py
+++ b/tests/test_colpali.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import pytest
+
+from pylate import models
+from pylate.models.colbert import (
+    _COLPALI_TO_BASE_ARCHITECTURE,
+)
+
+COLPALI_BASE = "vidore/colqwen2.5-base"
+COLPALI_ADAPTER = "vidore/colqwen2.5-v0.2"
+
+
+class TestDetectColpaliArchitecture:
+    def test_detects_colpali_base_model(self):
+        """Base ColPali repo has config.json with ColQwen2_5 architecture."""
+        arch, config = models.ColBERT._detect_colpali_architecture(
+            COLPALI_BASE, {}
+        )
+        assert arch is not None
+        assert arch in _COLPALI_TO_BASE_ARCHITECTURE
+        assert config is not None
+        assert config.model_type == "qwen2_5_vl"
+
+    def test_adapter_repo_detected(self):
+        """LoRA adapter repos resolve via adapter_config.json -> base model config."""
+        arch, config = models.ColBERT._detect_colpali_architecture(
+            COLPALI_ADAPTER, {}
+        )
+        assert arch is not None
+        assert arch in _COLPALI_TO_BASE_ARCHITECTURE
+        assert config is not None
+
+    def test_non_colpali_model(self):
+        arch, config = models.ColBERT._detect_colpali_architecture(
+            "bert-base-uncased", {}
+        )
+        assert arch is None
+        assert config is not None
+
+    def test_invalid_model_path(self):
+        arch, config = models.ColBERT._detect_colpali_architecture(
+            "this-model-does-not-exist-12345", {}
+        )
+        assert arch is None
+        assert config is None
+
+
+class TestColpaliBaseModelLoading:
+    """Test loading a non-adapter ColPali checkpoint (has config.json)."""
+
+    @pytest.fixture(scope="class")
+    def colpali_model(self):
+        return models.ColBERT(
+            model_name_or_path=COLPALI_BASE,
+            device="cpu",
+        )
+
+    def test_is_colpali_flag(self, colpali_model):
+        assert colpali_model._is_colpali_model is True
+
+    def test_has_two_modules(self, colpali_model):
+        module_list = list(colpali_model)
+        assert len(module_list) == 2
+
+    def test_dense_projection_dimensions(self, colpali_model):
+        module_list = list(colpali_model)
+        dense = module_list[1]
+        assert dense.in_features > 0
+        assert dense.out_features == 128
+
+    def test_encode_text_query(self, colpali_model):
+        embeddings = colpali_model.encode(
+            ["what is machine learning?"], is_query=True
+        )
+        assert len(embeddings) == 1
+        assert embeddings[0].ndim == 2
+        assert embeddings[0].shape[-1] == 128
+
+    def test_processor_is_base_vlm(self, colpali_model):
+        """The processor should be the base VLM processor, not a ColPali one."""
+        proc_name = type(colpali_model._first_module().processor).__name__
+        assert "Col" not in proc_name

--- a/tests/test_colpali.py
+++ b/tests/test_colpali.py
@@ -75,3 +75,26 @@ class TestColpaliBaseModelLoading:
         """The processor should be the base VLM processor, not a ColPali one."""
         proc_name = type(colpali_model._first_module().processor).__name__
         assert "Col" not in proc_name
+
+    def test_batched_queries_exclude_padding_tokens(self, colpali_model):
+        """Batch-alignment padding must not leak into query embeddings.
+
+        With suffix expansion, only text + expansion tokens are attended; the
+        trailing batch padding produces garbage embeddings that would inflate
+        MaxSim scores depending on the batch composition.
+        """
+        queries = [
+            "what is machine learning and how is it used in modern applications?",
+            "chemistry",
+        ]
+        features = colpali_model.preprocess(queries, is_query=True)
+        attended_lengths = features["attention_mask"].sum(dim=1).tolist()
+
+        embeddings = colpali_model.encode(queries, is_query=True)
+        for embedding, attended in zip(embeddings, attended_lengths):
+            assert embedding.shape[0] == attended
+
+        # Same queries encoded alone (no batch padding) yield the same counts
+        for query, attended in zip(queries, attended_lengths):
+            single = colpali_model.encode([query], is_query=True)[0]
+            assert single.shape[0] == attended

--- a/tests/test_contrastive.py
+++ b/tests/test_contrastive.py
@@ -13,7 +13,7 @@ from sentence_transformers import (
     SentenceTransformerTrainer,
     SentenceTransformerTrainingArguments,
 )
-from sentence_transformers.training_args import BatchSamplers
+from sentence_transformers.sentence_transformer.training_args import BatchSamplers
 
 from pylate import evaluation, losses, models, utils
 

--- a/tests/test_contrastive.py
+++ b/tests/test_contrastive.py
@@ -64,7 +64,7 @@ def test_contrastive_training() -> None:
         eval_dataset=eval_dataset,
         loss=train_loss,
         evaluator=dev_evaluation,
-        data_collator=utils.ColBERTCollator(tokenize_fn=model.tokenize),
+        data_collator=utils.ColBERTCollator(preprocess_fn=model.preprocess),
     )
 
     trainer.train()

--- a/tests/test_dense_conversion.py
+++ b/tests/test_dense_conversion.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+from sentence_transformers import SentenceTransformer
+from sentence_transformers.models import Dense as STDense
+from sentence_transformers.models import Pooling
+
+from pylate import models
+from pylate.models.Dense import Dense
+
+
+def test_st_checkpoint_with_sentence_level_dense_converts(tmp_path):
+    """ST checkpoints with a Dense after Pooling (e.g. sentence-t5, LaBSE)
+    must convert to a token-level projection instead of crashing with
+    KeyError('sentence_embedding') once Pooling is filtered out."""
+    base = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2", device="cpu")
+    transformer = base[0]
+    hidden = transformer.get_embedding_dimension()
+    st_dense = STDense(
+        in_features=hidden,
+        out_features=64,
+        bias=False,
+        activation_function=nn.Identity(),
+    )
+    st_model = SentenceTransformer(
+        modules=[transformer, Pooling(hidden), st_dense], device="cpu"
+    )
+    path = str(tmp_path / "st_dense_model")
+    st_model.save(path)
+
+    colbert = models.ColBERT(path, device="cpu")
+
+    assert [type(m).__name__ for m in colbert] == ["Transformer", "Dense"]
+    assert colbert[1].module_input_name == "token_embeddings"
+    assert colbert[1].module_output_name == "token_embeddings"
+    assert torch.equal(colbert[1].linear.weight, st_dense.linear.weight)
+
+    embeddings = colbert.encode(["hello world"], is_query=True)
+    assert embeddings[0].ndim == 2
+    assert embeddings[0].shape[-1] == 64
+
+
+def test_from_sentence_transformers_preserves_token_level_dense():
+    """A Dense already operating on token embeddings converts unchanged."""
+    st_dense = STDense(
+        in_features=32,
+        out_features=16,
+        bias=False,
+        activation_function=nn.Identity(),
+        module_input_name="token_embeddings",
+        module_output_name="token_embeddings",
+    )
+    converted = Dense.from_sentence_transformers(st_dense)
+    assert converted.module_input_name == "token_embeddings"
+    assert torch.equal(converted.linear.weight, st_dense.linear.weight)
+
+    features = {"token_embeddings": torch.randn(2, 5, 32)}
+    out = converted(features)
+    assert out["token_embeddings"].shape == (2, 5, 16)

--- a/tests/test_expansion.py
+++ b/tests/test_expansion.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from pylate import models
+
+
+@pytest.fixture
+def model():
+    return models.ColBERT(
+        model_name_or_path="bert-base-uncased",
+        device="cpu",
+    )
+
+
+class TestAppendExpansionTokens:
+    def test_appends_correct_number_of_tokens(self, model):
+        features = model._first_module().preprocess(["hello world"])
+        original_len = features["input_ids"].shape[1]
+        result = model._append_expansion_tokens(features, n_tokens=10)
+        assert result["input_ids"].shape[1] == original_len + 10
+
+    def test_appended_tokens_are_pad_id(self, model):
+        features = model._first_module().preprocess(["hello world"])
+        original_len = features["input_ids"].shape[1]
+        result = model._append_expansion_tokens(features, n_tokens=5)
+        pad_id = model.tokenizer.pad_token_id
+        appended = result["input_ids"][0, original_len:]
+        assert (appended == pad_id).all()
+
+    def test_attention_mask_extended(self, model):
+        features = model._first_module().preprocess(["hello world"])
+        original_len = features["attention_mask"].shape[1]
+        result = model._append_expansion_tokens(features, n_tokens=7)
+        assert result["attention_mask"].shape[1] == original_len + 7
+        # Appended attention mask entries should be 1
+        assert (result["attention_mask"][0, original_len:] == 1).all()
+
+    def test_token_type_ids_extended_with_zeros(self, model):
+        features = model._first_module().preprocess(["hello world"])
+        assert "token_type_ids" in features
+        original_len = features["token_type_ids"].shape[1]
+        result = model._append_expansion_tokens(features, n_tokens=4)
+        assert result["token_type_ids"].shape[1] == original_len + 4
+        assert (result["token_type_ids"][0, original_len:] == 0).all()
+
+    def test_n_tokens_zero(self, model):
+        features = model._first_module().preprocess(["hello world"])
+        original_len = features["input_ids"].shape[1]
+        result = model._append_expansion_tokens(features, n_tokens=0)
+        assert result["input_ids"].shape[1] == original_len
+
+    def test_batch_of_multiple_inputs(self, model):
+        features = model._first_module().preprocess(["hello", "world foo bar"])
+        batch_size = features["input_ids"].shape[0]
+        original_len = features["input_ids"].shape[1]
+        result = model._append_expansion_tokens(features, n_tokens=3)
+        assert result["input_ids"].shape == (batch_size, original_len + 3)
+
+    def test_suffix_expansion_via_preprocess(self, model):
+        """When _is_colpali_model is True and do_query_expansion is True,
+        preprocess should use suffix expansion (append tokens) instead of
+        pad-to-fixed-length expansion."""
+        model._is_colpali_model = True
+        model.do_query_expansion = True
+        tokens_a = model.preprocess(["short"], is_query=True)
+        tokens_b = model.preprocess(["a much longer query text here"], is_query=True)
+        len_a = tokens_a["input_ids"].shape[1]
+        len_b = tokens_b["input_ids"].shape[1]
+        # Suffix expansion: different query lengths should produce different output lengths
+        # (unlike pad-to-fixed-length which would make them equal)
+        assert len_a != len_b

--- a/tests/test_expansion.py
+++ b/tests/test_expansion.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-import torch
 
 from pylate import models
 

--- a/tests/test_is_text_input.py
+++ b/tests/test_is_text_input.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pylate.models import ColBERT
+
+
+class TestIsTextInput:
+    """Test ColBERT._is_text_input heuristic for text vs multimodal detection."""
+
+    def test_plain_string(self):
+        assert ColBERT._is_text_input("hello") is True
+
+    def test_list_of_strings(self):
+        assert ColBERT._is_text_input(["hello", "world"]) is True
+
+    def test_empty_list(self):
+        assert ColBERT._is_text_input([]) is False
+
+    def test_list_of_string_tuples(self):
+        assert ColBERT._is_text_input([("hello", "world")]) is True
+
+    def test_list_of_mixed_tuples(self):
+        """Tuple with a non-string element should return False."""
+        assert ColBERT._is_text_input([(42, "world")]) is False
+
+    def test_dict_text_only(self):
+        assert ColBERT._is_text_input([{"text": "hello"}]) is True
+
+    def test_dict_with_image_key(self):
+        assert ColBERT._is_text_input([{"image": "some_path"}]) is False
+
+    def test_dict_with_images_key(self):
+        assert ColBERT._is_text_input([{"images": "some_path"}]) is False
+
+    def test_dict_with_audio_key(self):
+        assert ColBERT._is_text_input([{"audio": "data"}]) is False
+
+    def test_dict_with_video_key(self):
+        assert ColBERT._is_text_input([{"video": "data"}]) is False
+
+    def test_dict_with_pixel_values_key(self):
+        assert ColBERT._is_text_input([{"pixel_values": "data"}]) is False
+
+    def test_dict_with_non_string_values(self):
+        """Dict with no multimodal keys but non-string values."""
+        assert ColBERT._is_text_input([{"key": 42}]) is False
+
+    def test_dict_mixed_text_and_image(self):
+        """Dict with both text and image keys."""
+        assert ColBERT._is_text_input([{"text": "hello", "image": "img"}]) is False
+
+    def test_non_iterable(self):
+        assert ColBERT._is_text_input(42) is False
+
+    def test_none(self):
+        assert ColBERT._is_text_input(None) is False

--- a/tests/test_kd.py
+++ b/tests/test_kd.py
@@ -59,7 +59,7 @@ def test_kd_training() -> None:
         args=args,
         train_dataset=train,
         loss=train_loss,
-        data_collator=utils.ColBERTCollator(tokenize_fn=model.tokenize),
+        data_collator=utils.ColBERTCollator(preprocess_fn=model.preprocess),
     )
 
     trainer.train()

--- a/tests/test_padding.py
+++ b/tests/test_padding.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import torch
+
+from pylate.losses.padding import pad_embeddings_and_masks
+
+
+class TestPadEmbeddingsAndMasks:
+    def test_no_padding_needed(self):
+        """All tensors same length — should be returned unchanged."""
+        e1 = torch.randn(2, 5, 8)
+        e2 = torch.randn(2, 5, 8)
+        m1 = torch.ones(2, 5, dtype=torch.bool)
+        m2 = torch.ones(2, 5, dtype=torch.bool)
+        out_e, out_m = pad_embeddings_and_masks([e1, e2], [m1, m2])
+        assert out_e[0].shape == (2, 5, 8)
+        assert out_e[1].shape == (2, 5, 8)
+        assert torch.equal(out_e[0], e1)
+        assert torch.equal(out_m[0], m1)
+
+    def test_pads_to_max(self):
+        """Shorter tensors are zero-padded to the longest."""
+        e_short = torch.ones(1, 3, 4)
+        e_long = torch.ones(1, 7, 4)
+        m_short = torch.ones(1, 3, dtype=torch.bool)
+        m_long = torch.ones(1, 7, dtype=torch.bool)
+        out_e, out_m = pad_embeddings_and_masks(
+            [e_short, e_long], [m_short, m_long]
+        )
+        assert out_e[0].shape == (1, 7, 4)
+        assert out_e[1].shape == (1, 7, 4)
+        # Padded region of embedding should be zeros
+        assert (out_e[0][:, 3:, :] == 0).all()
+        # Original region should be ones
+        assert (out_e[0][:, :3, :] == 1).all()
+        # Padded region of mask should be False
+        assert (out_m[0][:, 3:] == False).all()
+        assert (out_m[0][:, :3] == True).all()
+
+    def test_explicit_target_len(self):
+        """Pad to an explicit target_len larger than any input."""
+        e = torch.randn(2, 4, 6)
+        m = torch.ones(2, 4, dtype=torch.bool)
+        out_e, out_m = pad_embeddings_and_masks([e], [m], target_len=10)
+        assert out_e[0].shape == (2, 10, 6)
+        assert out_m[0].shape == (2, 10)
+        assert (out_e[0][:, 4:, :] == 0).all()
+        assert (out_m[0][:, 4:] == False).all()
+
+    def test_target_len_equal_to_input(self):
+        """target_len == input length — no padding."""
+        e = torch.randn(1, 5, 3)
+        m = torch.ones(1, 5, dtype=torch.bool)
+        out_e, out_m = pad_embeddings_and_masks([e], [m], target_len=5)
+        assert torch.equal(out_e[0], e)
+        assert torch.equal(out_m[0], m)
+
+    def test_multiple_varying_lengths(self):
+        """Three tensors with different lengths all padded to max."""
+        e1 = torch.randn(1, 2, 4)
+        e2 = torch.randn(1, 5, 4)
+        e3 = torch.randn(1, 3, 4)
+        m1 = torch.ones(1, 2, dtype=torch.bool)
+        m2 = torch.ones(1, 5, dtype=torch.bool)
+        m3 = torch.ones(1, 3, dtype=torch.bool)
+        out_e, out_m = pad_embeddings_and_masks(
+            [e1, e2, e3], [m1, m2, m3]
+        )
+        for e in out_e:
+            assert e.shape == (1, 5, 4)
+        for m in out_m:
+            assert m.shape == (1, 5)

--- a/tests/test_padding.py
+++ b/tests/test_padding.py
@@ -24,9 +24,7 @@ class TestPadEmbeddingsAndMasks:
         e_long = torch.ones(1, 7, 4)
         m_short = torch.ones(1, 3, dtype=torch.bool)
         m_long = torch.ones(1, 7, dtype=torch.bool)
-        out_e, out_m = pad_embeddings_and_masks(
-            [e_short, e_long], [m_short, m_long]
-        )
+        out_e, out_m = pad_embeddings_and_masks([e_short, e_long], [m_short, m_long])
         assert out_e[0].shape == (1, 7, 4)
         assert out_e[1].shape == (1, 7, 4)
         # Padded region of embedding should be zeros
@@ -34,8 +32,8 @@ class TestPadEmbeddingsAndMasks:
         # Original region should be ones
         assert (out_e[0][:, :3, :] == 1).all()
         # Padded region of mask should be False
-        assert (out_m[0][:, 3:] == False).all()
-        assert (out_m[0][:, :3] == True).all()
+        assert (~out_m[0][:, 3:]).all()
+        assert out_m[0][:, :3].all()
 
     def test_explicit_target_len(self):
         """Pad to an explicit target_len larger than any input."""
@@ -45,7 +43,7 @@ class TestPadEmbeddingsAndMasks:
         assert out_e[0].shape == (2, 10, 6)
         assert out_m[0].shape == (2, 10)
         assert (out_e[0][:, 4:, :] == 0).all()
-        assert (out_m[0][:, 4:] == False).all()
+        assert (~out_m[0][:, 4:]).all()
 
     def test_target_len_equal_to_input(self):
         """target_len == input length — no padding."""
@@ -63,9 +61,7 @@ class TestPadEmbeddingsAndMasks:
         m1 = torch.ones(1, 2, dtype=torch.bool)
         m2 = torch.ones(1, 5, dtype=torch.bool)
         m3 = torch.ones(1, 3, dtype=torch.bool)
-        out_e, out_m = pad_embeddings_and_masks(
-            [e1, e2, e3], [m1, m2, m3]
-        )
+        out_e, out_m = pad_embeddings_and_masks([e1, e2, e3], [m1, m2, m3])
         for e in out_e:
             assert e.shape == (1, 5, 4)
         for m in out_m:

--- a/tests/test_prefixes.py
+++ b/tests/test_prefixes.py
@@ -98,28 +98,19 @@ class TestTokenizePrefixInsertion:
         assert input_ids[0, 1].item() == model_custom_prefix.document_prefix_id
 
     def test_seq_length_with_custom_prefix(self, model_custom_prefix):
-        """Custom prefix should also reduce max_seq_length by 1."""
-        model_custom_prefix.tokenize(["hello world"], is_query=True)
-        assert (
-            model_custom_prefix._first_module().max_seq_length
-            == model_custom_prefix.query_length - 1
-        )
+        """With custom prefix, output length should not exceed query_length."""
+        tokens = model_custom_prefix.tokenize(["hello world"], is_query=True)
+        assert tokens["input_ids"].shape[1] <= model_custom_prefix.query_length
 
     def test_seq_length_with_prefix(self, model_with_prefix):
-        """With prefix, max_seq_length should be max_length - 1."""
-        model_with_prefix.tokenize(["hello world"], is_query=True)
-        assert (
-            model_with_prefix._first_module().max_seq_length
-            == model_with_prefix.query_length - 1
-        )
+        """With prefix, output length should not exceed query_length."""
+        tokens = model_with_prefix.tokenize(["hello world"], is_query=True)
+        assert tokens["input_ids"].shape[1] <= model_with_prefix.query_length
 
     def test_seq_length_without_prefix(self, model_without_prefix):
-        """Without prefix, max_seq_length should be max_length (no -1)."""
-        model_without_prefix.tokenize(["hello world"], is_query=True)
-        assert (
-            model_without_prefix._first_module().max_seq_length
-            == model_without_prefix.query_length
-        )
+        """Without prefix, output length should not exceed query_length."""
+        tokens = model_without_prefix.tokenize(["hello world"], is_query=True)
+        assert tokens["input_ids"].shape[1] <= model_without_prefix.query_length
 
     def test_output_length_difference(self, model_with_prefix, model_without_prefix):
         """With prefix, document tokenization has one extra token (the prefix)."""

--- a/tests/test_prefixes.py
+++ b/tests/test_prefixes.py
@@ -59,63 +59,65 @@ class TestPrefixInit:
         assert model_custom_prefix.document_prefix == "[DOC] "
 
 
-class TestTokenizePrefixInsertion:
-    """Test that tokenize() inserts/skips prefix tokens based on prefix strings."""
+class TestPreprocessPrefixInsertion:
+    """Test that preprocess() inserts/skips prefix tokens based on prefix strings."""
 
     def test_prefix_inserted_when_set(self, model_with_prefix):
-        tokens = model_with_prefix.tokenize(["hello world"], is_query=True)
+        tokens = model_with_prefix.preprocess(["hello world"], is_query=True)
         input_ids = tokens["input_ids"]
         # Second token (after [CLS]) should be the query prefix
         assert input_ids[0, 1].item() == model_with_prefix.query_prefix_id
 
     def test_prefix_not_inserted_when_empty(self, model_without_prefix):
-        tokens = model_without_prefix.tokenize(["hello world"], is_query=True)
-        ref = model_without_prefix._first_module().tokenize(["hello world"])
+        tokens = model_without_prefix.preprocess(["hello world"], is_query=True)
+        ref = model_without_prefix._first_module().preprocess(["hello world"])
         # Token at index 1 should be the first content token, not a prefix
         assert tokens["input_ids"][0, 1].item() == ref["input_ids"][0, 1].item()
         assert model_without_prefix.query_prefix_id is None
 
     def test_document_prefix_inserted_when_set(self, model_with_prefix):
-        tokens = model_with_prefix.tokenize(["hello world"], is_query=False)
+        tokens = model_with_prefix.preprocess(["hello world"], is_query=False)
         input_ids = tokens["input_ids"]
         assert input_ids[0, 1].item() == model_with_prefix.document_prefix_id
 
     def test_document_prefix_not_inserted_when_empty(self, model_without_prefix):
-        tokens = model_without_prefix.tokenize(["hello world"], is_query=False)
-        ref = model_without_prefix._first_module().tokenize(["hello world"])
+        tokens = model_without_prefix.preprocess(["hello world"], is_query=False)
+        ref = model_without_prefix._first_module().preprocess(["hello world"])
         # Token at index 1 should be the first content token, not a prefix
         assert tokens["input_ids"][0, 1].item() == ref["input_ids"][0, 1].item()
         assert model_without_prefix.document_prefix_id is None
 
     def test_custom_query_prefix_inserted(self, model_custom_prefix):
-        tokens = model_custom_prefix.tokenize(["hello world"], is_query=True)
+        tokens = model_custom_prefix.preprocess(["hello world"], is_query=True)
         input_ids = tokens["input_ids"]
         assert input_ids[0, 1].item() == model_custom_prefix.query_prefix_id
 
     def test_custom_document_prefix_inserted(self, model_custom_prefix):
-        tokens = model_custom_prefix.tokenize(["hello world"], is_query=False)
+        tokens = model_custom_prefix.preprocess(["hello world"], is_query=False)
         input_ids = tokens["input_ids"]
         assert input_ids[0, 1].item() == model_custom_prefix.document_prefix_id
 
     def test_seq_length_with_custom_prefix(self, model_custom_prefix):
         """With query expansion, output length should be exactly query_length."""
-        tokens = model_custom_prefix.tokenize(["hello world"], is_query=True)
+        tokens = model_custom_prefix.preprocess(["hello world"], is_query=True)
         assert tokens["input_ids"].shape[1] == model_custom_prefix.query_length
 
     def test_seq_length_with_prefix(self, model_with_prefix):
         """With query expansion, output length should be exactly query_length."""
-        tokens = model_with_prefix.tokenize(["hello world"], is_query=True)
+        tokens = model_with_prefix.preprocess(["hello world"], is_query=True)
         assert tokens["input_ids"].shape[1] == model_with_prefix.query_length
 
     def test_seq_length_without_prefix(self, model_without_prefix):
         """With query expansion, output length should be exactly query_length."""
-        tokens = model_without_prefix.tokenize(["hello world"], is_query=True)
+        tokens = model_without_prefix.preprocess(["hello world"], is_query=True)
         assert tokens["input_ids"].shape[1] == model_without_prefix.query_length
 
     def test_output_length_difference(self, model_with_prefix, model_without_prefix):
         """With prefix, document tokenization has one extra token (the prefix)."""
-        tokens_with = model_with_prefix.tokenize(["hello world"], is_query=False)
-        tokens_without = model_without_prefix.tokenize(["hello world"], is_query=False)
+        tokens_with = model_with_prefix.preprocess(["hello world"], is_query=False)
+        tokens_without = model_without_prefix.preprocess(
+            ["hello world"], is_query=False
+        )
         assert (
             tokens_with["input_ids"].shape[1]
             == tokens_without["input_ids"].shape[1] + 1
@@ -157,7 +159,7 @@ class TestSaveLoadPrefixes:
             model_without_prefix.save(tmpdir)
             loaded = models.ColBERT(model_name_or_path=tmpdir, device="cpu")
 
-            tokens = loaded.tokenize(["hello world"], is_query=True)
+            tokens = loaded.preprocess(["hello world"], is_query=True)
             input_ids = tokens["input_ids"]
             # Should not have the query prefix as second token
             assert input_ids[0, 1].item() != loaded.query_prefix_id
@@ -181,7 +183,7 @@ class TestSaveLoadPrefixes:
             model_custom_prefix.save(tmpdir)
             loaded = models.ColBERT(model_name_or_path=tmpdir, device="cpu")
 
-            tokens = loaded.tokenize(["hello world"], is_query=True)
+            tokens = loaded.preprocess(["hello world"], is_query=True)
             input_ids = tokens["input_ids"]
             assert input_ids[0, 1].item() == loaded.query_prefix_id
 

--- a/tests/test_prefixes.py
+++ b/tests/test_prefixes.py
@@ -98,19 +98,19 @@ class TestTokenizePrefixInsertion:
         assert input_ids[0, 1].item() == model_custom_prefix.document_prefix_id
 
     def test_seq_length_with_custom_prefix(self, model_custom_prefix):
-        """With custom prefix, output length should not exceed query_length."""
+        """With query expansion, output length should be exactly query_length."""
         tokens = model_custom_prefix.tokenize(["hello world"], is_query=True)
-        assert tokens["input_ids"].shape[1] <= model_custom_prefix.query_length
+        assert tokens["input_ids"].shape[1] == model_custom_prefix.query_length
 
     def test_seq_length_with_prefix(self, model_with_prefix):
-        """With prefix, output length should not exceed query_length."""
+        """With query expansion, output length should be exactly query_length."""
         tokens = model_with_prefix.tokenize(["hello world"], is_query=True)
-        assert tokens["input_ids"].shape[1] <= model_with_prefix.query_length
+        assert tokens["input_ids"].shape[1] == model_with_prefix.query_length
 
     def test_seq_length_without_prefix(self, model_without_prefix):
-        """Without prefix, output length should not exceed query_length."""
+        """With query expansion, output length should be exactly query_length."""
         tokens = model_without_prefix.tokenize(["hello world"], is_query=True)
-        assert tokens["input_ids"].shape[1] <= model_without_prefix.query_length
+        assert tokens["input_ids"].shape[1] == model_without_prefix.query_length
 
     def test_output_length_difference(self, model_with_prefix, model_without_prefix):
         """With prefix, document tokenization has one extra token (the prefix)."""

--- a/tests/test_vidore_evaluator.py
+++ b/tests/test_vidore_evaluator.py
@@ -52,3 +52,52 @@ def test_language_expansion_without_language(no_dataset_loading):
 def test_language_case_insensitive(no_dataset_loading):
     evaluator = ViDoREvaluator(dataset_names=["esgreports"], language="French")
     assert evaluator.dataset_names == ["esgreports:french"]
+
+
+@pytest.fixture
+def fake_hub_datasets(monkeypatch):
+    """Replace hub loading with a tiny in-memory v1-style dataset."""
+    import datasets
+
+    def fake_load_dataset(path, name, split):
+        if name == "queries":
+            return datasets.Dataset.from_dict(
+                {"query-id": [1, 2], "query": ["q one", "q two"]}
+            )
+        if name == "corpus":
+            return datasets.Dataset.from_dict(
+                {"corpus-id": [10, 11], "image": ["img-a", "img-b"]}
+            )
+        if name == "qrels":
+            return datasets.Dataset.from_dict(
+                {"query-id": [1, 2], "corpus-id": [10, 11], "score": [1, 1]}
+            )
+        raise AssertionError(name)
+
+    monkeypatch.setattr(datasets, "load_dataset", fake_load_dataset)
+
+
+def test_query_prompts_forwarded_to_sub_evaluators(fake_hub_datasets):
+    evaluator = ViDoREvaluator(
+        dataset_names=["arxivqa"], query_prompts="Find a relevant screenshot: "
+    )
+    assert evaluator.evaluators[0].query_prompt == "Find a relevant screenshot: "
+
+
+def test_corpus_prompts_injected_as_image_text(fake_hub_datasets):
+    evaluator = ViDoREvaluator(
+        dataset_names=["arxivqa"], corpus_prompts="Describe the image."
+    )
+    corpus = evaluator.evaluators[0].corpus
+    assert all(entry["text"] == "Describe the image." for entry in corpus)
+    # Not forwarded as an encode-time string prefix (meaningless for images)
+    assert not getattr(evaluator.evaluators[0], "corpus_prompt", None)
+
+
+def test_document_prompt_and_corpus_prompts_are_exclusive(no_dataset_loading):
+    with pytest.raises(ValueError, match="not both"):
+        ViDoREvaluator(
+            dataset_names=["arxivqa"],
+            document_prompt="Describe the image.",
+            corpus_prompts="Describe the image.",
+        )

--- a/tests/test_vidore_evaluator.py
+++ b/tests/test_vidore_evaluator.py
@@ -94,10 +94,7 @@ def test_corpus_prompts_injected_as_image_text(fake_hub_datasets):
     assert not getattr(evaluator.evaluators[0], "corpus_prompt", None)
 
 
-def test_document_prompt_and_corpus_prompts_are_exclusive(no_dataset_loading):
-    with pytest.raises(ValueError, match="not both"):
-        ViDoREvaluator(
-            dataset_names=["arxivqa"],
-            document_prompt="Describe the image.",
-            corpus_prompts="Describe the image.",
-        )
+def test_no_corpus_prompts_keeps_raw_images(fake_hub_datasets):
+    evaluator = ViDoREvaluator(dataset_names=["arxivqa"])
+    corpus = evaluator.evaluators[0].corpus
+    assert all("text" not in entry for entry in corpus)

--- a/tests/test_vidore_evaluator.py
+++ b/tests/test_vidore_evaluator.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pylate.evaluation import ViDoREvaluator
+
+
+@pytest.fixture
+def no_dataset_loading(monkeypatch):
+    """Stub _load_dataset so init-time validation can be tested offline."""
+    monkeypatch.setattr(
+        ViDoREvaluator,
+        "_load_dataset",
+        lambda self, name, **kwargs: MagicMock(name=name),
+    )
+
+
+def test_unknown_language_raises_at_init(no_dataset_loading):
+    with pytest.raises(ValueError, match="Unknown language 'klingon'"):
+        ViDoREvaluator(versions=["v3"], language="klingon")
+
+
+def test_language_unavailable_for_all_selected_raises(no_dataset_loading):
+    # italian exists in v3 only; a pure-v2 selection has nothing to evaluate
+    with pytest.raises(ValueError, match="No datasets left"):
+        ViDoREvaluator(dataset_names=["esgreports"], language="italian")
+
+
+def test_language_skips_unavailable_datasets(no_dataset_loading, caplog):
+    # Mixed v2+v3 selection: the v2 dataset is skipped with a warning, the
+    # v3 dataset is evaluated in the requested language.
+    with caplog.at_level("WARNING", logger="pylate.evaluation.vidore_evaluator"):
+        evaluator = ViDoREvaluator(
+            dataset_names=["esgreports", "hr"], language="italian"
+        )
+    assert evaluator.dataset_names == ["hr:italian"]
+    assert any("Skipping esgreports" in r.message for r in caplog.records)
+
+
+def test_language_expansion_without_language(no_dataset_loading):
+    evaluator = ViDoREvaluator(dataset_names=["esgreports"])
+    assert evaluator.dataset_names == [
+        "esgreports:english",
+        "esgreports:french",
+        "esgreports:spanish",
+        "esgreports:german",
+    ]
+
+
+def test_language_case_insensitive(no_dataset_loading):
+    evaluator = ViDoREvaluator(dataset_names=["esgreports"], language="French")
+    assert evaluator.dataset_names == ["esgreports:french"]


### PR DESCRIPTION
This PR adds multimodal ColPali support through the upgrade to sentence-transformers v5.4+

Summary

- Multimodal (ColPali) support: Native loading, training, and inference for Vision-Language ColBERT models (ColPali, ColQwen2/2.5/3/3.5, ColGemma3, ColIdefics3, etc.) without requiring colpali_engine. Includes automatic architecture detection, projection weight extraction (with LoRA adapter merging), chat template configuration, and suffix-based query expansion for VLMs.
- sentence-transformers v5.4+ migration: Adapts the entire codebase to the new ST v5.4/v5.5 API — renamed imports (sentence_transformers.base.modules, sentence_transformers.sentence_transformer.*), tokenize → preprocess rename with backward compat, ColBERTCollator now extends BaseDataCollator, and Dense module rewritten to use the new save/load/get_config_dict protocol.
- ViDoRe evaluator: Full v1/v2/v3 visual document retrieval benchmark evaluator aligned with MTEB (per-language evaluation, per-version macro averages, shared corpus encoding).
- Variable-length multimodal DDP support: Losses (Contrastive, CachedContrastive) now pad variable-length VLM outputs before all_gather and stacking, with new pad_embeddings_and_masks utility and all_reduce_max for cross-rank shape coordination.

Test plan

- [x] New tests: test_colpali.py, test_chat_template.py, test_copansion.py, test_is_text_input.py, test_padding.py,test_encode_output_value.py, test_scores_flash.py, test_scores_lik.py, test_tachiom.py
- [x] Updated tests: test_prefixes.py, test_cached_contrastive.pkd.py adapted to new preprocess API
- [x] All examples updated to use model.preprocess / preprocess_fn=model.preprocess
- [x] End-to-end multimodal training with a ColQwen model (@staghado ran a few trainings and I did as well)
- [x] ViDoRe v1/v2/v3 evaluation pass. This works great, the only thing missing is to add autocast to the evaluator when used outside of training. BF16 when not autocasting differs a bit in LayerNorm and cause massive e2e degradation. Not sure what's best to add it to the evaluator to not break for FP32 setups. Edit: added autocast in the encode function, should be no-op for fp32 and fixes the issue

Breaking changes

- sentence-transformers >= 5.5.1 required (was == 5.3.0)
- model.tokenize() still works but emits a FutureWarning — use model.preprocess() instead
- ColBERTCollator(tokenize_fn=...) deprecated in favor of ColBERTCollator(preprocess_fn=...)
- tokenizer_kwargs parameter renamed to processor_kwargs
- use_auth_token parameter deprecated in favor of token