### PR TITLE
test: run the LIK parity tests on MPS as well as CUDA

### DIFF
--- a/tests/test_scores_lik.py
+++ b/tests/test_scores_lik.py
@@ -24,17 +24,24 @@ from pylate.scores._lik_backend import LIKUnsupported
 
 _LIK_INSTALLED = importlib.util.find_spec("late_interaction_kernels") is not None
 _HAS_CUDA = torch.cuda.is_available()
+# LIK ships MPS kernels as well as CUDA ones, and `_lik_backend.is_available()`
+# accepts either, so the parity tests should run on whichever accelerator is present.
+_ACCELERATOR = "cuda" if _HAS_CUDA else ("mps" if torch.backends.mps.is_available() else None)
 
 requires_lik = pytest.mark.skipif(
+    not (_LIK_INSTALLED and _ACCELERATOR),
+    reason="requires CUDA or MPS + late-interaction-kernels",
+)
+requires_lik_cuda = pytest.mark.skipif(
     not (_LIK_INSTALLED and _HAS_CUDA),
-    reason="requires CUDA + late-interaction-kernels",
+    reason="LIK path under test is CUDA-only",
 )
 
 EMBEDDING_DIM: int = 128
 
 
 def _norm(shape: tuple[int, ...], dtype: torch.dtype = torch.float16) -> torch.Tensor:
-    x = torch.randn(*shape, dtype=dtype, device="cuda")
+    x = torch.randn(*shape, dtype=dtype, device=_ACCELERATOR)
     return F.normalize(x, dim=-1)
 
 
@@ -121,8 +128,8 @@ def test_colbert_scores_parity(dtype: torch.dtype) -> None:
     Nq, B, Lq, Ld = 4, 8, 32, 180
     query = _norm((Nq, Lq, EMBEDDING_DIM), dtype=dtype)
     doc = _norm((B, Ld, EMBEDDING_DIM), dtype=dtype)
-    q_mask = torch.ones(Nq, Lq, device="cuda")
-    d_mask = torch.ones(B, Ld, device="cuda")
+    q_mask = torch.ones(Nq, Lq, device=_ACCELERATOR)
+    d_mask = torch.ones(B, Ld, device=_ACCELERATOR)
     q_mask[1, 20:] = 0
     d_mask[3, 100:] = 0
 
@@ -133,7 +140,7 @@ def test_colbert_scores_parity(dtype: torch.dtype) -> None:
     torch.testing.assert_close(got.float(), ref.float(), atol=atol, rtol=atol)
 
 
-@requires_lik
+@requires_lik_cuda
 def test_colbert_scores_pairwise_parity() -> None:
     torch.manual_seed(0)
     B, Lq, Ld = 6, 32, 180
@@ -146,14 +153,14 @@ def test_colbert_scores_pairwise_parity() -> None:
     torch.testing.assert_close(got.float(), ref.float(), atol=5e-2, rtol=5e-2)
 
 
-@requires_lik
+@requires_lik_cuda
 def test_colbert_kd_scores_parity() -> None:
     torch.manual_seed(0)
     Nq, B, Lq, Ld = 4, 4, 32, 180
     query = _norm((Nq, Lq, EMBEDDING_DIM))
     doc = _norm((Nq, B, Ld, EMBEDDING_DIM))
-    q_mask = torch.ones(Nq, Lq, device="cuda")
-    d_mask = torch.ones(Nq, B, Ld, device="cuda")
+    q_mask = torch.ones(Nq, Lq, device=_ACCELERATOR)
+    d_mask = torch.ones(Nq, B, Ld, device=_ACCELERATOR)
     q_mask[0, 28:] = 0
     d_mask[1, 2, 150:] = 0
 
@@ -163,17 +170,17 @@ def test_colbert_kd_scores_parity() -> None:
     torch.testing.assert_close(got.float(), ref.float(), atol=5e-2, rtol=5e-2)
 
 
