### PR TITLE
Keep GradCache recompute inside the surrounding autocast

### DIFF
--- a/pylate/losses/cached_contrastive.py
+++ b/pylate/losses/cached_contrastive.py
@@ -44,17 +44,63 @@ class RandContext:
         self._fork = None
 
 
+def _capture_autocast_kwargs() -> dict:
+    """Snapshot the autocast context that is active during ``forward``.
+
+    GradCache's backward hook runs after that context has exited. Recomputing
+    the embedding pass in full precision against low-precision cached grads
+    either crashes on a dtype mismatch or produces the wrong Jacobian.
+    """
+    for device_type in ("cuda", "cpu", "mps"):
+        try:
+            enabled = torch.is_autocast_enabled(device_type)
+        except (TypeError, RuntimeError):
+            continue
+        if not enabled:
+            continue
+        try:
+            dtype = torch.get_autocast_dtype(device_type)
+        except (AttributeError, TypeError, RuntimeError):
+            if device_type == "cuda":
+                dtype = torch.get_autocast_gpu_dtype()
+            elif device_type == "cpu" and hasattr(torch, "get_autocast_cpu_dtype"):
+                dtype = torch.get_autocast_cpu_dtype()
+            else:
+                dtype = torch.bfloat16
+        return {"device_type": device_type, "dtype": dtype, "enabled": True}
+
+    if torch.is_autocast_enabled():
+        return {
+            "device_type": "cuda",
+            "dtype": torch.get_autocast_gpu_dtype(),
+            "enabled": True,
+        }
+    if getattr(torch, "is_autocast_cpu_enabled", lambda: False)():
+        return {
+            "device_type": "cpu",
+            "dtype": torch.get_autocast_cpu_dtype(),
+            "enabled": True,
+        }
+    return {"device_type": "cpu", "dtype": torch.float32, "enabled": False}
+
+
 def _backward_hook(
     grad_output: Tensor,
     sentence_features: Iterable[dict[str, Tensor]],
     loss_obj,
+    autocast_kwargs: dict | None = None,
 ) -> None:
     """A backward hook that re-runs the forward for each mini-batch with gradients enabled
     and uses the cached partial derivatives w.r.t. the embeddings to backprop.
     """
     assert loss_obj.cache is not None
     assert loss_obj.random_states is not None
-    with torch.enable_grad():
+    autocast_ctx = (
+        torch.autocast(**autocast_kwargs)
+        if autocast_kwargs is not None
+        else nullcontext()
+    )
+    with torch.enable_grad(), autocast_ctx:
         for sentence_feature, grad, random_states in zip(
             sentence_features, loss_obj.cache, loss_obj.random_states
         ):
@@ -374,7 +420,10 @@ class CachedContrastive(nn.Module):
             # Step (3): A 2nd embedding step with gradients/computation graphs and connect the cached gradients into the backward chain
             loss.register_hook(
                 partial(
-                    _backward_hook, sentence_features=sentence_features, loss_obj=self
+                    _backward_hook,
+                    sentence_features=sentence_features,
+                    loss_obj=self,
+                    autocast_kwargs=_capture_autocast_kwargs(),
                 )
             )
         else:

--- a/tests/test_cached_contrastive_autocast.py
+++ b/tests/test_cached_contrastive_autocast.py
@@ -1,0 +1,52 @@
+"""CachedContrastive must recompute under the surrounding autocast context."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from pylate import losses, models
+from pylate.losses.cached_contrastive import _capture_autocast_kwargs
+
+
+def test_capture_autocast_kwargs_cpu_bf16() -> None:
+    with torch.autocast("cpu", dtype=torch.bfloat16):
+        kwargs = _capture_autocast_kwargs()
+    assert kwargs["enabled"] is True
+    assert kwargs["device_type"] == "cpu"
+    assert kwargs["dtype"] == torch.bfloat16
+
+    kwargs = _capture_autocast_kwargs()
+    assert kwargs["enabled"] is False
+
+
+@pytest.mark.skipif(torch.backends.mps.is_available(), reason="MPS is not supported")
+def test_cached_contrastive_survives_surrounding_autocast() -> None:
+    torch.manual_seed(0)
+    model = models.ColBERT(
+        model_name_or_path="sentence-transformers/all-MiniLM-L6-v2",
+        device="cpu",
+    )
+    model.eval()
+    sentence_features = [
+        model.tokenize(
+            ["fruits are healthy.", "chips are not healthy."], is_query=True
+        ),
+        model.tokenize(
+            ["fruits are good for health.", "chips are junk food."],
+            is_query=False,
+            pad=True,
+        ),
+        model.tokenize(
+            ["the sky is blue today.", "cars need fuel to run."],
+            is_query=False,
+            pad=True,
+        ),
+    ]
+    loss_fn = losses.CachedContrastive(model=model, mini_batch_size=1)
+    for parameter in model.parameters():
+        parameter.grad = None
+    with torch.autocast("cpu", dtype=torch.bfloat16):
+        loss = loss_fn(sentence_features=sentence_features)
+    loss.backward()
+    assert isinstance(loss.item(), float)


### PR DESCRIPTION
`CachedContrastive` registers a backward hook for the GradCache recompute. That hook runs after a surrounding `torch.autocast` has already exited, so the second embedding pass happens in fp32 against low-precision cached grads. That either crashes on a dtype mismatch or produces the wrong Jacobian.

This snapshots the autocast state during `forward` and restores it inside the hook. The stock SentenceTransformerTrainer path is unchanged — Accelerate autocasts inside `model.forward`, which both GradCache passes already share.

Fixes #230
