### PR TITLE
fix: support MPS in RandContext so CachedContrastive runs on Apple Silicon

### DIFF
--- a/pylate/losses/cached_contrastive.py
+++ b/pylate/losses/cached_contrastive.py
@@ -26,20 +26,36 @@ class RandContext:
 
     def __init__(self, *tensors) -> None:
         self.fwd_cpu_state = torch.get_rng_state()
-        if torch.backends.mps.is_available():
-            raise RuntimeError(
-                "MPS backend is not supported for this operation. Please use CPU or CUDA."
+        # get_device_states() calls the nonexistent torch.mps.device() on MPS tensors, so snapshot the
+        # MPS RNG separately and filter MPS tensors out before calling it (restored in __enter__).
+        self.fwd_mps_state = (
+            torch.mps.get_rng_state()
+            if any(
+                isinstance(t, torch.Tensor) and t.device.type == "mps" for t in tensors
             )
-        else:
-            self.fwd_gpu_devices, self.fwd_gpu_states = get_device_states(*tensors)
+            else None
+        )
+        non_mps_tensors = tuple(
+            t
+            for t in tensors
+            if not (isinstance(t, torch.Tensor) and t.device.type == "mps")
+        )
+        self.fwd_gpu_devices, self.fwd_gpu_states = get_device_states(*non_mps_tensors)
 
     def __enter__(self) -> None:
         self._fork = torch.random.fork_rng(devices=self.fwd_gpu_devices, enabled=True)
         self._fork.__enter__()
         torch.set_rng_state(self.fwd_cpu_state)
+        if self.fwd_mps_state is not None:
+            # This fork_rng call uses the default device_type="cuda", so save the outer
+            # MPS state here and restore it in __exit__ (mirroring fork_rng for CPU/CUDA).
+            self._mps_state_outside = torch.mps.get_rng_state()
+            torch.mps.set_rng_state(self.fwd_mps_state)
         set_device_states(self.fwd_gpu_devices, self.fwd_gpu_states)
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        if self.fwd_mps_state is not None:
+            torch.mps.set_rng_state(self._mps_state_outside)
         self._fork.__exit__(exc_type, exc_val, exc_tb)
         self._fork = None
 

--- a/tests/test_randcontext.py
+++ b/tests/test_randcontext.py
@@ -1,0 +1,41 @@
+"""Tests for the GradCache RNG context used by CachedContrastive."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from pylate.losses.cached_contrastive import RandContext
+
+DEVICES = ["cpu"] + (["mps"] if torch.backends.mps.is_available() else [])
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_randcontext_replays_the_forward_randomness(device: str) -> None:
+    """The whole point of RandContext: the second forward must draw the same numbers."""
+    tensor = torch.randn(4, 4, device=device)
+
+    context = RandContext(tensor)
+    with context:
+        first = torch.randn(8, device=device).clone()
+    with context:
+        second = torch.randn(8, device=device).clone()
+
+    assert torch.equal(first, second)
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_randcontext_does_not_leak_rng_state(device: str) -> None:
+    """Leaving the context must not disturb the surrounding RNG stream, or every
+    training step after a cached backward would silently change its dropout."""
+    tensor = torch.randn(4, 4, device=device)
+
+    cpu_before = torch.get_rng_state().clone()
+    mps_before = torch.mps.get_rng_state().clone() if device == "mps" else None
+
+    with RandContext(tensor):
+        torch.randn(64, device=device)
+
+    assert torch.equal(cpu_before, torch.get_rng_state())
+    if device == "mps":
+        assert torch.equal(mps_before, torch.mps.get_rng_state())


### PR DESCRIPTION
Fixes #235.

`RandContext` raised whenever `torch.backends.mps.is_available()` was true — which is every Apple Silicon machine — so `CachedContrastive` was unusable there, on MPS and on CPU alike. `tests/test_cached_contrastive.py` fails at HEAD on such a machine, since `SentenceTransformerTrainer` selects `mps:0`.

The guard was necessary: `torch.utils.checkpoint.get_device_states` calls the nonexistent `torch.mps.device()` on an MPS tensor. `sentence-transformers` solved this in [#3862](https://github.com/huggingface/sentence-transformers/pull/3862) (`fddb49e`, 2026-07-16) with an MPS-aware `RandContext`. PyLate pins `sentence-transformers == 5.3.0`, which predates that work, and carries its own copy of the class — so it never picked the fix up.

This ports upstream's approach so the two stay aligned, and the vendored copy can simply be dropped whenever PyLate moves onto the ST v6 shared GradCache engine:

- snapshot `torch.mps.get_rng_state()` separately when any tensor is on MPS
- filter MPS tensors out before calling `get_device_states`
- save the outer MPS state on `__enter__` and restore it on `__exit__`, since `fork_rng` covers cpu and cuda only

That last point matters on its own: without the restore, the recomputed forward leaks its RNG state into the surrounding stream and silently changes the dropout of every subsequent training step. `tests/test_randcontext.py::test_randcontext_does_not_leak_rng_state` covers it.

### Tests

`tests/test_randcontext.py` adds two properties, parametrised over cpu and mps: that the context replays the same randomness on re-entry, and that it leaves the global RNG untouched on exit. All four cases fail on the unpatched source and pass with the change. They need no model download and run in ~2s.

`tests/test_cached_contrastive.py` goes from failing to passing on Apple Silicon.

### Verification

macOS arm64, torch 2.11.0, sentence-transformers 5.3.0, comparisons in float64:

| check | cpu | mps |
|---|---|---|
| `CachedContrastive` vs `Contrastive`, gradient cosine (eval mode) | 0.999999999999 | 0.999999999993 |
| same seed twice with dropout live | bitwise identical | cosine 1.000000000000 |
| `mini_batch_size` 1 vs 2, gradient cosine | 0.999999999999 | 0.999999999997 |

### One limitation, stated plainly

**I have no CUDA hardware, so the CUDA path is unverified by me.** Only MPS tensors are filtered out of `get_device_states`, so CUDA behaviour should be unchanged — but that is by inspection, not execution, and is worth a reviewer's eye.

### Not included

`tests/test_contrastive.py:21` skips on the same over-broad condition (`@pytest.mark.skipif(torch.backends.mps.is_available(), ...)`), so it silently skips on Apple Silicon instead of running. Left alone to keep this PR to one change — happy to narrow it here or in a follow-up.
