### PR TITLE
Pass epoch and step when storing ColBERT evaluator metrics

### DIFF
--- a/pylate/evaluation/colbert_distillation.py
+++ b/pylate/evaluation/colbert_distillation.py
@@ -190,7 +190,7 @@ class ColBERTDistillationEvaluator(SentenceEvaluator):
         metrics = self.prefix_name_to_metrics(
             {"kl_divergence": kl_divergence}, self.name
         )
-        self.store_metrics_in_model_card_data(model, metrics)
+        self.store_metrics_in_model_card_data(model, metrics, epoch, steps)
 
         if output_path is not None and self.write_csv:
             csv_writer(

--- a/pylate/evaluation/colbert_triplet.py
+++ b/pylate/evaluation/colbert_triplet.py
@@ -245,8 +245,6 @@ class ColBERTTripletEvaluator(TripletEvaluator):
         for metric in self.metrics:
             logger.info(f"{metric.capitalize()}: \t{metrics[metric]:.2f}")
 
-        self.store_metrics_in_model_card_data(model=model, metrics=metrics)
-
         if output_path is not None and self.write_csv:
             csv_writer(
                 path=os.path.join(output_path, self.csv_file),
@@ -257,5 +255,10 @@ class ColBERTTripletEvaluator(TripletEvaluator):
                 ]
                 + [metrics[metric] for metric in self.metrics],
             )
+
+        metrics = self.prefix_name_to_metrics(metrics=metrics, name=self.name)
+        self.store_metrics_in_model_card_data(
+            model=model, metrics=metrics, epoch=epoch, step=steps
+        )
 
         return metrics

--- a/tests/test_evaluator_model_card.py
+++ b/tests/test_evaluator_model_card.py
@@ -1,0 +1,72 @@
+"""Triplet/distillation evaluators should record epoch and step on the model card."""
+
+from __future__ import annotations
+
+import torch
+
+from pylate import evaluation
+
+
+class _DummyEncoder:
+    def encode(self, sentences, **kwargs):
+        if isinstance(sentences, str):
+            sentences = [sentences]
+        return torch.ones(len(sentences), 3, 4)
+
+
+def test_triplet_evaluator_passes_epoch_and_step_to_model_card(monkeypatch) -> None:
+    captured: dict = {}
+
+    def fake_store(self, model, metrics, epoch=0, step=0):
+        captured["epoch"] = epoch
+        captured["step"] = step
+        captured["metrics"] = dict(metrics)
+
+    monkeypatch.setattr(
+        evaluation.ColBERTTripletEvaluator,
+        "store_metrics_in_model_card_data",
+        fake_store,
+    )
+
+    evaluator = evaluation.ColBERTTripletEvaluator(
+        anchors=["fruits are healthy."],
+        positives=["fruits are good for health."],
+        negatives=["chips are junk food."],
+        name="dev",
+        write_csv=False,
+    )
+    evaluator(model=_DummyEncoder(), epoch=2, steps=17)
+
+    assert captured["epoch"] == 2
+    assert captured["step"] == 17
+    assert "dev_accuracy" in captured["metrics"]
+
+
+def test_distillation_evaluator_passes_epoch_and_step_to_model_card(
+    monkeypatch,
+) -> None:
+    captured: dict = {}
+
+    def fake_store(self, model, metrics, epoch=0, step=0):
+        captured["epoch"] = epoch
+        captured["step"] = step
+        captured["metrics"] = dict(metrics)
+
+    monkeypatch.setattr(
+        evaluation.ColBERTDistillationEvaluator,
+        "store_metrics_in_model_card_data",
+        fake_store,
+    )
+
+    evaluator = evaluation.ColBERTDistillationEvaluator(
+        queries=["query A"],
+        documents=[["document A", "document B"]],
+        scores=[[0.9, 0.1]],
+        write_csv=False,
+        normalize_scores=False,
+    )
+    evaluator(model=_DummyEncoder(), epoch=3, steps=9)
+
+    assert captured["epoch"] == 3
+    assert captured["step"] == 9
+    assert "kl_divergence" in captured["metrics"]


### PR DESCRIPTION
The triplet evaluator never passed `epoch` / `step` into `store_metrics_in_model_card_data`, so the training logs on the model card always showed 0. Distillation had the same gap.

This matches what sentence-transformers does after the NanoBEIR evaluator refactor: prefix the metric names, then store them with the current epoch and step.

Fixes #126
