### PR TITLE
Fix Ward hierarchical pooling Euclidean geometry and add error_bound cuts

### DIFF
--- a/docs/documentation/retrieval.md
+++ b/docs/documentation/retrieval.md
@@ -175,18 +175,32 @@ scores = retriever.retrieve(
 
 To reduce the memory and storage footprint of the index, you can "pool" similar token embeddings within a document. This technique averages token embeddings that are close to each other in the embedding space, effectively compressing the document representation.
 
-You can enable this by setting the `pool_factor` during document encoding. A `pool_factor` of 2 will attempt to reduce the number of token embeddings by half.
+Hierarchical pooling uses Ward linkage on Euclidean distances between L2-normalized token embeddings. You can cut the dendrogram in either of two ways:
+
+- **Fixed budget** (`pool_factor`): keep about `1/pool_factor` of the tokens in every document.
+- **Adaptive / error bound** (`error_bound` in `[0, 1]`): cut at a relative Ward-linkage height so easy documents compress more and hard ones keep more tokens. `0` keeps all tokens; `1` merges all poolable tokens into one cluster.
+
+These two options are mutually exclusive.
 
 ???+ tip "Performance vs. Compression"
 	As detailed in [this blog post](https://www.answer.ai/posts/colbert-pooling.html), a `pool_factor` of **2** can halve the index size with virtually zero drop in retrieval performance. Higher factors offer more compression at the cost of some accuracy.
 
     ```python
-    # Example of encoding with pooling
+    # Fixed budget: keep ~1/2 of the original tokens in every document
     documents_embeddings = model.encode(
         documents,
         batch_size=32,
         is_query=False,
-        pool_factor=2,  # Keep 1/2 of the original tokens
+        pool_factor=2,
+        show_progress_bar=True,
+    )
+
+    # Adaptive cut: relative Ward height in [0, 1]
+    documents_embeddings = model.encode(
+        documents,
+        batch_size=32,
+        is_query=False,
+        error_bound=0.35,
         show_progress_bar=True,
     )
     ```

--- a/pylate/models/colbert.py
+++ b/pylate/models/colbert.py
@@ -507,6 +507,7 @@ class ColBERT(SentenceTransformer):
         is_query: bool = True,
         pool_factor: int = 1,
         protected_tokens: int = 1,
+        error_bound: float | None = None,
         output_value: str | None = "token_embeddings",
     ) -> list[torch.Tensor] | ndarray | torch.Tensor | dict[str, list]:
         """
@@ -553,8 +554,13 @@ class ColBERT(SentenceTransformer):
         pool_factor
             The factor by which to pool the document embeddings, resulting in 1/pool_factor of the original tokens. If set
             to 1, no pooling is done; if set to 2, 50% of the tokens are kept; if set to 3, 33%, and so on. Defaults to 1.
+            Mutually exclusive with ``error_bound``.
         protected_tokens
             The number of tokens at the beginning of the sequence that should not be pooled. Defaults to 1 (CLS token).
+        error_bound
+            Optional relative Ward-linkage height cut in ``[0, 1]`` for hierarchical pooling. ``0`` keeps all tokens;
+            ``1`` merges all poolable tokens into a single cluster. Mutually exclusive with ``pool_factor > 1``.
+            Defaults to None (disabled; use ``pool_factor`` instead).
         output_value
             Controls the return format. ``"token_embeddings"`` (default): filtered
             per-document token embeddings — the existing behaviour.
@@ -562,19 +568,20 @@ class ColBERT(SentenceTransformer):
             ``"attention_mask"``, and ``"masks"`` (combined skiplist + attention mask,
             bool), each mapping to a list of per-document tensors/arrays of shape
             ``[seq_len, ...]``. The caller applies the mask to obtain aligned embeddings
-            and token IDs. Incompatible with ``pool_factor > 1``.
+            and token IDs. Incompatible with hierarchical pooling.
 
         """
         if output_value not in ("token_embeddings", None):
             raise ValueError(
                 f"output_value must be 'token_embeddings' or None, got {output_value!r}."
             )
-        if output_value is None and pool_factor > 1:
+        if output_value is None and (pool_factor > 1 or error_bound is not None):
             # Pooling merges token embeddings, so the per-token input_ids/masks
             # we would return could no longer be mapped 1-to-1 onto
             # token_embeddings, the pairing would be ill-defined.
             raise ValueError(
-                "output_value=None is not compatible with pool_factor > 1."
+                "output_value=None is not compatible with hierarchical pooling "
+                "(pool_factor > 1 or error_bound)."
             )
 
         if isinstance(sentences, list):
@@ -598,6 +605,7 @@ class ColBERT(SentenceTransformer):
                         is_query=is_query,
                         pool_factor=pool_factor,
                         protected_tokens=protected_tokens,
+                        error_bound=error_bound,
                         output_value=output_value,
                     )
 