-@requires_lik
+@requires_lik_cuda
 def test_colbert_kd_scores_variable_lengths_parity() -> None:
     """KD parity with right-padded per-(query, doc) lengths."""
     torch.manual_seed(3)
     Nq, B, Lq, Ld = 4, 5, 12, 24
     query = _norm((Nq, Lq, EMBEDDING_DIM), dtype=torch.float32)
     doc = _norm((Nq, B, Ld, EMBEDDING_DIM), dtype=torch.float32)
-    q_mask = torch.zeros(Nq, Lq, device="cuda")
+    q_mask = torch.zeros(Nq, Lq, device=_ACCELERATOR)
     for i in range(Nq):
         q_mask[i, : 6 + i] = 1.0
-    d_mask = torch.zeros(Nq, B, Ld, device="cuda")
+    d_mask = torch.zeros(Nq, B, Ld, device=_ACCELERATOR)
     for i in range(Nq):
         for j in range(B):
             d_mask[i, j, : 10 + j] = 1.0
@@ -225,7 +232,7 @@ def test_training_smoke() -> None:
         _norm((B, Ld, EMBEDDING_DIM), dtype=torch.float32).detach().requires_grad_(True)
     )
     optimizer = torch.optim.SGD([query, doc], lr=1e-2)
-    labels = torch.arange(B, device="cuda")
+    labels = torch.arange(B, device=_ACCELERATOR)
 
     losses: list[float] = []
     for _ in range(5):
@@ -244,9 +251,9 @@ def test_training_smoke() -> None:
 def test_lik_unsupported_strict_propagates() -> None:
     """backend='lik' (strict) re-raises LIKUnsupported instead of falling back."""
     query = torch.zeros(
-        2, 4, 100, device="cuda", dtype=torch.float16
+        2, 4, 100, device=_ACCELERATOR, dtype=torch.float16
     )  # head dim 100: not a multiple of 8
-    doc = torch.zeros(3, 5, 100, device="cuda", dtype=torch.float16)
+    doc = torch.zeros(3, 5, 100, device=_ACCELERATOR, dtype=torch.float16)
     with pytest.raises(LIKUnsupported):
         colbert_scores(query, doc, backend="lik")
 


### PR DESCRIPTION
Every `@requires_lik` test is gated on CUDA:

```python
_HAS_CUDA = torch.cuda.is_available()
requires_lik = pytest.mark.skipif(
    not (_LIK_INSTALLED and _HAS_CUDA),
    reason="requires CUDA + late-interaction-kernels",
)
```

But the LIK backend supports Apple Silicon as well. `_lik_backend.is_available()` returns `torch.cuda.is_available() or torch.backends.mps.is_available()`, the module docstring describes "routing CUDA Ampere+ to LIK's fused Triton kernels and Apple Silicon to its MPS kernels", and `_lik_backend.py:64` imports `late_interaction_kernels.mps.maxsim_mps`.

So the MPS kernel path — which `backend="auto"` selects on every Apple Silicon machine — is not exercised by any test in the suite.

### The change

Gate on whichever accelerator is present, and parametrise the device rather than hardcoding `"cuda"`.

Three tests stay CUDA-only, because the *backend* is: the pairwise and KD layouts raise `LIKUnsupported` outside CUDA (`"KD layout is CUDA-only"`, `"pairwise LIK path is CUDA-only"`). Those get a separate `requires_lik_cuda` marker rather than a device change — flipping the gate alone would have made them fail rather than skip, which is how I found out.

### Result

On macOS arm64 with `late-interaction-kernels` installed:

```
18 passed, 3 skipped
```

Previously every one of them skipped on this hardware. CUDA behaviour is unchanged: `_ACCELERATOR` resolves to `"cuda"` whenever CUDA is available, so the same tests run the same way there.

### Why it is worth covering

This gap hid a real divergence. In fp16 the LIK kernel and the pure-torch path return different scores, because LIK accumulates the MaxSim sum in fp32 and the torch path does not — worth 0.4 nDCG@10 in fp16 and 2.2 in bf16 on SciFact. That is #237; this PR is the coverage that would have caught it.

**I have no CUDA hardware**, so I have verified the MPS side and the skip logic, but not that the suite still passes on a CUDA machine.
