### PR TITLE
fix: accumulate the MaxSim sum in fp32 (bf16 currently costs 2.2 nDCG@10 on SciFact)

### DIFF
--- a/pylate/scores/colbert.py
+++ b/pylate/scores/colbert.py
@@ -197,7 +197,9 @@ def colbert_scores(
 
     if documents_mask is not None:
         scores = scores * documents_mask.unsqueeze(0).unsqueeze(2)
-    scores = scores.max(axis=-1).values.sum(axis=-1)
+    # accumulate the per-query-token maxima in fp32: summing ~32 terms in fp16/bf16
+    # loses retrieval quality, and reduced precision is the documented training path
+    scores = scores.max(axis=-1).values.sum(axis=-1, dtype=torch.float32)
     return scores
 
 

--- a/tests/test_colbert_scores.py
+++ b/tests/test_colbert_scores.py
@@ -93,3 +93,22 @@ class TestColBERTScoresQuerySlicing:
 
         assert chunk.shape == (3, Q * N)
         torch.testing.assert_close(chunk, full[:3])
+
+
+def test_maxsim_sum_accumulates_in_fp32() -> None:
+    """Summing the per-query-token maxima in fp16/bf16 loses retrieval quality
+    (bf16 cost 2.2 nDCG@10 on SciFact), so the accumulation is done in fp32."""
+    torch.manual_seed(0)
+    n_queries, n_docs, len_q, len_d, dim = 4, 8, 32, 180, 128
+    queries = torch.nn.functional.normalize(
+        torch.randn(n_queries, len_q, dim), dim=-1
+    )
+    documents = torch.nn.functional.normalize(
+        torch.randn(n_docs, len_d, dim), dim=-1
+    )
+
+    reference = colbert_scores(queries, documents)
+    for dtype in (torch.float16, torch.bfloat16):
+        reduced = colbert_scores(queries.to(dtype), documents.to(dtype))
+        assert reduced.dtype == torch.float32
+        assert torch.allclose(reduced, reference, atol=2e-2)


### PR DESCRIPTION
`colbert_scores` sums the per-query-token maxima in the input dtype:

```python
# pylate/scores/colbert.py:115
scores = scores.max(axis=-1).values.sum(axis=-1)
```

Under fp16 or bf16 that accumulation runs in reduced precision across ~32 query tokens, and it costs measurable retrieval quality. Accumulating the sum in fp32 recovers it.

### Measurement

BEIR SciFact, 1,500 documents (every judged document plus distractors), 300 queries, `lightonai/GTE-ModernColBERT-v1`. Embeddings are computed **once and cached**, so the only variable below is the accumulation — never the encoding. nDCG@10 and Recall@10 via `pytrec_eval`.

| accumulation | nDCG@10 | Recall@10 |
|---|---|---|
| fp32 embeddings (reference) | 0.854361 | 0.937000 |
| **fp16, sum in fp16 (current)** | **0.850314** | **0.927000** |
| fp16, sum in fp32 | 0.854400 | 0.937000 |
| **bf16, sum in bf16 (current)** | **0.832469** | **0.918667** |
| bf16, sum in fp32 | 0.851472 | 0.927000 |

bf16 loses **2.2 nDCG points and 1.8 points of Recall@10**; fp16 loses 0.4 and 1.0. In both cases summing in fp32 recovers essentially all of it.

This also explains a backend discrepancy: with `late-interaction-kernels` installed, `backend="auto"` scores fp16 at nDCG@10 0.854361 — matching fp32 — because the LIK kernel accumulates in fp32. Without it, the same call returns 0.850314. Same code, same model, same data; the result depends on whether an optional package is installed.

### This is the documented path, not a corner case

`fp16=True` appears in `docs/index.md`, `docs/documentation/training.md`, `examples/train/contrastive.py` and `examples/train/knowledge_distillation.py`; `bf16=True` in `examples/train/gte_modern_colbert.py` and `examples/train/agent_modern_colbert.py`. Loading in fp16 has been supported since #49/#52.

The training path reaches the same line. Instrumenting the call chain `Contrastive` → `ColBERTScores` → `colbert_scores`:

```
no autocast            -> colbert_scores receives torch.float32
autocast(float16)      -> torch.float16
autocast(bfloat16)     -> torch.bfloat16
```

So under the recommended `bf16=True` training config, the contrastive loss is computed from bf16-accumulated scores.

### The change

```python
scores = scores.max(axis=-1).values.sum(axis=-1, dtype=torch.float32)
```

Plus a regression test in `tests/test_colbert_scores.py` asserting fp16 and bf16 scores match the fp32 reference. It fails on the unpatched source for both dtypes.

`tests/test_colbert_scores.py`, `test_scores_lik.py`, `test_scores_flash.py`, `test_xtr_scores.py` and `test_kd.py` all pass with this applied (44 passed, 24 skipped).

**This makes `colbert_scores` return fp32 rather than the input dtype.** Deliberate, but your call on whether that is acceptable API-wise — happy to cast back to the input dtype after the sum if you prefer.

`colbert_scores_pairwise` and `colbert_kd_scores` accumulate the same way and would want the same treatment. Left out to keep this PR to one change.

### Why this has gone unnoticed


`tests/test_scores_lik.py` gates every LIK test on CUDA:

```python
_HAS_CUDA = torch.cuda.is_available()
requires_lik = pytest.mark.skipif(not (_LIK_INSTALLED and _HAS_CUDA), ...)
```

But the LIK backend supports MPS — `_lik_backend.is_available()` returns `torch.cuda.is_available() or torch.backends.mps.is_available()`, and `_lik_backend.py:64` imports `late_interaction_kernels.mps.maxsim_mps`. So the MPS kernel path that `auto` selects on Apple Silicon is never exercised by any test, and the torch-vs-LIK divergence above had nowhere to surface. Gating on `cuda or mps` would cover it.

### Limitations

- Numbers are from Apple Silicon (macOS arm64, torch 2.11.0, sentence-transformers 5.3.0). The mechanism is device-independent, but **I have no CUDA hardware and have not measured this on CUDA.**
- I measured **retrieval quality** with reduced-precision scores. I have **not** measured whether training under `bf16=True` produces a worse model — only that the loss is computed from degraded scores. That is a mechanism-level observation, not a measured training result.