@@ -790,11 +798,12 @@ class ColBERT(SentenceTransformer):
                         )
                         batch["token_embeddings"].append(token_emb)
 
-                if pool_factor > 1 and not is_query:
+                if (pool_factor > 1 or error_bound is not None) and not is_query:
                     batch["token_embeddings"] = self.pool_embeddings_hierarchical(
                         documents_embeddings=batch["token_embeddings"],
                         pool_factor=pool_factor,
                         protected_tokens=protected_tokens,
+                        error_bound=error_bound,
                     )
 
                 # fixes for #522 and #487 to avoid oom problems on gpu with large datasets
@@ -865,23 +874,45 @@ class ColBERT(SentenceTransformer):
         documents_embeddings: list[torch.Tensor],
         pool_factor: int = 1,
         protected_tokens: int = 1,
+        error_bound: float | None = None,
     ) -> list[torch.Tensor]:
         """
         Pools the embeddings hierarchically by clustering and averaging them.
+
+        Uses Ward linkage on Euclidean distances between L2-normalized token
+        embeddings. The dendrogram can be cut either to a fixed cluster count
+        (via ``pool_factor``) or at a relative height (via ``error_bound``).
 
         Parameters
         ----------
         documents_embeddings
             A list of embeddings for each document.
         pool_factor
-            Factor to determine the number of clusters. Defaults to 1.
+            Factor to determine the number of clusters
+            (``max(num_tokens // pool_factor, 1)``). Defaults to 1.
+            Mutually exclusive with ``error_bound``.
         protected_tokens
             Number of tokens to protect from pooling at the start of each document. Defaults to 1.
+        error_bound
+            Optional relative Ward-linkage height cut in ``[0, 1]``. The tree is
+            cut with ``criterion="distance"`` at ``error_bound * max_height``, so
+            documents with redundant tokens compress more aggressively than
+            diverse ones. Mutually exclusive with ``pool_factor > 1``.
 
         Returns
         -------
             A list of pooled embeddings for each document.
         """
+        if error_bound is not None:
+            if not 0.0 <= error_bound <= 1.0:
+                raise ValueError(
+                    f"error_bound must be in [0, 1], got {error_bound}."
+                )
+            if pool_factor > 1:
+                raise ValueError(
+                    "Specify either pool_factor (>1) or error_bound, not both."
+                )
+
         pooled_embeddings = []
 
         for document_embeddings in documents_embeddings:
@@ -893,24 +924,37 @@ class ColBERT(SentenceTransformer):
             to_pool = document_embeddings_cpu[protected_tokens:]
 
             num_embeddings = len(to_pool)
