### PR TITLE
fix: clamp the distillation normalisation denominator (1e-8 epsilon is zero in fp16)

### DIFF
--- a/pylate/evaluation/colbert_distillation.py
+++ b/pylate/evaluation/colbert_distillation.py
@@ -176,11 +176,15 @@ class ColBERTDistillationEvaluator(SentenceEvaluator):
             max_scores, _ = torch.max(scores, dim=1, keepdim=True)
             min_scores, _ = torch.min(scores, dim=1, keepdim=True)
 
-            # Avoid division by zero by adding a small epsilon
-            epsilon = 1e-8
+            # Clamp the denominator rather than adding an epsilon to it: 1e-8 is not
+            # representable in float16 (smallest subnormal ~5.96e-8), so under
+            # autocast(float16) the guard rounded to zero and a degenerate group
+            # produced NaN. finfo.tiny is representable in every supported dtype, and
+            # keeps the backward pass inside float16's range.
+            epsilon = torch.finfo(scores.dtype).tiny
 
             # Normalize the scores
-            scores = (scores - min_scores) / (max_scores - min_scores + epsilon)
+            scores = (scores - min_scores) / (max_scores - min_scores).clamp(min=epsilon)
         kl_divergence = self.loss(
             torch.nn.functional.log_softmax(scores, dim=-1),
             torch.nn.functional.log_softmax(

--- a/pylate/losses/distillation.py
+++ b/pylate/losses/distillation.py
@@ -125,11 +125,15 @@ class Distillation(torch.nn.Module):
             max_scores, _ = torch.max(scores, dim=1, keepdim=True)
             min_scores, _ = torch.min(scores, dim=1, keepdim=True)
 
-            # Avoid division by zero by adding a small epsilon
-            epsilon = 1e-8
+            # Clamp the denominator rather than adding an epsilon to it: 1e-8 is not
+            # representable in float16 (smallest subnormal ~5.96e-8), so under
+            # autocast(float16) the guard rounded to zero and a degenerate group
+            # produced NaN. finfo.tiny is representable in every supported dtype, and
+            # keeps the backward pass inside float16's range.
+            epsilon = torch.finfo(scores.dtype).tiny
 
             # Normalize the scores
-            scores = (scores - min_scores) / (max_scores - min_scores + epsilon)
+            scores = (scores - min_scores) / (max_scores - min_scores).clamp(min=epsilon)
         return self.loss_function(
             torch.nn.functional.log_softmax(scores, dim=-1),
             torch.nn.functional.log_softmax(labels, dim=-1),

--- a/tests/test_distillation_precision.py
+++ b/tests/test_distillation_precision.py
@@ -1,0 +1,64 @@
+"""The min-max normalisation guard must survive reduced precision.
+
+`Distillation` normalises its scores with
+``(scores - min) / (max - min + epsilon)``. When a candidate group's scores are
+equal the denominator is carried entirely by ``epsilon``, so ``epsilon`` has to be
+representable in the dtype the scores arrive in. ``1e-8`` is not: in float16 it
+rounds to zero.
+
+The scores are injected through ``score_metric`` so the test exercises the
+normalisation rather than any particular model's score distribution.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from pylate import losses, models
+
+MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+@pytest.fixture(scope="module")
+def model() -> models.ColBERT:
+    colbert = models.ColBERT(model_name_or_path=MODEL, device="cpu")
+    colbert.train()
+    return colbert
+
+
+def _degenerate_scores(dtype: torch.dtype):
+    """A group whose candidates all score the same, so max == min."""
+
+    def score_metric(queries_embeddings, documents_embeddings, **kwargs):
+        scores = torch.full((1, 4), 3.5, dtype=dtype)
+        # keep the graph alive so gradients still flow to the model
+        return scores + 0.0 * queries_embeddings.to(dtype).sum()
+
+    return score_metric
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_distillation_normalisation_is_finite(model: models.ColBERT, dtype: torch.dtype) -> None:
+    distillation = losses.Distillation(
+        model=model, score_metric=_degenerate_scores(dtype)
+    )
+    features = [
+        model.tokenize(["what causes programmed cell death"], is_query=True),
+        model.tokenize(["apoptosis is programmed cell death"] * 4, is_query=False, pad=True),
+    ]
+    labels = torch.tensor([[0.4, 0.3, 0.2, 0.1]])
+
+    for parameter in model.parameters():
+        parameter.grad = None
+
+    loss = distillation(sentence_features=features, labels=labels)
+    assert torch.isfinite(loss), f"loss is {loss} with {dtype} scores"
+
+    loss.backward()
+    non_finite = [
+        name
+        for name, parameter in model.named_parameters()
+        if parameter.grad is not None and not torch.isfinite(parameter.grad).all()
+    ]
+    assert not non_finite, f"{len(non_finite)} parameters have non-finite gradients"


### PR DESCRIPTION
`Distillation` normalises its scores with a `1e-8` epsilon guard:

```python
# pylate/losses/distillation.py
# Avoid division by zero by adding a small epsilon
epsilon = 1e-8
scores = (scores - min_scores) / (max_scores - min_scores + epsilon)
```

**`1e-8` is not representable in float16** — the smallest float16 subnormal is ~5.96e-8, so it rounds to exactly `0.0`:

```python
>>> torch.tensor(1e-8, dtype=torch.float32).item()
1e-08
>>> torch.tensor(1e-8, dtype=torch.bfloat16).item()
1.0011717677116394e-08
>>> torch.tensor(1e-8, dtype=torch.float16).item()
0.0
```

Under `autocast(float16)` the guard disappears, so a candidate group whose scores are equal divides by zero.

### Reproduction

`losses.Distillation(model=...)` with defaults (`normalize_scores=True`), one query and four documents a teacher scores identically:

| autocast | loss | parameters with NaN gradients |
|---|---|---|
| none (fp32) | 0.006223 | — |
| bfloat16 | 0.002742 | — |
| **float16** | **NaN** | **135 / 135** |

`normalize_scores=False` avoids it, which confirms the normalisation is the source. `examples/train/knowledge_distillation.py` sets `fp16=True`.

The same code is at `pylate/evaluation/colbert_distillation.py:180`, where it produces a NaN evaluation metric by the same mechanism.

### The obvious fix does not work

This is the part worth a reviewer's attention. Normalising the forward pass in fp32 makes the **loss** correct while leaving every gradient NaN:

| variant | fp16 loss | NaN gradients |
|---|---|---|
| `epsilon = 1e-8` (current) | NaN | 135/135 |
| cast the forward to fp32 | 0.006223 — looks correct | **135/135 — still broken** |
| `(max - min).clamp(min=torch.finfo(dtype).tiny)` | 0.006648 | **0/135** |

With a near-zero denominator the gradient scales as `1/epsilon ≈ 1e8`, which exceeds float16's maximum of 65504 and becomes `inf`; `inf * 0` is then `NaN` in the backward pass. Clamping to `finfo.tiny` (6.1e-5 in float16) keeps the gradient near 1.6e4, inside range, and fixes both the loss and the gradients.

### How often this triggers

Measured on real scores rather than assumed — SciFact, 1,500 documents, 300 queries, `lightonai/GTE-ModernColBERT-v1` (score range 7.6–46.9), grouping each query's top-k as a candidate set:

| group size k | groups collapsing to a single float16 value |
|---|---|
| 2 | 10 / 300 (3.3%) |
| 4, 8, 16, 32 | 0 / 300 |

So it fires on small candidate groups rather than wide ones. Worth noting the `Distillation` docstring example uses exactly two documents. 44/300 queries have their top-2 within one float16 ulp (0.031 at score ~32).

### Severity, bounded honestly

`GradScaler` detects the NaN gradients and skips the optimizer step, so under `Trainer(fp16=True)` **the weights are not corrupted** — the cost is a silently skipped step and a NaN in the loss logs. Code calling the loss under a manual `torch.autocast` without a scaler does get NaN weights.

### Not verified

- No CUDA hardware here. The mechanism is dtype arithmetic and so device-independent, but the numbers above are from CPU and MPS.
- Whether the KD datasets used in training (`lightonai/ms-marco-en-bge`) contain collapsing groups — only that SciFact-derived groups do at k=2.
- The clamp removes the additive `1e-8` in fp32 as well; I have not measured whether that shifts any published number.

Fixes #239.

The change clamps the denominator at both sites and adds a regression test that injects degenerate scores through `score_metric`, so it exercises the normalisation rather than any particular model's score distribution. It fails on the unpatched source for float16 only, and passes for bfloat16 and float32.