-            num_clusters = max(num_embeddings // pool_factor, 1)
-
-            # Skip pooling if it wouldn't reduce anything
-            if num_clusters >= num_embeddings:
+            if num_embeddings <= 1:
                 pooled_embeddings.append(document_embeddings_cpu)
                 continue
 
-            # Compute cosine similarity and convert to condensed distance matrix
-            cos_sim = torch.mm(to_pool, to_pool.t()).numpy()
-            dist_full = 1 - cos_sim
-            # Extract upper triangle as condensed form for scipy linkage
-            condensed = dist_full[np.triu_indices(num_embeddings, k=1)]
+            if error_bound is None:
+                num_clusters = max(num_embeddings // pool_factor, 1)
+                # Skip pooling if it wouldn't reduce anything
+                if num_clusters >= num_embeddings:
+                    pooled_embeddings.append(document_embeddings_cpu)
+                    continue
 
-            # Hierarchical clustering
-            linkage_matrix = hierarchy.linkage(condensed, method="ward")
-            labels = hierarchy.fcluster(
-                linkage_matrix, t=num_clusters, criterion="maxclust"
-            )
+            # Ward linkage requires Euclidean geometry. Pass L2-normalized
+            # observations (not cosine distances) so scipy computes true
+            # Euclidean pairwise distances.
+            observations = torch.nn.functional.normalize(
+                to_pool.float(), p=2, dim=1
+            ).numpy()
+            linkage_matrix = hierarchy.linkage(observations, method="ward")
+
+            if error_bound is None:
+                labels = hierarchy.fcluster(
+                    linkage_matrix, t=num_clusters, criterion="maxclust"
+                )
+            else:
+                # Relative cut of the dendrogram height range in [0, 1].
+                max_height = float(linkage_matrix[-1, 2])
+                distance_threshold = error_bound * max_height
+                labels = hierarchy.fcluster(
+                    linkage_matrix, t=distance_threshold, criterion="distance"
+                )
+                num_clusters = int(labels.max())
 
             # Vectorized cluster mean via scatter_add_
             labels_tensor = torch.from_numpy(labels.astype(np.int64)) - 1  # 0-indexed
@@ -1015,6 +1059,7 @@ class ColBERT(SentenceTransformer):
         is_query: bool = True,
         pool_factor: int = 1,
         protected_tokens: int = 1,
+        error_bound: float | None = None,
     ) -> list[np.ndarray]:
         """
         Encodes a list of sentences using multiple processes and GPUs via
@@ -1058,8 +1103,12 @@ class ColBERT(SentenceTransformer):
             Whether the input sentences are queries. If True, the query prefix is added to the input sentences
         pool_factor
             The factor by which to pool the document embeddings, resulting in 1/pool_factor of the original tokens.
+            Mutually exclusive with ``error_bound``.
         protected_tokens
             The number of tokens at the beginning of the sequence that should not be pooled. Defaults to 1 (CLS token).
+        error_bound
+            Optional relative Ward-linkage height cut in ``[0, 1]`` for hierarchical pooling. Mutually exclusive
+            with ``pool_factor > 1``. Defaults to None.
 
         Examples
         --------
@@ -1112,6 +1161,7 @@ class ColBERT(SentenceTransformer):
                         is_query,
                         pool_factor,
                         protected_tokens,
+                        error_bound,
                     ]
                 )
                 last_chunk_id += 1
@@ -1131,6 +1181,7 @@ class ColBERT(SentenceTransformer):
                     is_query,
                     pool_factor,
                     protected_tokens,
+                    error_bound,
                 ]
             )
             last_chunk_id += 1

--- a/pylate/utils/multi_process.py
+++ b/pylate/utils/multi_process.py
@@ -91,6 +91,7 @@ def _encode_multi_process_worker(
                 is_query,
                 pool_factor,
                 protected_tokens,
+                error_bound,
             ) = input_queue.get()
 
             embeddings = model.encode(
@@ -107,6 +108,7 @@ def _encode_multi_process_worker(
                 is_query=is_query,
                 pool_factor=pool_factor,
                 protected_tokens=protected_tokens,
+                error_bound=error_bound,
             )
 
             results_queue.put([chunk_id, embeddings])

--- a/tests/test_encode_output_value.py
+++ b/tests/test_encode_output_value.py
@@ -109,8 +109,14 @@ def test_encode_output_value_none_with_padding(model):
 
 def test_encode_output_value_none_rejects_pool_factor(model):
     """Pooling merges tokens, so token IDs can no longer align with embeddings."""
-    with pytest.raises(ValueError, match="pool_factor"):
+    with pytest.raises(ValueError, match="hierarchical pooling"):
         model.encode(DOCUMENTS, is_query=False, output_value=None, pool_factor=2)
+
+
+def test_encode_output_value_none_rejects_error_bound(model):
+    """Error-bound pooling also merges tokens and breaks ID alignment."""
+    with pytest.raises(ValueError, match="hierarchical pooling"):
+        model.encode(DOCUMENTS, is_query=False, output_value=None, error_bound=0.3)
 
 
 def test_encode_output_value_invalid_raises(model):

--- a/tests/test_hierarchical_pooling.py
+++ b/tests/test_hierarchical_pooling.py
@@ -1,0 +1,120 @@
+"""Tests for hierarchical / Ward token pooling."""
+
+import numpy as np
+import pytest
+import torch
+from scipy.cluster import hierarchy
+
+from pylate.models.colbert import ColBERT
+
+
+def _normalized_tokens(n_tokens: int = 12, dim: int = 8, seed: int = 0) -> torch.Tensor:
+    generator = torch.Generator().manual_seed(seed)
+    tokens = torch.randn(n_tokens, dim, generator=generator)
+    return torch.nn.functional.normalize(tokens, p=2, dim=1)
+
+
+def test_ward_linkage_uses_euclidean_observations():
+    """Ward must be built from Euclidean geometry on L2-normalized tokens."""
+    tokens = _normalized_tokens()
+    pooled = ColBERT.pool_embeddings_hierarchical(
+        None, [tokens], pool_factor=2, protected_tokens=0
+    )[0]
+
+    expected_linkage = hierarchy.linkage(
+        tokens.float().numpy(), method="ward"
+    )
+    labels = hierarchy.fcluster(
+        expected_linkage, t=max(len(tokens) // 2, 1), criterion="maxclust"
+    )
+    expected = torch.stack(
+        [
+            tokens[labels == cluster_id].mean(dim=0)
+            for cluster_id in range(1, int(labels.max()) + 1)
+            if (labels == cluster_id).any()
+        ]
+    )
+
+    assert pooled.shape[0] < tokens.shape[0]
+    torch.testing.assert_close(pooled, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_pool_factor_reduces_token_count():
+    tokens = _normalized_tokens(n_tokens=16)
+    pooled = ColBERT.pool_embeddings_hierarchical(
+        None, [tokens], pool_factor=4, protected_tokens=1
+    )[0]
+
+    assert pooled.shape[0] == 1 + max((16 - 1) // 4, 1)
+    torch.testing.assert_close(pooled[0], tokens[0])
+
+
+def test_error_bound_zero_keeps_all_tokens():
+    tokens = _normalized_tokens()
+    pooled = ColBERT.pool_embeddings_hierarchical(
+        None, [tokens], protected_tokens=0, error_bound=0.0
+    )[0]
+
+    assert pooled.shape[0] == tokens.shape[0]
+
+
+def test_error_bound_one_collapses_to_single_cluster():
+    tokens = _normalized_tokens()
+    pooled = ColBERT.pool_embeddings_hierarchical(
+        None, [tokens], protected_tokens=1, error_bound=1.0
+    )[0]
+
+    assert pooled.shape[0] == 2  # protected CLS + one pooled cluster
+    torch.testing.assert_close(pooled[0], tokens[0])
+
+
+def test_error_bound_is_adaptive_across_documents():
+    """Redundant tokens compress more than diverse tokens at the same bound."""
+    generator = torch.Generator().manual_seed(1)
+    base = torch.nn.functional.normalize(torch.randn(1, 8, generator=generator), dim=1)
+    # Near-duplicates should merge early under a relative height cut.
+    redundant = torch.nn.functional.normalize(
+        base + 1e-3 * torch.randn(12, 8, generator=generator), dim=1
+    )
+    diverse = torch.nn.functional.normalize(
+        torch.randn(12, 8, generator=generator), dim=1
+    )
+
+    pooled = ColBERT.pool_embeddings_hierarchical(
+        None,
+        [redundant, diverse],
+        protected_tokens=0,
+        error_bound=0.4,
+    )
+
+    assert pooled[0].shape[0] < pooled[1].shape[0]
+    assert pooled[1].shape[0] <= diverse.shape[0]
+
+
+def test_pool_factor_and_error_bound_are_mutually_exclusive():
+    tokens = _normalized_tokens()
+    with pytest.raises(ValueError, match="either pool_factor"):
+        ColBERT.pool_embeddings_hierarchical(
+            None, [tokens], pool_factor=2, error_bound=0.3
+        )
+
+
+def test_error_bound_must_be_unit_interval():
+    tokens = _normalized_tokens()
+    with pytest.raises(ValueError, match="error_bound must be in"):
+        ColBERT.pool_embeddings_hierarchical(
+            None, [tokens], error_bound=1.5
+        )
+
+
+def test_cosine_distance_ward_differs_from_euclidean_ward():
+    """Sanity check that the previous cosine-distance Ward path was incorrect."""
+    tokens = _normalized_tokens(n_tokens=20, dim=16, seed=7)
+    observations = tokens.float().numpy()
+    euclidean = hierarchy.linkage(observations, method="ward")
+
+    cos_sim = tokens @ tokens.T
+    condensed = (1 - cos_sim.numpy())[np.triu_indices(len(tokens), k=1)]
+    cosine_as_ward = hierarchy.linkage(condensed, method="ward")
+
+    assert not np.allclose(euclidean[:, 2], cosine_as_ward[:, 2])


### PR DESCRIPTION
## Summary
- Fix hierarchical pooling so Ward linkage is built from Euclidean distances on L2-normalized token embeddings, instead of feeding cosine distances into Ward (which is invalid).
- Add an optional `error_bound` in `[0, 1]` that cuts the dendrogram at a relative Ward height (`criterion="distance"`), as an alternative to the existing fixed-budget `pool_factor` path. The two options are mutually exclusive.
- Wire `error_bound` through `encode` / `encode_multi_process`, document both cut modes, and add unit tests covering Euclidean correctness, adaptive compression, and validation.

## Test plan
- [x] `pytest tests/test_hierarchical_pooling.py`
- [ ] Smoke encode with `pool_factor=2` and with `error_bound=0.35` on a small document set
- [ ] Confirm `pool_factor` and `error_bound` raise when both are set


Made with [Cursor](https://cursor.com)